### PR TITLE
Enable parallel encoding for NVENC and AMF

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -36,7 +36,7 @@ using dup_t                 = util::safe_ptr<IDXGIOutputDuplication, Release<IDX
 using texture2d_t           = util::safe_ptr<ID3D11Texture2D, Release<ID3D11Texture2D>>;
 using texture1d_t           = util::safe_ptr<ID3D11Texture1D, Release<ID3D11Texture1D>>;
 using resource_t            = util::safe_ptr<IDXGIResource, Release<IDXGIResource>>;
-using multithread_t         = util::safe_ptr<ID3D11Multithread, Release<ID3D11Multithread>>;
+using multithread_t         = util::safe_ptr<ID3D10Multithread, Release<ID3D10Multithread>>;
 using vs_t                  = util::safe_ptr<ID3D11VertexShader, Release<ID3D11VertexShader>>;
 using ps_t                  = util::safe_ptr<ID3D11PixelShader, Release<ID3D11PixelShader>>;
 using blend_t               = util::safe_ptr<ID3D11BlendState, Release<ID3D11BlendState>>;
@@ -175,6 +175,8 @@ public:
   int init(int framerate, const std::string &display_name);
 
   std::shared_ptr<platf::hwdevice_t> make_hwdevice(pix_fmt_e pix_fmt) override;
+
+  multithread_t multithread;
 
   sampler_state_t sampler_linear;
 


### PR DESCRIPTION
## Description
This PR introduces the required use of the `ID3D10Multithread` interface and enables `PARALLEL_ENCODING` for NVENC and AMF encoders to hopefully improve performance for capturing Vulkan applications.

This works fine for me (no warnings with the debug runtime using NVENC), but I'd like a test from @psyke83 on AMD to verify that it works fine there and see if it improves performance for Gravity Mark in Vulkan mode.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
