### PR TITLE
Remove Enter prompt on exit and make log levels for execution messages consistent

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -150,7 +150,7 @@ int proc_t::execute(int app_id) {
   }
 
   if(proc.cmd.empty()) {
-    BOOST_LOG(debug) << "Executing [Desktop]"sv;
+    BOOST_LOG(info) << "Executing [Desktop]"sv;
     placebo = true;
   }
   else {
@@ -202,7 +202,7 @@ void proc_t::terminate() {
       continue;
     }
 
-    BOOST_LOG(debug) << "Executing: ["sv << cmd << ']';
+    BOOST_LOG(info) << "Executing: ["sv << cmd << ']';
 
     auto ret = exe_with_full_privs(cmd, _env, _pipe, ec);
 


### PR DESCRIPTION
## Description
This addresses the feedback on #647 and #648 of removing the Enter prompt on exit and changing the log level of the "Executing" messages to be consistent.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
