### PR TITLE
Add Media Foundation encoder

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -822,6 +822,7 @@ encoder
    nvenc      For NVIDIA graphics cards
    quicksync  For Intel graphics cards
    amdvce     For AMD graphics cards
+   mf         Media Foundation (slower than encoders above)
    software   Encoding occurs on the CPU
    =========  ===========
 

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -216,7 +216,7 @@ namespace platf {
    * implementations must take ownership of 'frame'
    */
     virtual int
-    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) {
+    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format) {
       BOOST_LOG(error) << "Illegal call to hwdevice_t::set_frame(). Did you forget to override it?";
       return -1;
     };

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -102,7 +102,7 @@ namespace cuda {
     }
 
     int
-    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) override {
+    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format) override {
       this->hwframe.reset(frame);
       this->frame = frame;
 
@@ -193,8 +193,8 @@ namespace cuda {
     }
 
     int
-    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) {
-      if (cuda_t::set_frame(frame, hw_frames_ctx)) {
+    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format) {
+      if (cuda_t::set_frame(frame, hw_frames_ctx, target_format)) {
         return -1;
       }
 

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -329,7 +329,7 @@ namespace va {
     }
 
     int
-    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) override {
+    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format) override {
       this->hwframe.reset(frame);
       this->frame = frame;
 

--- a/src/platform/macos/nv12_zero_device.cpp
+++ b/src/platform/macos/nv12_zero_device.cpp
@@ -56,7 +56,7 @@ namespace platf {
   }
 
   int
-  nv12_zero_device::set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) {
+  nv12_zero_device::set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format) {
     this->frame = frame;
 
     av_frame.reset(frame);

--- a/src/platform/macos/nv12_zero_device.h
+++ b/src/platform/macos/nv12_zero_device.h
@@ -23,7 +23,7 @@ namespace platf {
     int
     convert(img_t &img);
     int
-    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx);
+    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format);
     void
     set_colorspace(std::uint32_t colorspace, std::uint32_t color_range);
   };

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -355,6 +355,16 @@ namespace platf::dxgi {
       ID3D11ShaderResourceView *emptyShaderResourceView = nullptr;
       device_ctx->PSSetShaderResources(0, 1, &emptyShaderResourceView);
 
+      // If this requires conversion to a swframe, transfer data back from the GPU
+      if (swframe) {
+        auto status = av_hwframe_transfer_data(this->frame, hwframe.get(), 0);
+        if (status < 0) {
+          char string[AV_ERROR_MAX_STRING_SIZE];
+          BOOST_LOG(error) << "Failed to transfer image data from hardware frame: "sv << av_make_error_string(string, AV_ERROR_MAX_STRING_SIZE, status);
+          return -1;
+        }
+      }
+
       return 0;
     }
 
@@ -425,9 +435,25 @@ namespace platf::dxgi {
     }
 
     int
-    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) override {
+    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format) override {
       this->hwframe.reset(frame);
-      this->frame = frame;
+
+      // If we have to do conversion to a different swframe pixel format, set up our context to do so
+      if (frame->format != target_format) {
+        swframe.reset(av_frame_alloc());
+        swframe->format = target_format;
+        swframe->width = frame->width;
+        swframe->height = frame->height;
+
+        // Allocate buffers for the swframe data
+        av_frame_get_buffer(swframe.get(), 0);
+
+        // Expose the swframe to the encoder rather than the hwframe
+        this->frame = swframe.get();
+      }
+      else {
+        this->frame = frame;
+      }
 
       // Populate this frame with a hardware buffer if one isn't there already
       if (!frame->buf[0]) {
@@ -723,6 +749,9 @@ namespace platf::dxgi {
 
   public:
     frame_t hwframe;
+
+    // Used when target_format differs from hwframe.format
+    frame_t swframe;
 
     ::video::color_t *color_p;
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -599,6 +599,45 @@ namespace video {
     PARALLEL_ENCODING,
     dxgi_make_hwdevice_ctx
   };
+
+  static encoder_t mfenc {
+    "mf"sv,
+    AV_HWDEVICE_TYPE_NONE, AV_HWDEVICE_TYPE_NONE,
+    AV_PIX_FMT_NONE,
+    AV_PIX_FMT_NV12, AV_PIX_FMT_P010,
+    {
+      // Common options
+      {
+        { "hw_encoding"s, 1 },
+        { "scenario"s, "display_remoting"s },
+        { "low_latency", 1 },
+
+        // Other rate controls exist but they are inconsistently implemented
+        // and can cause codec init to totally fail if unsupported.
+        { "rate_control"s, "cbr"s },
+      },
+      {},  // SDR-specific options
+      {},  // HDR-specific options
+      std::nullopt,
+      "hevc_mf"s,
+    },
+    {
+      // Common options
+      {
+        { "hw_encoding"s, 1 },
+        { "scenario"s, "display_remoting"s },
+        { "low_latency", 1 },
+        { "rate_control"s, "cbr"s },
+      },
+      {},  // SDR-specific options
+      {},  // HDR-specific options
+      std::nullopt,
+      "h264_mf"s,
+    },
+    PARALLEL_ENCODING,
+    nullptr
+  };
+
 #endif
 
   static encoder_t software {
@@ -717,6 +756,7 @@ namespace video {
 #ifdef _WIN32
     &quicksync,
     &amdvce,
+    &mfenc,
 #endif
 #ifdef __linux__
     &vaapi,

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -141,7 +141,7 @@ namespace video {
     }
 
     int
-    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) {
+    set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx, int target_format) {
       this->frame = frame;
 
       // If it's a hwframe, allocate buffers for hardware
@@ -321,6 +321,12 @@ namespace video {
     AVHWDeviceType base_dev_type, derived_dev_type;
     AVPixelFormat dev_pix_fmt;
 
+    // Encoder requires frames to be read back into the sw_pix_fmt
+    // prior to being passed to the encoder. This can provide GPU
+    // accelerated RGB->YUV color conversion for encoders that can't
+    // otherwise accept GPU surfaces as input.
+    bool sw_frame_readback;
+
     AVPixelFormat static_pix_fmt, dynamic_pix_fmt;
 
     struct {
@@ -445,10 +451,10 @@ namespace video {
     "nvenc"sv,
 #ifdef _WIN32
     AV_HWDEVICE_TYPE_D3D11VA, AV_HWDEVICE_TYPE_NONE,
-    AV_PIX_FMT_D3D11,
+    AV_PIX_FMT_D3D11, false,
 #else
     AV_HWDEVICE_TYPE_CUDA, AV_HWDEVICE_TYPE_NONE,
-    AV_PIX_FMT_CUDA,
+    AV_PIX_FMT_CUDA, false,
 #endif
     AV_PIX_FMT_NV12, AV_PIX_FMT_P010,
     {
@@ -504,6 +510,7 @@ namespace video {
     AV_HWDEVICE_TYPE_D3D11VA,
     AV_HWDEVICE_TYPE_QSV,
     AV_PIX_FMT_QSV,
+    false,
     AV_PIX_FMT_NV12,
     AV_PIX_FMT_P010,
     {
@@ -557,7 +564,7 @@ namespace video {
   static encoder_t amdvce {
     "amdvce"sv,
     AV_HWDEVICE_TYPE_D3D11VA, AV_HWDEVICE_TYPE_NONE,
-    AV_PIX_FMT_D3D11,
+    AV_PIX_FMT_D3D11, false,
     AV_PIX_FMT_NV12, AV_PIX_FMT_P010,
     {
       // Common options
@@ -602,8 +609,8 @@ namespace video {
 
   static encoder_t mfenc {
     "mf"sv,
-    AV_HWDEVICE_TYPE_NONE, AV_HWDEVICE_TYPE_NONE,
-    AV_PIX_FMT_NONE,
+    AV_HWDEVICE_TYPE_D3D11VA, AV_HWDEVICE_TYPE_NONE,
+    AV_PIX_FMT_D3D11, true,
     AV_PIX_FMT_NV12, AV_PIX_FMT_P010,
     {
       // Common options
@@ -635,7 +642,7 @@ namespace video {
       "h264_mf"s,
     },
     PARALLEL_ENCODING,
-    nullptr
+    dxgi_make_hwdevice_ctx
   };
 
 #endif
@@ -643,7 +650,7 @@ namespace video {
   static encoder_t software {
     "software"sv,
     AV_HWDEVICE_TYPE_NONE, AV_HWDEVICE_TYPE_NONE,
-    AV_PIX_FMT_NONE,
+    AV_PIX_FMT_NONE, false,
     AV_PIX_FMT_YUV420P, AV_PIX_FMT_YUV420P10,
     {
       // x265's Info SEI is so long that it causes the IDR picture data to be
@@ -681,7 +688,7 @@ namespace video {
   static encoder_t vaapi {
     "vaapi"sv,
     AV_HWDEVICE_TYPE_VAAPI, AV_HWDEVICE_TYPE_NONE,
-    AV_PIX_FMT_VAAPI,
+    AV_PIX_FMT_VAAPI, false,
     AV_PIX_FMT_NV12, AV_PIX_FMT_YUV420P10,
     {
       // Common options
@@ -717,7 +724,7 @@ namespace video {
   static encoder_t videotoolbox {
     "videotoolbox"sv,
     AV_HWDEVICE_TYPE_NONE, AV_HWDEVICE_TYPE_NONE,
-    AV_PIX_FMT_VIDEOTOOLBOX,
+    AV_PIX_FMT_VIDEOTOOLBOX, false,
     AV_PIX_FMT_NV12, AV_PIX_FMT_NV12,
     {
       // Common options
@@ -756,7 +763,7 @@ namespace video {
 #ifdef _WIN32
     &quicksync,
     &amdvce,
-    &mfenc,
+    &mfenc,  // Should be lowest priority hw encoder
 #endif
 #ifdef __linux__
     &vaapi,
@@ -1270,16 +1277,6 @@ namespace video {
       return std::nullopt;
     }
 
-    if (auto status = avcodec_open2(ctx.get(), codec, &options)) {
-      char err_str[AV_ERROR_MAX_STRING_SIZE] { 0 };
-      BOOST_LOG(error)
-        << "Could not open codec ["sv
-        << video_format.name << "]: "sv
-        << av_make_error_string(err_str, AV_ERROR_MAX_STRING_SIZE, status);
-
-      return std::nullopt;
-    }
-
     frame_t frame { av_frame_alloc() };
     frame->format = ctx->pix_fmt;
     frame->width = ctx->width;
@@ -1331,11 +1328,33 @@ namespace video {
       device = std::move(hwdevice);
     }
 
-    if (device->set_frame(frame.release(), ctx->hw_frames_ctx)) {
+    // If this encoder doesn't accept hardware frames, use the swformat
+    if (hardware && encoder.sw_frame_readback) {
+      ctx->pix_fmt = sw_fmt;
+    }
+
+    if (device->set_frame(frame.release(), ctx->hw_frames_ctx, ctx->pix_fmt)) {
       return std::nullopt;
     }
 
     device->set_colorspace(sws_color_space, ctx->color_range);
+
+    // FFmpeg doesn't allow a hw_frames_ctx to be attached to the codec context
+    // if we're going to be using a software pixel format, so we will remove it
+    // now that set_frame() has had a chance to attach it to the AVFrame.
+    if (hardware && encoder.sw_frame_readback) {
+      av_buffer_unref(&ctx->hw_frames_ctx);
+    }
+
+    if (auto status = avcodec_open2(ctx.get(), codec, &options)) {
+      char err_str[AV_ERROR_MAX_STRING_SIZE] { 0 };
+      BOOST_LOG(error)
+        << "Could not open codec ["sv
+        << video_format.name << "]: "sv
+        << av_make_error_string(err_str, AV_ERROR_MAX_STRING_SIZE, status);
+
+      return std::nullopt;
+    }
 
     session_t session {
       std::move(ctx),

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -671,6 +671,7 @@
           <option value="amdvce" v-if="platform === 'windows'">AMD AMF/VCE</option>
           <option value="vaapi" v-if="platform === 'linux'">VA-API</option>
           <option value="videotoolbox" v-if="platform === 'macos'">VideoToolbox</option>
+          <option value="mf" v-if="platform === 'windows'">Media Foundation</option>
           <option value="software">Software</option>
         </select>
         <div class="form-text">


### PR DESCRIPTION
## Description
This PR introduces support for Media Foundation encoders (h264_mf and hevc_mf). This enables partial hardware acceleration on Windows systems where NVENC, QSV, and AMD AMF are unsupported, like ARM platforms. I also implemented support for GPU accelerated color conversion when encoding from CPU memory and enabled that feature for Media Foundation.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
![image](https://user-images.githubusercontent.com/2695644/213344614-36126832-88cb-4721-9cc4-c3f3f3ddc2df.png)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
