### PR TITLE
video: reduce nvenc delay/async_depth to 0

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -418,6 +418,7 @@ static encoder_t nvenc {
   AV_PIX_FMT_NV12, AV_PIX_FMT_P010,
   {
     {
+      { "delay"s, 0 },
       { "forced-idr"s, 1 },
       { "zerolatency"s, 1 },
       { "preset"s, &config::video.nv.preset },
@@ -428,6 +429,7 @@ static encoder_t nvenc {
   },
   {
     {
+      { "delay"s, 0 },
       { "forced-idr"s, 1 },
       { "zerolatency"s, 1 },
       { "preset"s, &config::video.nv.preset },


### PR DESCRIPTION
## Description

If `delay` is not set manually, it defaults to INT_MAX, which is then reduced to number of surfaces - 1, which can potentially cause encode delay.

See: 
https://github.com/FFmpeg/FFmpeg/blob/eb1e359a14e04367239a784506e1ae414512a104/libavcodec/nvenc_hevc.c#L110-L111
https://github.com/FFmpeg/FFmpeg/blob/eb1e359a14e04367239a784506e1ae414512a104/libavcodec/nvenc.c#L961
https://forums.developer.nvidia.com/t/nvenc-hevc-ultra-low-latency-with-ffmpeg-libraries-what-should-be-my-expectations/143954/5

Note that I don't own NVIDIA hardware, so this change needs testing by someone else.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
