### PR TITLE
Generate certificates with unique serial numbers

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -31,6 +31,7 @@ using md_ctx_t         = util::safe_ptr<EVP_MD_CTX, md_ctx_destroy>;
 using bio_t            = util::safe_ptr<BIO, BIO_free_all>;
 using pkey_t           = util::safe_ptr<EVP_PKEY, EVP_PKEY_free>;
 using pkey_ctx_t       = util::safe_ptr<EVP_PKEY_CTX, EVP_PKEY_CTX_free>;
+using bignum_t         = util::safe_ptr<BIGNUM, BN_free>;
 
 sha256_t hash(const std::string_view &plaintext);
 


### PR DESCRIPTION
## Description
Firefox doesn't like duplicate certificates with the same serial number. Additional certificates encountered will result in SEC_ERROR_REUSED_ISSUER_AND_SERIAL. We can easily avoid this by generating a unique serial number in our certificates.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed
Fixes #114

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
