### PR TITLE
windows/vram: fix fringing in NV12 colour conversion

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -326,6 +326,7 @@ public:
       return;
     }
 
+    device_ctx_p->VSSetConstantBuffers(0, 1, &info_scene);
     device_ctx_p->PSSetConstantBuffers(0, 1, &color_matrix);
     this->color_matrix = std::move(color_matrix);
   }
@@ -376,10 +377,10 @@ public:
     img.row_pitch   = out_width * 4;
     img.pixel_pitch = 4;
 
-    float info_in[16 / sizeof(float)] { 1.0f / (float)out_width }; //aligned to 16-byte
+    float info_in[16 / sizeof(float)] { 1.0f / (float)out_width_f }; //aligned to 16-byte
     info_scene = make_buffer(device_p, info_in);
 
-    if(!info_in) {
+    if(!info_scene) {
       BOOST_LOG(error) << "Failed to create info scene buffer"sv;
       return -1;
     }


### PR DESCRIPTION
## Description

VSSetConstantBuffers was not passing the constant buffers for the vertex shader correctly. Resolve by initializing vertex buffers at the same time as the pixel shader buffers are updated to change the colourspace.

Also fix width_i float to use out_width_f to account for aspect ratio scaling.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
Before:
![Screenshot from 2022-12-25 04-46-17](https://user-images.githubusercontent.com/749000/209457681-6e29b6d3-07e7-4d31-af66-7d104a12e226.png)

After:
![Screenshot from 2022-12-25 04-47-37](https://user-images.githubusercontent.com/749000/209457690-cae49e88-8aab-44b6-9b16-cb9706350f9c.png)


### Issues Fixed or Closed
Resolves #608 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
