### PR TITLE
Remove duplicate boost port

### DIFF
--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -32,7 +32,6 @@ post-fetch {
 }
 
 depends_lib              port:avahi \
-                         port:boost180 \
                          port:curl \
                          port:libopus \
                          port:npm9 \


### PR DESCRIPTION
## Description
`boost.version` automatically adds the correct boost port dependency, removing `port:boost180` to avoid. See https://github.com/macports/macports-ports/blob/0cb1b3a7edb791ed0464eea6bc5b77294ee248bf/_resources/port1.0/group/boost-1.0.tcl#L61

Installed successfully with this change on an M1 MacBook Pro.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
