### PR TITLE
Convert keyboard input to scancodes using the US English layout

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -170,12 +170,31 @@ void CALLBACK ds4_notify(
   task_pool.push(&vigem_t::rumble, (vigem_t *)userdata, target, smallMotor, largeMotor);
 }
 
-input_t input() {
-  input_t result { new vigem_t {} };
+struct input_raw_t {
+  ~input_raw_t() {
+    delete vigem;
+  }
 
-  auto vigem = (vigem_t *)result.get();
-  if(vigem->init()) {
-    return nullptr;
+  vigem_t *vigem;
+  HKL keyboard_layout;
+};
+
+input_t input() {
+  input_t result { new input_raw_t {} };
+  auto &raw = *(input_raw_t *)result.get();
+
+  raw.vigem = new vigem_t {};
+  if(raw.vigem->init()) {
+    delete raw.vigem;
+    raw.vigem = nullptr;
+  }
+
+  // Moonlight currently sends keys normalized to the US English layout.
+  // We need to use that layout when converting to scancodes.
+  raw.keyboard_layout = LoadKeyboardLayoutA("00000409", 0);
+  if(!raw.keyboard_layout || LOWORD(raw.keyboard_layout) != 0x409) {
+    BOOST_LOG(warning) << "Unable to load US English keyboard layout for scancode translation. Keyboard input may not work in games."sv;
+    raw.keyboard_layout = NULL;
   }
 
   return result;
@@ -285,16 +304,23 @@ void scroll(input_t &input, int distance) {
 }
 
 void keyboard(input_t &input, uint16_t modcode, bool release) {
+  auto raw = (input_raw_t *)input.get();
+
   INPUT i {};
   i.type   = INPUT_KEYBOARD;
   auto &ki = i.ki;
 
   // For some reason, MapVirtualKey(VK_LWIN, MAPVK_VK_TO_VSC) doesn't seem to work :/
-  if(modcode != VK_LWIN && modcode != VK_RWIN && modcode != VK_PAUSE) {
-    ki.wScan   = MapVirtualKey(modcode, MAPVK_VK_TO_VSC);
+  if(modcode != VK_LWIN && modcode != VK_RWIN && modcode != VK_PAUSE && raw->keyboard_layout != NULL) {
+    ki.wScan = MapVirtualKeyEx(modcode, MAPVK_VK_TO_VSC, raw->keyboard_layout);
+  }
+
+  // If we can map this to a scancode, send it as a scancode for maximum game compatibility.
+  if(ki.wScan) {
     ki.dwFlags = KEYEVENTF_SCANCODE;
   }
   else {
+    // If there is no scancode mapping, send it as a regular VK event.
     ki.wVk = modcode;
   }
 
@@ -355,19 +381,23 @@ void unicode(input_t &input, char *utf8, int size) {
 }
 
 int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue) {
-  if(!input) {
+  auto raw = (input_raw_t *)input.get();
+
+  if(!raw->vigem) {
     return 0;
   }
 
-  return ((vigem_t *)input.get())->alloc_gamepad_interal(nr, rumble_queue, map(config::input.gamepad));
+  return raw->vigem->alloc_gamepad_interal(nr, rumble_queue, map(config::input.gamepad));
 }
 
 void free_gamepad(input_t &input, int nr) {
-  if(!input) {
+  auto raw = (input_raw_t *)input.get();
+
+  if(!raw->vigem) {
     return;
   }
 
-  ((vigem_t *)input.get())->free_target(nr);
+  raw->vigem->free_target(nr);
 }
 
 static VIGEM_ERROR x360_update(client_t::pointer client, target_t::pointer gp, const gamepad_state_t &gamepad_state) {
@@ -476,12 +506,12 @@ static VIGEM_ERROR ds4_update(client_t::pointer client, target_t::pointer gp, co
 
 
 void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
+  auto vigem = ((input_raw_t *)input.get())->vigem;
+
   // If there is no gamepad support
-  if(!input) {
+  if(!vigem) {
     return;
   }
-
-  auto vigem = (vigem_t *)input.get();
 
   auto &[_, gp] = vigem->gamepads[nr];
 
@@ -500,9 +530,9 @@ void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
 }
 
 void freeInput(void *p) {
-  auto vigem = (vigem_t *)p;
+  auto input = (input_raw_t *)p;
 
-  delete vigem;
+  delete input;
 }
 
 std::vector<std::string_view> &supported_gamepads() {


### PR DESCRIPTION
## Description
This is an attempt to address the keyboard layout issues when not using a US English layout on the host.

We need testing from one of the affected users to see if this fixes the issue.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
