### PR TITLE
Fix SunshineSvc hanging if an error occurs during startup

### DIFF
--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -71,12 +71,12 @@ HANDLE OpenLogFileHandle() {
 
   // Overwrite the old sunshine.log
   return CreateFileW(log_file_name,
-                     GENERIC_WRITE,
-                     FILE_SHARE_READ,
-                     &security_attributes,
-                     CREATE_ALWAYS,
-                     0,
-                     NULL);
+    GENERIC_WRITE,
+    FILE_SHARE_READ,
+    &security_attributes,
+    CREATE_ALWAYS,
+    0,
+    NULL);
 }
 
 VOID WINAPI ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
@@ -91,7 +91,7 @@ VOID WINAPI ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
   }
 
   auto log_file_handle = OpenLogFileHandle();
-  if (log_file_handle == INVALID_HANDLE_VALUE) {
+  if(log_file_handle == INVALID_HANDLE_VALUE) {
     return;
   }
 
@@ -113,25 +113,25 @@ VOID WINAPI ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
     }
 
     STARTUPINFOW startup_info = {};
-    startup_info.cb         = sizeof(startup_info);
-    startup_info.lpDesktop  = (LPWSTR)L"winsta0\\default";
-    startup_info.dwFlags    = STARTF_USESTDHANDLES;
-    startup_info.hStdInput  = INVALID_HANDLE_VALUE;
-    startup_info.hStdOutput = log_file_handle;
-    startup_info.hStdError  = log_file_handle;
+    startup_info.cb           = sizeof(startup_info);
+    startup_info.lpDesktop    = (LPWSTR)L"winsta0\\default";
+    startup_info.dwFlags      = STARTF_USESTDHANDLES;
+    startup_info.hStdInput    = INVALID_HANDLE_VALUE;
+    startup_info.hStdOutput   = log_file_handle;
+    startup_info.hStdError    = log_file_handle;
 
     PROCESS_INFORMATION process_info;
     if(!CreateProcessAsUserW(console_token,
-                             L"Sunshine.exe",
-                             NULL,
-                             NULL,
-                             NULL,
-                             TRUE,
-                             ABOVE_NORMAL_PRIORITY_CLASS | CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
-                             NULL,
-                             NULL,
-                             &startup_info,
-                             &process_info)) {
+         L"Sunshine.exe",
+         NULL,
+         NULL,
+         NULL,
+         TRUE,
+         ABOVE_NORMAL_PRIORITY_CLASS | CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
+         NULL,
+         NULL,
+         &startup_info,
+         &process_info)) {
       CloseHandle(console_token);
       continue;
     }
@@ -162,8 +162,7 @@ VOID WINAPI ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
   SetServiceStatus(service_status_handle, &service_status);
 }
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char *argv[]) {
   static const SERVICE_TABLE_ENTRY service_table[] = {
     { (LPSTR)SERVICE_NAME, ServiceMain },
     { NULL, NULL }


### PR DESCRIPTION
## Description
This fixes a bug in SunshineSvc where it would not properly inform the Service Control Manager when startup failed. Without a call to `SetServiceStatus()`, SCM will just keep waiting for us until a system-wide service start timeout expires, even though we returned from `ServiceMain()`. The actual error that led us to fail startup will be lost and never logged.

With this change, we properly report errors back to SCM during startup, so `net start` and the Event Log will correctly display the failure and the error code.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
