### PR TITLE
Fix unexpected format switching in display_vram

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -185,6 +185,8 @@ public:
   vs_t scene_vs;
 
   gpu_cursor_t cursor;
+
+  texture2d_t last_frame_copy;
 };
 } // namespace platf::dxgi
 


### PR DESCRIPTION
## Description
I think I finally figured out what's going on with the unexpected capture format changes. It looks like DWM will cheat by using a surface that is in the desktop format until a frame is returned that that has `LastPresentTime != 0` (which requires the DWM to convert the surface into the format we asked for).

Due to this behavior, #654 introduced a bug that would cause the surface format to constantly flip-flop between the requested capture format (when the desktop is updated) and the desktop format (when returning a cursor-only update). This format-switching happened constantly when requesting `DXGI_FORMAT_R10G10B10A2_UNORM` which led to very poor performance due to constantly reinitializing the capture session. This issue wasn't visible when we tested #654 because `display_vram` reported support for both R8G8B8A8 and B8G8R8A8 desktop formats, so the desktop format always matched the capture format.

To address this, I've added an intermediate texture (similar to the staging texture `display_ram` uses) to store a copy of the last captured desktop frame. If `LastPresentTime == 0`, we copy from that frame instead of `src`.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
