### PR TITLE
Add missing EGL extension for linux

### DIFF
--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -365,6 +365,7 @@ display_t make_display(std::variant<gbm::gbm_t::pointer, wl_display *, _XDisplay
     "EGL_KHR_create_context",
     "EGL_KHR_surfaceless_context",
     "EGL_EXT_image_dma_buf_import",
+    "EGL_EXT_image_dma_buf_import_modifiers",
   };
 
   for(auto ext : extensions) {


### PR DESCRIPTION
## Description
Adds 'EGL_EXT_image_dma_buf_import_modifiers' to the list of required EGL extensions when initializing display. This extension is required to support the many of the parameters passed to `eglCreateImage()`. The parameters provided by the extension are listed here: 
https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt
and are used in (src/platform/linux/graphics.cpp)]https://github.com/LizardByte/Sunshine/blob/6000b85b1a4ec574d93fbc7545f5bf48f3d5aaa7/src/platform/linux/graphics.cpp#L436]. Adding this extension fixes the `EGL_BAD_ATTRIBUTE` (00003004) error code from `eglCreateImage()`. It may also fix the `EGL_BAD_ACCESS` (00003002) error but I can't verify. 

### Issues Fixed or Closed
- Fixes #48 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- DO NOT delete any options here. It is okay to have items unchecked! --->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring/documentation-blocks for new or existing methods/components
