### PR TITLE
Add support for UTF-8 input messages on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,6 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(SUNSHINE_SOURCE_ASSETS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src_assets")
 
-if(WIN32)
-	# Ugly hack to compile with #include <qos2.h>
-	add_compile_definitions(
-		QOS_FLOWID=UINT32
-		PQOS_FLOWID=UINT32*
-		QOS_NON_ADAPTIVE_FLOW=2)
-endif()
 if(APPLE)
 	macro(ADD_FRAMEWORK fwname appname)
     find_library(FRAMEWORK_${fwname}

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 extern "C" {
 #include <moonlight-common-c/src/Input.h>
+#include <moonlight-common-c/src/Limelight.h>
 }
 
 #include <bitset>
@@ -175,7 +176,7 @@ void print(PNV_ABS_MOUSE_MOVE_PACKET packet) {
 void print(PNV_MOUSE_BUTTON_PACKET packet) {
   BOOST_LOG(debug)
     << "--begin mouse button packet--"sv << std::endl
-    << "action ["sv << util::hex(packet->action).to_string_view() << ']' << std::endl
+    << "action ["sv << util::hex(packet->header.magic).to_string_view() << ']' << std::endl
     << "button ["sv << util::hex(packet->button).to_string_view() << ']' << std::endl
     << "--end mouse button packet--"sv;
 }
@@ -190,7 +191,7 @@ void print(PNV_SCROLL_PACKET packet) {
 void print(PNV_KEYBOARD_PACKET packet) {
   BOOST_LOG(debug)
     << "--begin keyboard packet--"sv << std::endl
-    << "keyAction ["sv << util::hex(packet->keyAction).to_string_view() << ']' << std::endl
+    << "keyAction ["sv << util::hex(packet->header.magic).to_string_view() << ']' << std::endl
     << "keyCode ["sv << util::hex(packet->keyCode).to_string_view() << ']' << std::endl
     << "modifiers ["sv << util::hex(packet->modifiers).to_string_view() << ']' << std::endl
     << "--end keyboard packet--"sv;
@@ -212,33 +213,29 @@ void print(PNV_MULTI_CONTROLLER_PACKET packet) {
     << "--end controller packet--"sv;
 }
 
-constexpr int PACKET_TYPE_SCROLL_OR_KEYBOARD = PACKET_TYPE_SCROLL;
-void print(void *input) {
-  int input_type = util::endian::big(*(int *)input);
+void print(void *payload) {
+  auto header = (PNV_INPUT_HEADER)payload;
 
-  switch(input_type) {
-  case PACKET_TYPE_REL_MOUSE_MOVE:
-    print((PNV_REL_MOUSE_MOVE_PACKET)input);
+  switch(util::endian::little(header->magic)) {
+  case MOUSE_MOVE_REL_MAGIC_GEN5:
+    print((PNV_REL_MOUSE_MOVE_PACKET)payload);
     break;
-  case PACKET_TYPE_ABS_MOUSE_MOVE:
-    print((PNV_ABS_MOUSE_MOVE_PACKET)input);
+  case MOUSE_MOVE_ABS_MAGIC:
+    print((PNV_ABS_MOUSE_MOVE_PACKET)payload);
     break;
-  case PACKET_TYPE_MOUSE_BUTTON:
-    print((PNV_MOUSE_BUTTON_PACKET)input);
+  case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
+  case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
+    print((PNV_MOUSE_BUTTON_PACKET)payload);
     break;
-  case PACKET_TYPE_SCROLL_OR_KEYBOARD: {
-    char *tmp_input = (char *)input + 4;
-    if(tmp_input[0] == 0x0A) {
-      print((PNV_SCROLL_PACKET)input);
-    }
-    else {
-      print((PNV_KEYBOARD_PACKET)input);
-    }
-
+  case SCROLL_MAGIC_GEN5:
+    print((PNV_SCROLL_PACKET)payload);
     break;
-  }
-  case PACKET_TYPE_MULTI_CONTROLLER:
-    print((PNV_MULTI_CONTROLLER_PACKET)input);
+  case KEY_DOWN_EVENT_MAGIC:
+  case KEY_UP_EVENT_MAGIC:
+    print((PNV_KEYBOARD_PACKET)payload);
+    break;
+  case MULTI_CONTROLLER_MAGIC_GEN5:
+    print((PNV_MULTI_CONTROLLER_PACKET)payload);
     break;
   }
 }
@@ -294,14 +291,8 @@ void passthrough(std::shared_ptr<input_t> &input, PNV_ABS_MOUSE_MOVE_PACKET pack
 }
 
 void passthrough(std::shared_ptr<input_t> &input, PNV_MOUSE_BUTTON_PACKET packet) {
-  auto constexpr BUTTON_RELEASED = 0x09;
-
-  auto constexpr BUTTON_LEFT  = 0x01;
-  auto constexpr BUTTON_RIGHT = 0x03;
-
-  auto release = packet->action == BUTTON_RELEASED;
-
-  auto button = util::endian::big(packet->button);
+  auto release = util::endian::little(packet->header.magic) == MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5;
+  auto button  = util::endian::big(packet->button);
   if(button > 0 && button < mouse_press.size()) {
     if(mouse_press[button] != release) {
       // button state is already what we want
@@ -417,9 +408,7 @@ void repeat_key(short key_code) {
 }
 
 void passthrough(std::shared_ptr<input_t> &input, PNV_KEYBOARD_PACKET packet) {
-  auto constexpr BUTTON_RELEASED = 0x04;
-
-  auto release = packet->keyAction == BUTTON_RELEASED;
+  auto release = util::endian::little(packet->header.magic) == KEY_UP_EVENT_MAGIC;
   auto keyCode = packet->keyCode & 0x00FF;
 
   auto &pressed = key_press[keyCode];
@@ -600,31 +589,27 @@ void passthrough(std::shared_ptr<input_t> &input, PNV_MULTI_CONTROLLER_PACKET pa
 
 void passthrough_helper(std::shared_ptr<input_t> input, std::vector<std::uint8_t> &&input_data) {
   void *payload = input_data.data();
+  auto header   = (PNV_INPUT_HEADER)payload;
 
-  int input_type = util::endian::big(*(int *)payload);
-
-  switch(input_type) {
-  case PACKET_TYPE_REL_MOUSE_MOVE:
+  switch(util::endian::little(header->magic)) {
+  case MOUSE_MOVE_REL_MAGIC_GEN5:
     passthrough(input, (PNV_REL_MOUSE_MOVE_PACKET)payload);
     break;
-  case PACKET_TYPE_ABS_MOUSE_MOVE:
+  case MOUSE_MOVE_ABS_MAGIC:
     passthrough(input, (PNV_ABS_MOUSE_MOVE_PACKET)payload);
     break;
-  case PACKET_TYPE_MOUSE_BUTTON:
+  case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
+  case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
     passthrough(input, (PNV_MOUSE_BUTTON_PACKET)payload);
     break;
-  case PACKET_TYPE_SCROLL_OR_KEYBOARD: {
-    char *tmp_input = (char *)payload + 4;
-    if(tmp_input[0] == 0x0A) {
-      passthrough((PNV_SCROLL_PACKET)payload);
-    }
-    else {
-      passthrough(input, (PNV_KEYBOARD_PACKET)payload);
-    }
-
+  case SCROLL_MAGIC_GEN5:
+    passthrough((PNV_SCROLL_PACKET)payload);
     break;
-  }
-  case PACKET_TYPE_MULTI_CONTROLLER:
+  case KEY_DOWN_EVENT_MAGIC:
+  case KEY_UP_EVENT_MAGIC:
+    passthrough(input, (PNV_KEYBOARD_PACKET)payload);
+    break;
+  case MULTI_CONTROLLER_MAGIC_GEN5:
     passthrough(input, (PNV_MULTI_CONTROLLER_PACKET)payload);
     break;
   }

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -296,6 +296,7 @@ void button_mouse(input_t &input, int button, bool release);
 void scroll(input_t &input, int distance);
 void keyboard(input_t &input, uint16_t modcode, bool release);
 void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state);
+void unicode(input_t &input, char *utf8, int size);
 
 int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue);
 void free_gamepad(input_t &input, int nr);

--- a/src/platform/linux/input.cpp
+++ b/src/platform/linux/input.cpp
@@ -994,6 +994,10 @@ void keyboard(input_t &input, uint16_t modcode, bool release) {
   keycode.pressed = 1;
 }
 
+void unicode(input_t &input, char *utf8, int size) {
+  BOOST_LOG(info) << "unicode: Unicode input not yet implemented for Linux."sv;
+}
+
 int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue) {
   return ((input_raw_t *)input.get())->alloc_gamepad(nr, std::move(rumble_queue));
 }

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -277,6 +277,10 @@ void keyboard(input_t &input, uint16_t modcode, bool release) {
   CGEventPost(kCGHIDEventTap, event);
 }
 
+void unicode(input_t &input, char *utf8, int size) {
+  BOOST_LOG(info) << "unicode: Unicode input not yet implemented for MacOS."sv;
+}
+
 int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue) {
   BOOST_LOG(info) << "alloc_gamepad: Gamepad not yet implemented for MacOS."sv;
   return -1;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -326,6 +326,34 @@ void keyboard(input_t &input, uint16_t modcode, bool release) {
   send_input(i);
 }
 
+void unicode(input_t &input, char *utf8, int size) {
+  // We can do no worse than one UTF-16 character per byte of UTF-8
+  WCHAR wide[size];
+
+  int chars = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, size, wide, size);
+  if(chars <= 0) {
+    return;
+  }
+
+  // Send all key down events
+  for(int i = 0; i < chars; i++) {
+    INPUT input {};
+    input.type       = INPUT_KEYBOARD;
+    input.ki.wScan   = wide[i];
+    input.ki.dwFlags = KEYEVENTF_UNICODE;
+    send_input(input);
+  }
+
+  // Send all key up events
+  for(int i = 0; i < chars; i++) {
+    INPUT input {};
+    input.type       = INPUT_KEYBOARD;
+    input.ki.wScan   = wide[i];
+    input.ki.dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP;
+    send_input(input);
+  }
+}
+
 int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue) {
   if(!input) {
     return 0;


### PR DESCRIPTION
## Description
The Moonlight PC client allows pasting UTF-8 from the client to the server using the Ctrl+Alt+Shift+V hotkey. Under the hood, this grabs the clipboard text and uses `PNV_UNICODE_PACKET` messages to send UTF-8 characters to the host.

This PR adds support for `PNV_UNICODE_PACKET` on Windows. We convert the UTF-8 bytes to UTF-16 and inject them via `SendInput()`. The focused application will receive them as `WM_CHAR` messages.

I needed to pull the latest `moonlight-common-c` which required some changes to input.cpp and allowed us to get rid of the qos2.h hack too. This change is in a separate commit for easier review.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #519 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
