### PR TITLE
Reduce Docker Image Size

### DIFF
--- a/scripts/Dockerfile-ubuntu_18_04
+++ b/scripts/Dockerfile-ubuntu_18_04
@@ -48,8 +48,10 @@ RUN apt-get update -y && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
 # Install CuDA
-RUN wget https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run --progress=bar:force:noscroll -q --show-progress -O /root/cuda.run && chmod a+x /root/cuda.run
-RUN /root/cuda.run --silent --toolkit --toolkitpath=/usr --no-opengl-libs --no-man-page --no-drm && rm /root/cuda.run
+RUN wget https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run --progress=bar:force:noscroll -q --show-progress -O /root/cuda.run \
+    && chmod a+x /root/cuda.run \
+    && /root/cuda.run --silent --toolkit --toolkitpath=/usr --no-opengl-libs --no-man-page --no-drm \
+    && rm /root/cuda.run
 
 # Install cmake
 ADD https://cmake.org/files/v3.22/cmake-3.22.2-linux-x86_64.sh /cmake-3.22.2-linux-x86_64.sh

--- a/scripts/Dockerfile-ubuntu_20_04
+++ b/scripts/Dockerfile-ubuntu_20_04
@@ -38,8 +38,10 @@ RUN apt-get update -y && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
 # Install CuDA
-RUN wget https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run --progress=bar:force:noscroll -q --show-progress -O /root/cuda.run && chmod a+x /root/cuda.run
-RUN /root/cuda.run --silent --toolkit --toolkitpath=/usr --no-opengl-libs --no-man-page --no-drm && rm /root/cuda.run
+RUN wget https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run --progress=bar:force:noscroll -q --show-progress -O /root/cuda.run \
+    && chmod a+x /root/cuda.run \
+    && /root/cuda.run --silent --toolkit --toolkitpath=/usr --no-opengl-libs --no-man-page --no-drm \
+    && rm /root/cuda.run
 
 # Entrypoint
 COPY build-private.sh /root/build.sh


### PR DESCRIPTION
## Description

Docker image size can be further reduced by making sure the CuDA installer file's download and deletion are running within the same `RUN` command. Previously, the CuDA installer file was still exist inside an intermediary docker layer because the removal was performed in a separate `RUN` command. This changes can reduce disk usage by ~3.8 GB.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the documentation blocks for new or existing components
