### PR TITLE
Fix streaming with non-B8G8R8A8 desktop mode

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -318,9 +318,17 @@ int display_base_t::init(int framerate, const std::string &display_name) {
   DXGI_OUTDUPL_DESC dup_desc;
   dup.dup->GetDesc(&dup_desc);
 
-  format = dup_desc.ModeDesc.Format;
+  BOOST_LOG(info) << "Desktop resolution ["sv << dup_desc.ModeDesc.Width << 'x' << dup_desc.ModeDesc.Height << ']';
+  BOOST_LOG(info) << "Desktop format ["sv << format_str[dup_desc.ModeDesc.Format] << ']';
 
-  BOOST_LOG(debug) << "Source format ["sv << format_str[dup_desc.ModeDesc.Format] << ']';
+  // For IDXGIOutput1::DuplicateOutput(), the format of the desktop image we receive from AcquireNextFrame() is
+  // converted to DXGI_FORMAT_B8G8R8A8_UNORM, even if the current mode (as returned in dup_desc) differs.
+  // See https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/desktop-dup-api for details.
+  //
+  // TODO: When we implement IDXGIOutput5, we will need to actually call AcquireNextFrame(), then call GetDesc()
+  // on the the texture we receive to determine which format in our list that it has decided to use.
+  format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  BOOST_LOG(info) << "Capture format ["sv << format_str[format] << ']';
 
   return 0;
 }


### PR DESCRIPTION
## Description
We had an incorrect assumption that the DXGI format of the mode in `DXGI_OUTDUPL_DESC` was the format of the frames that we will receive from `AcquireNextFrame()`.

This is incorrect as [MSDN](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/desktop-dup-api) states:
> The format of the desktop image is always DXGI_FORMAT_B8G8R8A8_UNORM no matter what the current display mode is.

This is why we thought we were getting formats like `DXGI_FORMAT_R16G16B16A16_FLOAT` (in HDR) and `DXGI_FORMAT_R8G8B8A8_UNORM` (in Vulkan apps). This change "fixes" streaming with HDR enabled (though output is clipped to SDR, causing it to look blown out). However, HDR can be successfully toggled off while streaming, which then streams a correct SDR image.

cc: @psyke83 

### Screenshot
Blown out HDR streaming (but better than nothing, which is what you get today)
![image](https://user-images.githubusercontent.com/2695644/209205273-6eaeec8f-fe65-492a-a38a-9afb343b9f95.png)

### Issues Fixed or Closed
Fixes #553

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
