### PR TITLE
ci: build all before releasing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -235,15 +235,6 @@ jobs:
           name: sunshine-linux-flatpak
           path: artifacts/
 
-      - name: Create Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: LizardByte/.github/actions/create_release@master
-        with:
-          token: ${{ secrets.GH_BOT_TOKEN }}
-          next_version: ${{ needs.check_changelog.outputs.next_version }}
-          last_version: ${{ needs.check_changelog.outputs.last_version }}
-          release_body: ${{ needs.check_changelog.outputs.release_body }}
-
   build_linux:
     name: Linux
     runs-on: ubuntu-20.04
@@ -444,15 +435,6 @@ jobs:
           name: sunshine-linux-${{ matrix.type }}
           path: artifacts/
 
-      - name: Create Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: LizardByte/.github/actions/create_release@master
-        with:
-          token: ${{ secrets.GH_BOT_TOKEN }}
-          next_version: ${{ needs.check_changelog.outputs.next_version }}
-          last_version: ${{ needs.check_changelog.outputs.last_version }}
-          release_body: ${{ needs.check_changelog.outputs.release_body }}
-
   build_mac:
     name: MacOS
     runs-on: macos-11
@@ -513,15 +495,6 @@ jobs:
           rm -f ./sunshine-macos-experimental-bundle.dmg
           rm -f ./sunshine-macos-experimental-archive.zip
 
-      ##  no artifacts to release currently
-      # - name: Create Release
-      #   if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-      #   uses: LizardByte/.github/actions/create_release@master
-      #   with:
-      #     token: ${{ secrets.GH_BOT_TOKEN }}
-      #     next_version: ${{ needs.check_changelog.outputs.next_version }}
-      #     last_version: ${{ needs.check_changelog.outputs.last_version }}
-      #     release_body: ${{ needs.check_changelog.outputs.release_body }}
 
   build_mac_port:
     name: Macports
@@ -723,15 +696,6 @@ jobs:
           name: sunshine-macports
           path: artifacts/
 
-      - name: Create Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: LizardByte/.github/actions/create_release@master
-        with:
-          token: ${{ secrets.GH_BOT_TOKEN }}
-          next_version: ${{ needs.check_changelog.outputs.next_version }}
-          last_version: ${{ needs.check_changelog.outputs.last_version }}
-          release_body: ${{ needs.check_changelog.outputs.release_body }}
-
   build_win:
     name: Windows
     runs-on: windows-2019
@@ -795,11 +759,25 @@ jobs:
           name: sunshine-windows
           path: artifacts/
 
-      - name: Create Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: LizardByte/.github/actions/create_release@master
+  release:
+    needs: [ check_changelog, build_win, build_mac_port, build_mac, build_linux, build_linux_flatpak ]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.check_changelog.outputs.next_version != needs.check_changelog.outputs.last_version }}
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GH_BOT_TOKEN }}
-          next_version: ${{ needs.check_changelog.outputs.next_version }}
-          last_version: ${{ needs.check_changelog.outputs.last_version }}
-          release_body: ${{ needs.check_changelog.outputs.release_body }}
+          tag_name: ${{ needs.check_changelog.outputs.next_version }}
+          body: ${{ needs.check_changelog.outputs.release_body }}
+          files: |
+            artifacts/sunshine-windows/*
+            artifacts/sunshine-linux-appimage/*
+            artifacts/sunshine-linux-flatpak/*
+            artifacts/sunshine-macports/*
+          discussion_category_name: announcements


### PR DESCRIPTION
## Description
Upon creating a new release, all binaries should be available. This should fix https://github.com/LizardByte/Sunshine/discussions/318#discussioncomment-3362357

The https://github.com/softprops/action-gh-release action is used for releasing and the action from this org is no longer used as the action is only run once and not reused elsewhere.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed
<!--- Delete if not relevant. --->
- Fixes https://github.com/LizardByte/Sunshine/discussions/318#discussioncomment-3362357

## Type of Change
<!--- Please delete options that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- DO NOT delete any options here. It is okay to have items unchecked! --->
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring/documentation-blocks for new or existing methods/components
