### PR TITLE
platform/windows: implement IDXGIOutput5 / Per Monitor v2

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -153,6 +153,7 @@ public:
   std::int32_t height {};
   std::int32_t pixel_pitch {};
   std::int32_t row_pitch {};
+  bool is_bgr = true;
 
   virtual ~img_t() = default;
 };

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -31,6 +31,7 @@ using device_ctx_t          = util::safe_ptr<ID3D11DeviceContext, Release<ID3D11
 using adapter_t             = util::safe_ptr<IDXGIAdapter1, Release<IDXGIAdapter1>>;
 using output_t              = util::safe_ptr<IDXGIOutput, Release<IDXGIOutput>>;
 using output1_t             = util::safe_ptr<IDXGIOutput1, Release<IDXGIOutput1>>;
+using output5_t             = util::safe_ptr<IDXGIOutput5, Release<IDXGIOutput5>>;
 using dup_t                 = util::safe_ptr<IDXGIOutputDuplication, Release<IDXGIOutputDuplication>>;
 using texture2d_t           = util::safe_ptr<ID3D11Texture2D, Release<ID3D11Texture2D>>;
 using texture1d_t           = util::safe_ptr<ID3D11Texture1D, Release<ID3D11Texture1D>>;

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -285,6 +285,7 @@ std::shared_ptr<platf::img_t> display_ram_t::alloc_img() {
   img->width       = width;
   img->height      = height;
   img->data        = new std::uint8_t[img->row_pitch * height];
+  img->is_bgr      = (format == DXGI_FORMAT_B8G8R8A8_UNORM ? true : false);
 
   return img;
 }

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -434,6 +434,7 @@ public:
 
     this->device_ctx_p = device_ctx_p;
 
+    DXGI_FORMAT src_format = format;
     format = (pix_fmt == pix_fmt_e::nv12 ? DXGI_FORMAT_NV12 : DXGI_FORMAT_P010);
     status = device_p->CreateVertexShader(scene_vs_hlsl->GetBufferPointer(), scene_vs_hlsl->GetBufferSize(), nullptr, &scene_vs);
     if(status) {
@@ -490,7 +491,7 @@ public:
     }
 
     D3D11_SHADER_RESOURCE_VIEW_DESC desc {
-      DXGI_FORMAT_B8G8R8A8_UNORM,
+      src_format,
       D3D11_SRV_DIMENSION_TEXTURE2D
     };
     desc.Texture2D.MipLevels = 1;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -89,9 +89,13 @@ public:
       data[1] = sw_frame->data[1] + offsetUV * 2;
       data[2] = nullptr;
     }
-    else {
+    else if (img.is_bgr) { // BGR0
       data[1] = sw_frame->data[1] + offsetUV;
       data[2] = sw_frame->data[2] + offsetUV;
+      data[3] = nullptr;
+    } else { // RGB0
+      data[1] = sw_frame->data[2] + offsetUV;
+      data[2] = sw_frame->data[1] + offsetUV;
       data[3] = nullptr;
     }
 


### PR DESCRIPTION
## Description
Implements IDXGIOutput5 with Per Monitor V2 DPI awareness support and additional fixes to fix mouse cursor rendering for hw encoding, and handle other screen formats that are used by exclusive fullscreen Vulkan and DX titles with "fullscreen optimizations" disabled.

### Issues Fixed or Closed
Fixes: https://github.com/LizardByte/Sunshine/issues/553
May resolve error 0x887A0004 observed in DuplicateOutput on certain configurations and/or improve general capture performance.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
