### PR TITLE
Rework audio bitrate and quality handling

### DIFF
--- a/src/audio.h
+++ b/src/audio.h
@@ -6,6 +6,7 @@
 namespace audio {
 enum stream_config_e : int {
   STEREO,
+  HIGH_STEREO,
   SURROUND51,
   HIGH_SURROUND51,
   SURROUND71,
@@ -19,6 +20,7 @@ struct opus_stream_config_t {
   int streams;
   int coupledStreams;
   const std::uint8_t *mapping;
+  int bitrate;
 };
 
 extern opus_stream_config_t stream_configs[MAX_STREAM_CONFIG];


### PR DESCRIPTION
## Description
This PR implements the proper audio bitrate logic needed to support high-quality stereo and surround when requested by Moonlight. The audio bitrate values match those used by GFE in those various audio configurations.

It fixes issues with variable-sized audio packets due to the `OPUS_BITRATE_MAX` workaround that would cause audio FEC to be disabled in Moonlight when streaming surround sound. Audio FEC is important to avoid audible artifacts due to dropped audio packets.

It fixes issues with 7.1 surround sound exceeding the maximum available packet size on Moonlight's end (found when testing #640). When this happens with a Windows client, Moonlight will receive a `WSAEMSGSIZE` error and terminate the connection. On a Linux client, Moonlight will just read the first 1400 bytes and fail to decrypt the audio packet, causing crackling due to missing audio data.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
