### PR TITLE
Fix credentials command typo in docs

### DIFF
--- a/docs/source/troubleshooting/general.rst
+++ b/docs/source/troubleshooting/general.rst
@@ -3,7 +3,7 @@ General
 If you forgot your credentials to the web UI, try this.
    .. code-block:: bash
 
-      sunshine -creds <new username> <new password>
+      sunshine --creds <new username> <new password>
 
 Can't access the web UI?
    #. Check firewall rules.


### PR DESCRIPTION
## Description
The command to create new credentials via the terminal has a typo, one dash instead of two.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
