### PR TITLE
QSV hardware encoding

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -430,6 +430,7 @@ jobs:
             libcurl4-openssl-dev \
             libdrm-dev \
             libevdev-dev \
+            libmfx-dev \
             libnuma-dev \
             libopus-dev \
             libpulse-dev \
@@ -885,6 +886,7 @@ jobs:
             mingw-w64-x86_64-binutils
             mingw-w64-x86_64-boost
             mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-libmfx
             mingw-w64-x86_64-nsis
             mingw-w64-x86_64-openssl
             mingw-w64-x86_64-opus

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,8 +387,8 @@ set_source_files_properties(src/upnp.cpp PROPERTIES COMPILE_FLAGS -Wno-pedantic)
 
 # Pre-compiled binaries
 if(WIN32)
-    set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-windows-x86_64")
-    set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid)
+    set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/test/ffmpeg-windows-x86_64")
+    set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid mfx)
 elseif(APPLE)
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-macos-aarch64")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -285,7 +285,7 @@ video_t video {
   },                                    // amd
   {
     qsv::medium,
-    0,
+    qsv::disabled,
     "" }, // qsv
 
   {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,8 +1,10 @@
 #include <algorithm>
+#include <charconv>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <string>
 #include <unordered_map>
 
 #include <boost/asio.hpp>
@@ -200,6 +202,26 @@ int coder_from_view(const std::string_view &coder) {
 }
 } // namespace amd
 
+namespace qsv {
+enum preset_e : int {
+  _default = 4,
+  veryslow = 1,
+  slower   = 2,
+  slow     = 3,
+  medium   = 4,
+  fast     = 5,
+  faster   = 6,
+  veryfast = 7
+};
+
+enum cavlc_e : int {
+  _auto    = false,
+  enabled  = true,
+  disabled = false
+};
+
+} // namespace qsv
+
 namespace vt {
 
 enum coder_e : int {
@@ -261,6 +283,11 @@ video_t video {
     (int)amd::rc_hevc_e::vbr_latency,   // rate control (hevc)
     (int)amd::coder_e::_auto,           // coder
   },                                    // amd
+  {
+    qsv::medium,
+    0,
+    "" }, // qsv
+
   {
     0,
     0,
@@ -775,6 +802,10 @@ void apply_config(std::unordered_map<std::string, std::string> &&vars) {
     video.amd.rc_h264 = amd::rc_from_view(rc, 1);
     video.amd.rc_hevc = amd::rc_from_view(rc, 0);
   }
+
+  int_f(vars, "qsv_preset", video.qsv.preset);
+  int_f(vars, "qsv_cavlc", video.qsv.cavlc);
+  string_f(vars, "qsv_child_device", video.qsv.child_device);
 
   int_f(vars, "vt_coder", video.vt.coder, vt::coder_from_view);
   int_f(vars, "vt_software", video.vt.allow_sw, vt::allow_software_from_view);

--- a/src/config.h
+++ b/src/config.h
@@ -37,6 +37,12 @@ struct video_t {
   } amd;
 
   struct {
+    std::optional<int> preset;
+    std::optional<int> cavlc;
+    std::string child_device;
+  } qsv;
+
+  struct {
     int allow_sw;
     int require_sw;
     int realtime;

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -232,6 +232,14 @@ int display_base_t::init(int framerate, const std::string &display_name) {
   }
 
   dup.use_dwmflush = config::video.dwmflush && !(framerate > refresh_rate) ? true : false;
+  
+  ID3D10Multithread *pMultithread;
+  
+  status = device->QueryInterface(IID_ID3D10Multithread, (void **)&pMultithread);
+  if(SUCCEEDED(status)) {
+    pMultithread->SetMultithreadProtected(TRUE);
+    Release(pMultithread);
+  }
 
   // Bump up thread priority
   {

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -410,6 +410,12 @@ public:
     frame->height = img.height;
     frame->width  = img.width;
 
+    // This resets the frame and produces bad output but does allow us to pass encoder checks
+//    if(av_hwframe_get_buffer(frame->hw_frames_ctx, frame, 0)) {
+//      BOOST_LOG(error) << "Couldn't get hwframe for QSV"sv;
+//      return -1;
+//    }
+
     AVFrame* qsv_frame = av_frame_alloc();
     qsv_frame->format = AV_PIX_FMT_QSV;
     av_hwframe_map(qsv_frame, frame, AV_HWFRAME_MAP_READ);

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -410,6 +410,10 @@ public:
     frame->height = img.height;
     frame->width  = img.width;
 
+    AVFrame* qsv_frame = av_frame_alloc();
+    qsv_frame->format = AV_PIX_FMT_QSV;
+    av_hwframe_map(qsv_frame, frame, AV_HWFRAME_MAP_READ);
+
     return 0;
   }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -20,7 +20,6 @@ extern "C" {
 #ifdef _WIN32
 extern "C" {
 #include <libavutil/hwcontext_d3d11va.h>
-#include <libavutil/hwcontext_qsv.h>
 }
 #endif
 
@@ -1835,9 +1834,8 @@ util::Either<buffer_t, int> dxgi_make_hwdevice_ctx(platf::hwdevice_t *hwdevice_c
 
 util::Either<buffer_t, int> qsv_make_hwdevice_ctx(platf::hwdevice_t *hwdevice_ctx) {
 
-  AVBufferRef *hw_device_ctx = NULL;
-
-  AVDictionary *child_device_opts = NULL;
+  AVBufferRef *hw_device_ctx = nullptr;
+  AVDictionary *child_device_opts = nullptr;
 
   if(!config::video.qsv.child_device.empty()) {
     av_dict_set(&child_device_opts, "child_device", config::video.qsv.child_device.data(), 0);
@@ -1848,10 +1846,8 @@ util::Either<buffer_t, int> qsv_make_hwdevice_ctx(platf::hwdevice_t *hwdevice_ct
     return buf_or_error.right();
   }
 
-  auto dxgi_hwdevice_ctx = std::move(buf_or_error.left().get());
-
-  // auto err = av_hwdevice_ctx_create(&hw_device_ctx, AV_HWDEVICE_TYPE_QSV, NULL, child_device_opts, 0);
-  auto err = av_hwdevice_ctx_create_derived(&hw_device_ctx, AV_HWDEVICE_TYPE_QSV, dxgi_hwdevice_ctx, 0);
+  auto dxgi_hwdevice_ctx = buf_or_error.left().get();
+  auto err = av_hwdevice_ctx_create_derived_opts(&hw_device_ctx, AV_HWDEVICE_TYPE_QSV, dxgi_hwdevice_ctx, child_device_opts, 0);
 
   if(err) {
     char err_str[AV_ERROR_MAX_STRING_SIZE] { 0 };


### PR DESCRIPTION
## Description
Initial support for Intel Quick Sync Video. This will use the libmfx/mediasdk route for now as FFmpeg 5.1 does not have oneVPL. 

This is mostly copied from the work done on #77 plus a few of the mentioned fixes as best as I could interpret them.

Currently using a test build of the ffmpeg libraries from LizardByte/build-deps#56 (`third-party/test/ffmpeg-windows-x86_64`)

TODO:
- [ ] Get it working 🙃
- [ ] Update docs
- [ ] Web changes

### Issues Fixed or Closed
- Resolves #436 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Dependency update (updates to dependencies)
- [X] Documentation update (changes to documentation)
- [X] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
