### PR TITLE
Dynamic capture format selection (IDXGIOutput5)

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -31,6 +31,7 @@ using device_ctx_t          = util::safe_ptr<ID3D11DeviceContext, Release<ID3D11
 using adapter_t             = util::safe_ptr<IDXGIAdapter1, Release<IDXGIAdapter1>>;
 using output_t              = util::safe_ptr<IDXGIOutput, Release<IDXGIOutput>>;
 using output1_t             = util::safe_ptr<IDXGIOutput1, Release<IDXGIOutput1>>;
+using output5_t             = util::safe_ptr<IDXGIOutput5, Release<IDXGIOutput5>>;
 using dup_t                 = util::safe_ptr<IDXGIOutputDuplication, Release<IDXGIOutputDuplication>>;
 using texture2d_t           = util::safe_ptr<ID3D11Texture2D, Release<ID3D11Texture2D>>;
 using texture1d_t           = util::safe_ptr<ID3D11Texture1D, Release<ID3D11Texture1D>>;

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -184,7 +184,6 @@ public:
   ps_t scene_ps;
   vs_t scene_vs;
 
-  texture2d_t src;
   gpu_cursor_t cursor;
 };
 } // namespace platf::dxgi

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -140,7 +140,8 @@ protected:
 
   const char *dxgi_format_to_string(DXGI_FORMAT format);
 
-  virtual int complete_img(img_t *img, bool dummy) = 0;
+  virtual int complete_img(img_t *img, bool dummy)                     = 0;
+  virtual std::vector<DXGI_FORMAT> get_supported_sdr_capture_formats() = 0;
 };
 
 class display_ram_t : public display_base_t {
@@ -152,6 +153,7 @@ public:
   std::shared_ptr<img_t> alloc_img() override;
   int dummy_img(img_t *img) override;
   int complete_img(img_t *img, bool dummy) override;
+  std::vector<DXGI_FORMAT> get_supported_sdr_capture_formats() override;
 
   int init(int framerate, const std::string &display_name);
 
@@ -168,6 +170,7 @@ public:
   std::shared_ptr<img_t> alloc_img() override;
   int dummy_img(img_t *img_base) override;
   int complete_img(img_t *img_base, bool dummy) override;
+  std::vector<DXGI_FORMAT> get_supported_sdr_capture_formats() override;
 
   int init(int framerate, const std::string &display_name);
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -118,7 +118,7 @@ public:
   device_ctx_t device_ctx;
   duplication_t dup;
 
-  DXGI_FORMAT format;
+  DXGI_FORMAT capture_format;
   D3D_FEATURE_LEVEL feature_level;
 
   typedef enum _D3DKMT_SCHEDULINGPRIORITYCLASS {
@@ -134,8 +134,12 @@ public:
 
 protected:
   int get_pixel_pitch() {
-    return (format == DXGI_FORMAT_R16G16B16A16_FLOAT) ? 8 : 4;
+    return (capture_format == DXGI_FORMAT_R16G16B16A16_FLOAT) ? 8 : 4;
   }
+
+  const char *dxgi_format_to_string(DXGI_FORMAT format);
+
+  virtual int complete_img(img_t *img, bool dummy) = 0;
 };
 
 class display_ram_t : public display_base_t {
@@ -146,6 +150,7 @@ public:
 
   std::shared_ptr<img_t> alloc_img() override;
   int dummy_img(img_t *img) override;
+  int complete_img(img_t *img, bool dummy) override;
 
   int init(int framerate, const std::string &display_name);
 
@@ -161,6 +166,7 @@ public:
 
   std::shared_ptr<img_t> alloc_img() override;
   int dummy_img(img_t *img_base) override;
+  int complete_img(img_t *img_base, bool dummy) override;
 
   int init(int framerate, const std::string &display_name);
 

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -319,16 +319,10 @@ int display_base_t::init(int framerate, const std::string &display_name) {
   dup.dup->GetDesc(&dup_desc);
 
   BOOST_LOG(info) << "Desktop resolution ["sv << dup_desc.ModeDesc.Width << 'x' << dup_desc.ModeDesc.Height << ']';
-  BOOST_LOG(info) << "Desktop format ["sv << format_str[dup_desc.ModeDesc.Format] << ']';
+  BOOST_LOG(info) << "Desktop format ["sv << dxgi_format_to_string(dup_desc.ModeDesc.Format) << ']';
 
-  // For IDXGIOutput1::DuplicateOutput(), the format of the desktop image we receive from AcquireNextFrame() is
-  // converted to DXGI_FORMAT_B8G8R8A8_UNORM, even if the current mode (as returned in dup_desc) differs.
-  // See https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/desktop-dup-api for details.
-  //
-  // TODO: When we implement IDXGIOutput5, we will need to actually call AcquireNextFrame(), then call GetDesc()
-  // on the the texture we receive to determine which format in our list that it has decided to use.
-  format = DXGI_FORMAT_B8G8R8A8_UNORM;
-  BOOST_LOG(info) << "Capture format ["sv << format_str[format] << ']';
+  // Capture format will be determined from the first call to AcquireNextFrame()
+  capture_format = DXGI_FORMAT_UNKNOWN;
 
   return 0;
 }
@@ -457,6 +451,10 @@ const char *format_str[] = {
   "DXGI_FORMAT_V208",
   "DXGI_FORMAT_V408"
 };
+
+const char *display_base_t::dxgi_format_to_string(DXGI_FORMAT format) {
+  return format_str[format];
+}
 
 } // namespace platf::dxgi
 

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -350,6 +350,10 @@ int display_ram_t::dummy_img(platf::img_t *img) {
   return complete_img(img, true);
 }
 
+std::vector<DXGI_FORMAT> display_ram_t::get_supported_sdr_capture_formats() {
+  return std::vector { DXGI_FORMAT_B8G8R8A8_UNORM };
+}
+
 int display_ram_t::init(int framerate, const std::string &display_name) {
   if(display_base_t::init(framerate, display_name)) {
     return -1;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -567,7 +567,7 @@ capture_e display_vram_t::snapshot(platf::img_t *img_base, std::chrono::millisec
   }
 
   const bool mouse_update_flag = frame_info.LastMouseUpdateTime.QuadPart != 0 || frame_info.PointerShapeBufferSize > 0;
-  const bool frame_update_flag = frame_info.AccumulatedFrames != 0 || frame_info.LastPresentTime.QuadPart != 0;
+  const bool frame_update_flag = frame_info.AccumulatedFrames != 0 || frame_info.LastPresentTime.QuadPart != 0 || !src;
   const bool update_flag       = mouse_update_flag || frame_update_flag;
 
   if(!update_flag) {
@@ -625,7 +625,7 @@ capture_e display_vram_t::snapshot(platf::img_t *img_base, std::chrono::millisec
   }
 
   if(frame_info.LastMouseUpdateTime.QuadPart) {
-    cursor.set_pos(frame_info.PointerPosition.Position.x, frame_info.PointerPosition.Position.y, frame_info.PointerPosition.Visible && cursor_visible);
+    cursor.set_pos(frame_info.PointerPosition.Position.x, frame_info.PointerPosition.Position.y, frame_info.PointerPosition.Visible);
   }
 
   if(frame_update_flag) {
@@ -652,7 +652,7 @@ capture_e display_vram_t::snapshot(platf::img_t *img_base, std::chrono::millisec
   }
 
   device_ctx->CopyResource(img->texture.get(), src.get());
-  if(cursor.visible) {
+  if(cursor.visible && cursor_visible) {
     D3D11_VIEWPORT view {
       0.0f, 0.0f,
       (float)width, (float)height,

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -638,12 +638,27 @@ capture_e display_vram_t::snapshot(platf::img_t *img_base, std::chrono::millisec
       return capture_e::error;
     }
 
+    D3D11_TEXTURE2D_DESC desc;
+    src->GetDesc(&desc);
+
     // If we don't know the capture format yet, grab it from this texture
     if(capture_format == DXGI_FORMAT_UNKNOWN) {
-      D3D11_TEXTURE2D_DESC desc;
-      src->GetDesc(&desc);
       capture_format = desc.Format;
       BOOST_LOG(info) << "Capture format ["sv << dxgi_format_to_string(capture_format) << ']';
+    }
+
+    // It's possible for our display enumeration to race with mode changes and result in
+    // mismatched image pool and desktop texture sizes. If this happens, just reinit again.
+    if(desc.Width != width || desc.Height != height) {
+      BOOST_LOG(info) << "Capture size changed ["sv << width << 'x' << height << " -> "sv << desc.Width << 'x' << desc.Height << ']';
+      return capture_e::reinit;
+    }
+
+    // It's also possible for the capture format to change on the fly. If that happens,
+    // reinitialize capture to try format detection again and create new images.
+    if(capture_format != desc.Format) {
+      BOOST_LOG(info) << "Capture format changed ["sv << dxgi_format_to_string(capture_format) << " -> "sv << dxgi_format_to_string(desc.Format) << ']';
+      return capture_e::reinit;
     }
 
     // Now that we know the capture format, we can finish creating the image

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -665,8 +665,8 @@ capture_e display_vram_t::snapshot(platf::img_t *img_base, std::chrono::millisec
     device_ctx->VSSetShader(scene_vs.get(), nullptr, 0);
     device_ctx->PSSetShader(scene_ps.get(), nullptr, 0);
     device_ctx->RSSetViewports(1, &view);
-    device_ctx->OMSetRenderTargets(1, &img->scene_rt, nullptr);
     device_ctx->PSSetShaderResources(0, 1, &cursor.input_res);
+    device_ctx->OMSetRenderTargets(1, &img->scene_rt, nullptr);
     device_ctx->OMSetBlendState(blend_enable.get(), nullptr, 0xFFFFFFFFu);
     device_ctx->RSSetViewports(1, &cursor.cursor_view);
     device_ctx->Draw(3, 0);

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -791,6 +791,10 @@ int display_vram_t::dummy_img(platf::img_t *img_base) {
   return complete_img(img_base, true);
 }
 
+std::vector<DXGI_FORMAT> display_vram_t::get_supported_sdr_capture_formats() {
+  return std::vector { DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM };
+}
+
 std::shared_ptr<platf::hwdevice_t> display_vram_t::make_hwdevice(pix_fmt_e pix_fmt) {
   if(pix_fmt != platf::pix_fmt_e::nv12 && pix_fmt != platf::pix_fmt_e::p010) {
     BOOST_LOG(error) << "display_vram_t doesn't support pixel format ["sv << from_pix_fmt(pix_fmt) << ']';


### PR DESCRIPTION
## Description
The first commit in this PR implements support for detection of DXGI format at the time `AcquireNextFrame()` is called rather than during `display::init()`. This required reworking a lot of logic around the initialization of `img_t` objects to separate format-dependent and format-independent attributes and handle creating dummy images where we don't know the capture format yet. I also did a little bit of P010 format prep work while I was in there.

The second commit is a cherry-pick of @psyke83 's IDXGIOutput5 implementation which now works properly with the dynamic capture format support implemented in the first commit.

The third commit implements support for the `display_ram_t` and `display_vram_t` backends to influence the selected capture formats. `display_vram_t` is pretty flexible (it even works with `DXGI_FORMAT_R16G16B16A16_FLOAT`), but `display_ram_t` has some specific pixel format requirements due to the code that handles blending the cursor into the final image. In this commit, I also opted `display_vram_t` into `DXGI_FORMAT_R8G8B8A8_UNORM` support to hopefully improve capture performance for Vulkan and full-screen DX11 apps.

Note for future testing: It is possible to request a specific format for testing by returning a single entry from `get_supported_sdr_capture_formats()`. This allows testing things like `DXGI_FORMAT_R16G16B16A16_FLOAT` even without HDR enabled. DWM will convert the desktop surface to the requested format.

@psyke83 : I'd appreciate your review and testing before merging if you have time, since you did a lot of this initial work on IDXGIOutput5.

### Screenshot
HEVC Main 10 works with NVENC (though video is still SDR):
![image](https://user-images.githubusercontent.com/2695644/210042068-67e5baa9-18d8-407b-90ec-57a3495a86ae.png)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
