### PR TITLE
video: sync capture: resend frame if needed to avoid capture delay

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@ bl::sources::severity_logger<int> error(4);   // Recoverable errors
 bl::sources::severity_logger<int> fatal(5);   // Unrecoverable errors
 
 bool display_cursor = true;
+bool force_callback = false;
 
 using text_sink = bl::sinks::asynchronous_sink<bl::sinks::text_ostream_backend>;
 boost::shared_ptr<text_sink> sink;

--- a/src/main.h
+++ b/src/main.h
@@ -12,6 +12,7 @@
 
 extern util::ThreadPool task_pool;
 extern bool display_cursor;
+extern bool force_callback;
 
 extern boost::log::sources::severity_logger<int> verbose;
 extern boost::log::sources::severity_logger<int> debug;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -573,14 +573,16 @@ capture_e display_vram_t::capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<:
     }
     next_frame = now + delay;
 
-    auto status = snapshot(img.get(), 1000ms, *cursor);
+    auto status = snapshot(img.get(), force_callback ? std::chrono::duration_cast<std::chrono::milliseconds>(delay * 2) : 1000ms, *cursor);
     switch(status) {
     case platf::capture_e::reinit:
     case platf::capture_e::error:
       return status;
     case platf::capture_e::timeout:
-      std::this_thread::sleep_for(1ms);
-      continue;
+      if(!force_callback) {
+        std::this_thread::sleep_for(1ms);
+        continue;
+      }
     case platf::capture_e::ok:
       img = snapshot_cb(img);
       break;


### PR DESCRIPTION
## Description
* platform: replace generic 1000ms capture delay with real frame delay
* for sync encoding, ensure that a frame is sent within frame to frame interval
regardless of timeout status.

This resolves the issue in which the last captured frame is delayed which
is especially noticeable in low framerate content (such as desktop streaming)
on certain encoders.

Please note that I have only verified capture delay as fixed on Windows via AMF, so nvenc and Linux capture needs to be validated before merging.

### Issues Fixed or Closed
Fixes #122, #387, #412

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
