### PR TITLE
Fix pixel pitch handling for DXGI_FORMAT_R16G16B16A16_FLOAT

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -131,6 +131,11 @@ public:
   } D3DKMT_SCHEDULINGPRIORITYCLASS;
 
   typedef NTSTATUS WINAPI (*PD3DKMTSetProcessSchedulingPriorityClass)(HANDLE, D3DKMT_SCHEDULINGPRIORITYCLASS);
+
+protected:
+  int get_pixel_pitch() {
+    return (format == DXGI_FORMAT_R16G16B16A16_FLOAT) ? 8 : 4;
+  }
 };
 
 class display_ram_t : public display_base_t {

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -280,7 +280,7 @@ capture_e display_ram_t::snapshot(::platf::img_t *img_base, std::chrono::millise
 std::shared_ptr<platf::img_t> display_ram_t::alloc_img() {
   auto img = std::make_shared<img_t>();
 
-  img->pixel_pitch = 4;
+  img->pixel_pitch = get_pixel_pitch();
   img->row_pitch   = img_info.RowPitch;
   img->width       = width;
   img->height      = height;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -757,7 +757,7 @@ int display_vram_t::init(int framerate, const std::string &display_name) {
 std::shared_ptr<platf::img_t> display_vram_t::alloc_img() {
   auto img = std::make_shared<img_d3d_t>();
 
-  img->pixel_pitch = 4;
+  img->pixel_pitch = get_pixel_pitch();
   img->row_pitch   = img->pixel_pitch * width;
   img->width       = width;
   img->height      = height;
@@ -802,13 +802,14 @@ int display_vram_t::dummy_img(platf::img_t *img_base) {
     return 0;
   }
 
-  img->row_pitch  = width * 4;
-  auto dummy_data = std::make_unique<int[]>(width * height);
+  img->pixel_pitch = get_pixel_pitch();
+  img->row_pitch   = img->pixel_pitch * width;
+  auto dummy_data  = std::make_unique<uint8_t[]>(img->row_pitch * height);
   D3D11_SUBRESOURCE_DATA data {
     dummy_data.get(),
     (UINT)img->row_pitch
   };
-  std::fill_n(dummy_data.get(), width * height, 0);
+  std::fill_n(dummy_data.get(), img->row_pitch * height, 0);
 
   D3D11_TEXTURE2D_DESC t {};
   t.Width            = width;


### PR DESCRIPTION
## Description
Pixel pitch was being calculated incorrectly for `DXGI_FORMAT_R16G16B16A16_FLOAT` (which is a 64-bit format), so our buffers weren't large enough to contain the full image. Additionally, `display_vram_t::dummy_img()` had a subtle bug where it was using `int[]` as the data buffer type (which is 4 bytes per element) instead of using `uint8_t[]` and the actual `pixel_pitch` value.

The combination of these would cause the display driver to read out of bounds inside `CreateTexture2D()` when attempting to populate the dummy texture during initialization if HDR was enabled in Windows.

With this change, Sunshine can now initialize without crashing on systems with HDR enabled. For semi-usable streaming, we also need #522 merged.

### Screenshot

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
