### PR TITLE
update id on application edit

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -298,6 +298,13 @@ void saveApp(resp_https_t response, req_https_t request) {
     pt::read_json(ss, inputTree);
     pt::read_json(config::stream.file_apps, fileTree);
 
+    // Moonlight checks the id of an item to determine if an item was changed
+    // Add a property named "id" to the inputTree with a value of the current timestamp
+    // Time is in seconds because some Moonlight clients cannot accept more than a 32-bit integer
+    // Milliseconds would be a better option
+    time_t id = time(nullptr);
+    inputTree.put("id", id);
+
     if(inputTree.get_child("prep-cmd").empty()) {
       inputTree.erase("prep-cmd");
     }

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -687,9 +687,18 @@ void applist(resp_https_t response, req_https_t request) {
   for(auto &proc : proc::proc.get_apps()) {
     pt::ptree app;
 
+    // Check if the "id" field is empty
+    if(!proc.id.empty()) {
+      // Use the "id" field if it is not empty
+      app.put("ID", proc.id);
+    }
+    else {
+      // Otherwise, use the "x" counter to set the ID
+      app.put("ID", ++x);
+    }
+
     app.put("IsHdrSupported"s, config::video.hevc_mode == 3 ? 1 : 0);
     app.put("AppTitle"s, proc.name);
-    app.put("ID"s, ++x);
 
     apps.push_back(std::make_pair("App", std::move(app)));
   }

--- a/src/process.h
+++ b/src/process.h
@@ -54,6 +54,7 @@ struct ctx_t {
   std::string working_dir;
   std::string output;
   std::string image_path;
+  std::string id;
 };
 
 class proc_t {


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When an application is saved, the current timestamp in milliseconds is added to as the application id. A timestamp was used instead of a random integer to prevent any chance of repeated values.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #551 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
