### PR TITLE
[Linux Pulse/Pipewire] No sink path

### DIFF
--- a/sunshine/audio.cpp
+++ b/sunshine/audio.cpp
@@ -163,11 +163,11 @@ void capture(safe::mail_t mail, config_t config, void *channel_data) {
     ref->restore_sink = !config.flags[config_t::HOST_AUDIO];
 
     // If the sink is empty (Host has no sink!), definately switch to the virtual.
-    if (ref->sink.host.empty()) {
-      if (control->set_sink(*sink)) {
+    if(ref->sink.host.empty()) {
+      if(control->set_sink(*sink)) {
         return;
       }
-    } 
+    }
     // If the client requests audio on the host, don't change the default sink
     else if(!config.flags[config_t::HOST_AUDIO] && control->set_sink(*sink)) {
       return;

--- a/sunshine/audio.cpp
+++ b/sunshine/audio.cpp
@@ -162,8 +162,14 @@ void capture(safe::mail_t mail, config_t config, void *channel_data) {
   if(!ref->sink_flag->exchange(true, std::memory_order_acquire)) {
     ref->restore_sink = !config.flags[config_t::HOST_AUDIO];
 
+    // If the sink is empty (Host has no sink!), definately switch to the virtual.
+    if (ref->sink.host.empty()) {
+      if (control->set_sink(*sink)) {
+        return;
+      }
+    } 
     // If the client requests audio on the host, don't change the default sink
-    if(!config.flags[config_t::HOST_AUDIO] && control->set_sink(*sink)) {
+    else if(!config.flags[config_t::HOST_AUDIO] && control->set_sink(*sink)) {
       return;
     }
   }

--- a/sunshine/platform/linux/audio.cpp
+++ b/sunshine/platform/linux/audio.cpp
@@ -343,12 +343,7 @@ public:
     }
 
     auto sink_name = get_default_sink_name();
-    if(sink_name.empty()) {
-      BOOST_LOG(warning) << "Couldn't find an active sink"sv;
-    }
-    else {
-      sink.host = sink_name;
-    }
+    sink.host = sink_name;
 
     if(index.stereo == PA_INVALID_INDEX) {
       index.stereo = load_null(stereo, speaker::map_stereo, sizeof(speaker::map_stereo));
@@ -380,6 +375,10 @@ public:
       }
     }
 
+    if(sink_name.empty()) {
+      BOOST_LOG(warning) << "Couldn't find an active default sink. Continuing with virtual audio only."sv;
+    }
+
     if(nullcount == 3) {
       sink.null = std::make_optional(sink_t::null_t { stereo, surround51, surround71 });
     }
@@ -388,8 +387,8 @@ public:
   }
 
   std::string get_default_sink_name() {
-    std::string sink_name = "@DEFAULT_SINK@"s;
-    auto alarm            = safe::make_alarm<int>();
+    std::string sink_name;
+    auto alarm = safe::make_alarm<int>();
 
     cb_simple_t<pa_server_info *> server_f = [&](ctx_t::pointer ctx, const pa_server_info *server_info) {
       if(!server_info) {
@@ -397,7 +396,9 @@ public:
         alarm->ring(-1);
       }
 
-      sink_name = server_info->default_sink_name;
+      if (server_info->default_sink_name) {
+        sink_name = server_info->default_sink_name;
+      }
       alarm->ring(0);
     };
 
@@ -408,8 +409,12 @@ public:
   }
 
   std::string get_monitor_name(const std::string &sink_name) {
-    std::string monitor_name = "@DEFAULT_MONITOR@"s;
-    auto alarm               = safe::make_alarm<int>();
+    std::string monitor_name;
+    auto alarm = safe::make_alarm<int>();
+
+    if (sink_name.empty()) {
+      return monitor_name;
+    }
 
     cb_t<pa_sink_info *> sink_f = [&](ctx_t::pointer ctx, const pa_sink_info *sink_info, int eol) {
       if(!sink_info) {

--- a/sunshine/platform/linux/audio.cpp
+++ b/sunshine/platform/linux/audio.cpp
@@ -343,7 +343,7 @@ public:
     }
 
     auto sink_name = get_default_sink_name();
-    sink.host = sink_name;
+    sink.host      = sink_name;
 
     if(index.stereo == PA_INVALID_INDEX) {
       index.stereo = load_null(stereo, speaker::map_stereo, sizeof(speaker::map_stereo));
@@ -396,7 +396,7 @@ public:
         alarm->ring(-1);
       }
 
-      if (server_info->default_sink_name) {
+      if(server_info->default_sink_name) {
         sink_name = server_info->default_sink_name;
       }
       alarm->ring(0);
@@ -412,7 +412,7 @@ public:
     std::string monitor_name;
     auto alarm = safe::make_alarm<int>();
 
-    if (sink_name.empty()) {
+    if(sink_name.empty()) {
       return monitor_name;
     }
 


### PR DESCRIPTION
## Description
Added some logic so it should handle the case of no default audio sink.
I do not currently have a setup where there are no audio sinks to test this, and am having encoder issues on my current machine, therefore I marked this as draft until further testing can occur.

### Issues Fixed or Closed
- Fixes #226 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing Scenarios
- [ ] No sinks on launch (Should create and switch to virtual sink)
- [ ] Has a sink, Uses "play audio on host"
- [ ] Has a sink, Does not use "play audio on host"