### PR TITLE
Change bufsize

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -970,9 +970,9 @@ std::optional<session_t> make_session(const encoder_t &encoder, const config_t &
   }
 
   if(video_format[encoder_t::CBR]) {
-    auto bitrate        = config.bitrate * (hardware ? 1000 : 800); // software bitrate overshoots by ~20%
+    auto bitrate        = config.bitrate * 1000;
     ctx->rc_max_rate    = bitrate;
-    ctx->rc_buffer_size = bitrate / 10;
+    ctx->rc_buffer_size = bitrate / config.framerate;
     ctx->bit_rate       = bitrate;
     ctx->rc_min_rate    = bitrate;
   }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -972,7 +972,7 @@ std::optional<session_t> make_session(const encoder_t &encoder, const config_t &
   if(video_format[encoder_t::CBR]) {
     auto bitrate        = config.bitrate * 1000;
     ctx->rc_max_rate    = bitrate;
-    ctx->rc_buffer_size = bitrate / config.framerate;
+    ctx->rc_buffer_size = bitrate / (config.framerate / 2);
     ctx->bit_rate       = bitrate;
     ctx->rc_min_rate    = bitrate;
   }


### PR DESCRIPTION
## Description
* Revert previous change to software bitrate calculation & bufsize. I was not aware that Moonlight-QT internally scales the requested bandwidth by 75% if HEVC is selected.
* Add back a more conservative bufsize increase. This still appears to resolve the quality degradation issue seen when using 8/16 slices, and may hopefully resolve the RPI3 decoder issues in #478.

### Issues Fixed or Closed
Closes #478

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
