### PR TITLE
CMake: Linux: use standard FreeDesktop udev/systemd paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.16.0] - 2022-12-12
+## [0.16.0] - 2022-12-13
 ### Added
 - Add cover finder
 - (Docker) Add arm64 docker image
@@ -8,6 +8,7 @@
 - (Windows) Add support for Unicode input messages
 ### Fixed
 - (Linux) Reintroduce Ubuntu 20.04 and 22.04 specific deb packages
+- (Linux) Fixed udev and systemd file locations
 ### Dependencies
 - Bump babel from 2.10.3 to 2.11.0
 - Bump sphinx-copybutton from 0.5.0 to 0.5.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,8 +645,8 @@ elseif(UNIX)
 			install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/85-sunshine.rules" DESTINATION "${SUNSHINE_ASSETS_DIR}/udev/rules.d")
 			install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service" DESTINATION "${SUNSHINE_ASSETS_DIR}/systemd/user")
 		else()
-			install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/85-sunshine.rules" DESTINATION "${CMAKE_INSTALL_LIBDIR}/udev/rules.d")
-			install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service" DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/user")
+			install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/85-sunshine.rules" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d")
+			install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/systemd/user")
 		endif()
 
 		# Post install


### PR DESCRIPTION
## Description
The multiarch path (e.g. /usr/lib/x86_64-linux-gnu) is not the correct path for these files.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
