### PR TITLE
Remove/fix calls to std::abort()

### DIFF
--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -241,8 +241,7 @@ Application List
 
      - ``undo`` - Run after the application has terminated
 
-       - This should not fail considering it is supposed to undo the ``do`` commands
-       - If it fails, Sunshine is terminated
+       - Failures of ``undo`` commands are ignored
 
    - ``working-dir`` - The working directory to use. If not specified, Sunshine will use the application directory.
 

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <string>
 
+#include "src/main.h"
 #include "src/thread_safe.h"
 #include "src/utility.h"
 
@@ -197,7 +198,7 @@ struct hwdevice_t {
    * implementations must take ownership of 'frame'
    */
   virtual int set_frame(AVFrame *frame) {
-    std::abort(); // ^ This function must never be called
+    BOOST_LOG(error) << "Illegal call to hwdevice_t::set_frame(). Did you forget to override it?";
     return -1;
   };
 

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -89,9 +89,7 @@ std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std
   if(!mic->mic) {
     auto err_str = pa_strerror(status);
     BOOST_LOG(error) << "pa_simple_new() failed: "sv << err_str;
-
-    log_flush();
-    std::abort();
+    return nullptr;
   }
 
   return mic;
@@ -232,10 +230,8 @@ public:
         auto status = pa_mainloop_run(loop, &retval);
 
         if(status < 0) {
-          BOOST_LOG(fatal) << "Couldn't run pulseaudio main loop"sv;
-
-          log_flush();
-          std::abort();
+          BOOST_LOG(error) << "Couldn't run pulseaudio main loop"sv;
+          return;
         }
       },
       loop.get()

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -251,11 +251,18 @@ public:
 
   fb_t fb(plane_t::pointer plane) {
     cap_sys_admin admin;
-    auto fb = drmModeGetFB2(fd.el, plane->fb_id);
+
+    auto fb2 = drmModeGetFB2(fd.el, plane->fb_id);
+    if(fb2) {
+      return std::make_unique<wrapper_fb>(fb2);
+    }
+
+    auto fb = drmModeGetFB(fd.el, plane->fb_id);
     if(fb) {
       return std::make_unique<wrapper_fb>(fb);
     }
-    return std::make_unique<wrapper_fb>(drmModeGetFB(fd.el, plane->fb_id));
+
+    return nullptr;
   }
 
   crtc_t crtc(std::uint32_t id) {

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -495,10 +495,7 @@ void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
   }
 
   if(!VIGEM_SUCCESS(status)) {
-    BOOST_LOG(fatal) << "Couldn't send gamepad input to ViGEm ["sv << util::hex(status).to_string_view() << ']';
-
-    log_flush();
-    std::abort();
+    BOOST_LOG(warning) << "Couldn't send gamepad input to ViGEm ["sv << util::hex(status).to_string_view() << ']';
   }
 }
 

--- a/src/platform/windows/publish.cpp
+++ b/src/platform/windows/publish.cpp
@@ -151,7 +151,8 @@ class deinit_t : public ::platf::deinit_t {
 public:
   ~deinit_t() override {
     if(service(false)) {
-      std::abort();
+      BOOST_LOG(error) << "Unable to unregister mDNS service"sv;
+      return;
     }
 
     BOOST_LOG(info) << "Unregistered Sunshine Gamestream service"sv;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -195,12 +195,6 @@ void proc_t::terminate() {
   _process_handle = bp::group();
   _app_id         = -1;
 
-  if(ec) {
-    BOOST_LOG(fatal) << "System: "sv << ec.message();
-    log_flush();
-    std::abort();
-  }
-
   for(; _undo_it != _undo_begin; --_undo_it) {
     auto &cmd = (_undo_it - 1)->undo_cmd;
 
@@ -213,15 +207,11 @@ void proc_t::terminate() {
     auto ret = exe_with_full_privs(cmd, _env, _pipe, ec);
 
     if(ec) {
-      BOOST_LOG(fatal) << "System: "sv << ec.message();
-      log_flush();
-      std::abort();
+      BOOST_LOG(warning) << "System: "sv << ec.message();
     }
 
     if(ret != 0) {
-      BOOST_LOG(fatal) << "Return code ["sv << ret << ']';
-      log_flush();
-      std::abort();
+      BOOST_LOG(warning) << "Return code ["sv << ret << ']';
     }
   }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -877,10 +877,8 @@ void recvThread(broadcast_ctx_t &ctx) {
       }
 
       if(ec || !bytes) {
-        BOOST_LOG(fatal) << "Couldn't receive data from udp socket: "sv << ec.message();
-
-        log_flush();
-        std::abort();
+        BOOST_LOG(error) << "Couldn't receive data from udp socket: "sv << ec.message();
+        return;
       }
 
       auto it = peer_to_session.find(peer.address());


### PR DESCRIPTION
## Description
We shouldn't be aborting for non-fatal things like failing to deregister an mDNS service, failing to send input to the ViGEmBus driver, or an `undo` command returning a non-zero exit code.

This also reworks the mDNS registration code for Windows to address an issue that was causing us to consistently (at least on my machine) hit the the `std::abort()` in publish.cpp.

I also included a fix for a crash in KMS grab that I initially thought was a `std::abort()` before actually debugging it.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
