### PR TITLE
Add IPv6 streaming support

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -557,6 +557,30 @@ port
 
       port = 47989
 
+address_family
+^^^^^^^^^^^^^^
+
+**Description**
+   Set the address family that Sunshine will use.
+
+.. table::
+   :widths: auto
+
+   =====     ===========
+   Value     Description
+   =====     ===========
+   ipv4      IPv4 only
+   both      IPv4+IPv6
+   =====     ===========
+
+**Default**
+   ``ipv4``
+
+**Example**
+   .. code-block:: text
+
+      address_family = both
+
 pkey
 ^^^^
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -511,7 +511,8 @@ namespace config {
     {},  // Password Salt
     platf::appdata().string() + "/sunshine.conf",  // config file
     {},  // cmd args
-    47989,
+    47989,  // Base port number
+    "ipv4",  // Address family
     platf::appdata().string() + "/sunshine.log",  // log file
     {},  // prep commands
   };
@@ -1109,6 +1110,8 @@ namespace config {
     int port = sunshine.port;
     int_f(vars, "port"s, port);
     sunshine.port = (std::uint16_t) port;
+
+    string_restricted_f(vars, "address_family", sunshine.address_family, { "ipv4"sv, "both"sv });
 
     bool upnp = false;
     bool_f(vars, "upnp"s, upnp);

--- a/src/config.h
+++ b/src/config.h
@@ -155,6 +155,8 @@ namespace config {
     } cmd;
 
     std::uint16_t port;
+    std::string address_family;
+
     std::string log_file;
 
     std::vector<prep_cmd_t> prep_cmds;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -102,12 +102,96 @@ namespace net {
     return "wan"sv;
   }
 
+  /**
+   * @brief Returns the `af_e` enum value for the `address_family` config option value.
+   * @param view The config option value.
+   * @return The `af_e` enum value.
+   */
+  af_e
+  af_from_enum_string(const std::string_view &view) {
+    if (view == "ipv4") {
+      return IPV4;
+    }
+    if (view == "both") {
+      return BOTH;
+    }
+
+    // avoid warning
+    return BOTH;
+  }
+
+  /**
+   * @brief Returns the wildcard binding address for a given address family.
+   * @param af Address family.
+   * @return Normalized address.
+   */
+  std::string_view
+  af_to_any_address_string(af_e af) {
+    switch (af) {
+      case IPV4:
+        return "0.0.0.0"sv;
+      case BOTH:
+        return "::"sv;
+    }
+
+    // avoid warning
+    return "::"sv;
+  }
+
+  /**
+   * @brief Converts an address to a normalized form.
+   * @details Normalization converts IPv4-mapped IPv6 addresses into IPv4 addresses.
+   * @param address The address to normalize.
+   * @return Normalized address.
+   */
+  boost::asio::ip::address
+  normalize_address(boost::asio::ip::address address) {
+    // Convert IPv6-mapped IPv4 addresses into regular IPv4 addresses
+    if (address.is_v6()) {
+      auto v6 = address.to_v6();
+      if (v6.is_v4_mapped()) {
+        return boost::asio::ip::make_address_v4(boost::asio::ip::v4_mapped, v6);
+      }
+    }
+
+    return address;
+  }
+
+  /**
+   * @brief Returns the given address in normalized string form.
+   * @details Normalization converts IPv4-mapped IPv6 addresses into IPv4 addresses.
+   * @param address The address to normalize.
+   * @return Normalized address in string form.
+   */
+  std::string
+  addr_to_normalized_string(boost::asio::ip::address address) {
+    return normalize_address(address).to_string();
+  }
+
+  /**
+   * @brief Returns the given address in a normalized form for in the host portion of a URL.
+   * @details Normalization converts IPv4-mapped IPv6 addresses into IPv4 addresses.
+   * @param address The address to normalize and escape.
+   * @return Normalized address in URL-escaped string.
+   */
+  std::string
+  addr_to_url_escaped_string(boost::asio::ip::address address) {
+    address = normalize_address(address);
+    if (address.is_v6()) {
+      return "["s + address.to_string() + ']';
+    }
+    else {
+      return address.to_string();
+    }
+  }
+
   host_t
-  host_create(ENetAddress &addr, std::size_t peers, std::uint16_t port) {
-    enet_address_set_host(&addr, "0.0.0.0");
+  host_create(af_e af, ENetAddress &addr, std::size_t peers, std::uint16_t port) {
+    auto any_addr = net::af_to_any_address_string(af);
+    enet_address_set_host(&addr, any_addr.data());
     enet_address_set_port(&addr, port);
 
-    return host_t { enet_host_create(AF_INET, &addr, peers, 0, 0, 0) };
+    return host_t { enet_host_create(af == IPV4 ? AF_INET : AF_INET6, &addr, peers, 0, 0, 0) };
   }
 
   void

--- a/src/network.h
+++ b/src/network.h
@@ -6,6 +6,8 @@
 
 #include <tuple>
 
+#include <boost/asio.hpp>
+
 #include <enet/enet.h>
 
 #include "utility.h"
@@ -24,6 +26,11 @@ namespace net {
     WAN
   };
 
+  enum af_e : int {
+    IPV4,
+    BOTH
+  };
+
   net_e
   from_enum_string(const std::string_view &view);
   std::string_view
@@ -33,5 +40,39 @@ namespace net {
   from_address(const std::string_view &view);
 
   host_t
-  host_create(ENetAddress &addr, std::size_t peers, std::uint16_t port);
+  host_create(af_e af, ENetAddress &addr, std::size_t peers, std::uint16_t port);
+
+  /**
+   * @brief Returns the `af_e` enum value for the `address_family` config option value.
+   * @param view The config option value.
+   * @return The `af_e` enum value.
+   */
+  af_e
+  af_from_enum_string(const std::string_view &view);
+
+  /**
+   * @brief Returns the wildcard binding address for a given address family.
+   * @param af Address family.
+   * @return Normalized address.
+   */
+  std::string_view
+  af_to_any_address_string(af_e af);
+
+  /**
+   * @brief Returns the given address in normalized string form.
+   * @details Normalization converts IPv4-mapped IPv6 addresses into IPv4 addresses.
+   * @param address The address to normalize.
+   * @return Normalized address in string form.
+   */
+  std::string
+  addr_to_normalized_string(boost::asio::ip::address address);
+
+  /**
+   * @brief Returns the given address in a normalized form for in the host portion of a URL.
+   * @details Normalization converts IPv4-mapped IPv6 addresses into IPv4 addresses.
+   * @param address The address to normalize and escape.
+   * @return Normalized address in URL-escaped string.
+   */
+  std::string
+  addr_to_url_escaped_string(boost::asio::ip::address address);
 }  // namespace net

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -225,7 +225,7 @@ namespace rtsp_stream {
     }
 
     int
-    bind(std::uint16_t port, boost::system::error_code &ec) {
+    bind(net::af_e af, std::uint16_t port, boost::system::error_code &ec) {
       {
         auto lg = _session_slots.lock();
 
@@ -233,14 +233,14 @@ namespace rtsp_stream {
         _slot_count = config::stream.channels;
       }
 
-      acceptor.open(tcp::v4(), ec);
+      acceptor.open(af == net::IPV4 ? tcp::v4() : tcp::v6(), ec);
       if (ec) {
         return -1;
       }
 
       acceptor.set_option(boost::asio::socket_base::reuse_address { true });
 
-      acceptor.bind(tcp::endpoint(tcp::v4(), port), ec);
+      acceptor.bind(tcp::endpoint(af == net::IPV4 ? tcp::v4() : tcp::v6(), port), ec);
       if (ec) {
         return -1;
       }
@@ -766,7 +766,7 @@ namespace rtsp_stream {
     server.map("PLAY"sv, &cmd_play);
 
     boost::system::error_code ec;
-    if (server.bind(map_port(rtsp_stream::RTSP_SETUP_PORT), ec)) {
+    if (server.bind(net::af_from_enum_string(config::sunshine.address_family), map_port(rtsp_stream::RTSP_SETUP_PORT), ec)) {
       BOOST_LOG(fatal) << "Couldn't bind RTSP server to port ["sv << map_port(rtsp_stream::RTSP_SETUP_PORT) << "], " << ec.message();
       shutdown_event->raise(true);
 

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -607,6 +607,19 @@
       </div>
     </div>
     <div v-if="currentTab === 'advanced'" class="config-page">
+      <!--Address family-->
+      <div class="mb-3">
+        <label for="address_family" class="form-label">Address Family</label>
+        <select
+          id="address_family"
+          class="form-select"
+          v-model="config.address_family"
+        >
+          <option value="ipv4">IPv4 only</option>
+          <option value="both">IPv4+IPv6</option>
+        </select>
+        <div class="form-text">Set the address family used by Sunshine</div>
+      </div>
       <!--Port family-->
       <div class="mb-3">
         <label for="port" class="form-label">Port</label>
@@ -1027,6 +1040,7 @@
 <script>
   // create dictionary for defaultConfig
   const defaultConfig = {
+    "address_family": "ipv4",
     "always_send_scancodes": "enabled",
     "amd_coder": "auto",
     "amd_preanalysis": "disabled",


### PR DESCRIPTION
## Description
This PR introduces a new "Address Family" option in the "Advanced" settings page which can be used to select between IPv4-only and IPv4+IPv6 modes for streaming. IPv4-only is the default to match the current behavior.

I've also implemented IPv6 Firewall Control via UPnP (based on the GSv6Fwd code) which is supported by some routers. This will automatically open the IPv6 firewall to allow communication when UPnP is enabled, similar to how we create port mappings via UPnP for IPv4. Some routers that don't support UPnP IPv6 firewall control support PCP for pinholes instead, but I will implement that in a future PR. For now, users can open the IPv6 firewall manually in those cases.

The dual address family mode depends on OS support for the `IPV6_V6ONLY` socket option which allows us to have a single socket that can communicate with IPv4 and IPv6 endpoints. There is currently no IPv6-only option due to the need to plumb support for that `IPV6_V6ONLY` option into `Simple-HTTP-Server`. On OSes like OpenBSD that lack support for `IPV6_V6ONLY` , IPv6+IPv4 mode behaves like IPv6-only.

Note: The web UI is dual-stack, however it doesn't accept on-link interface addresses as LAN. Any GUA will be treated as a WAN address even if it's on-link.

### Screenshot
![Screenshot from 2022-12-16 18-27-26](https://user-images.githubusercontent.com/2695644/208212897-b819e51c-894e-4566-8d70-71f9e7267940.png)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #234 
- Fixes #390 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
