### PR TITLE
Avoid using functions deprecated in OpenSSL 3.0

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -30,6 +30,7 @@ using cipher_ctx_t     = util::safe_ptr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_free>;
 using md_ctx_t         = util::safe_ptr<EVP_MD_CTX, md_ctx_destroy>;
 using bio_t            = util::safe_ptr<BIO, BIO_free_all>;
 using pkey_t           = util::safe_ptr<EVP_PKEY, EVP_PKEY_free>;
+using pkey_ctx_t       = util::safe_ptr<EVP_PKEY_CTX, EVP_PKEY_CTX_free>;
 
 sha256_t hash(const std::string_view &plaintext);
 


### PR DESCRIPTION
## Description
This PR fixes deprecation warnings in crypto.cpp due to use of legacy low-level SHA256/RSA APIs. I have replaced these with the high-level EVP equivalents as suggested by the OpenSSL 3.0 migration guide.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
