### PR TITLE
Fix PATH variable handling on Windows

### DIFF
--- a/src_assets/windows/assets/apps.json
+++ b/src_assets/windows/assets/apps.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "PATH": "$(PATH);C:\\Program Files (x86)\\Steam"
+    "PATH": "$(PATH);$(ProgramFiles(x86))\\Steam"
   },
   "apps": [
     {


### PR DESCRIPTION
## Description
`boost::process::environment` uses a case-sensitive match when looking up environment variables, but Windows variables (especially `PATH`) tend to behave case-insensitively. Because the name of the Windows variable is `Path`, not `PATH`, we would attempt to concatenate `;C:\Program Files (x86)\Steam` to the `PATH` but end up overwriting the entire thing because `env["PATH"]` returned an empty string.

Our `PATH` value itself was also incorrectly hardcoded such that a system where the `Program Files (x86)` folder (or the whole Windows installation) did not reside on the C: drive would not be able to launch Steam.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
