### PR TITLE
Fix UPnP IGD detection

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -111,7 +111,7 @@ std::unique_ptr<platf::deinit_t> start() {
   IGDdatas data;
 
   auto status = UPNP_GetValidIGD(device.get(), &urls.el, &data, lan_addr.data(), lan_addr.size());
-  if(status != 1) {
+  if(status != 1 && status != 2) {
     BOOST_LOG(error) << status_string(status);
     return nullptr;
   }

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -82,6 +82,8 @@ static std::string_view status_string(int status) {
   case 1:
     return "Valid IGD device found"sv;
   case 2:
+    return "Valid IGD device found,  but it isn't connected"sv;
+  case 3:
     return "A UPnP device has been found,  but it wasn't recognized as an IGD"sv;
   }
 


### PR DESCRIPTION
## Description
This PR fixes the UPnP status messages and allows the detection of UPnP iuds that are in status 2 (not connected)

An IGD in status 1 is the IGD of the network and connected (has an external IP which isn't in a private block)
An IGD in status 2 is also the IGD of the network but may not be connected due to various reasons (no external IP or external IP in a private IPv4/IPv6 block)

Sunshine should not discard an IGD of status 2 as the reason to the unconnected status is not determinable by an outside source and has to be fixed by the network administrator/owner. This can be a misconfigured second router or just the ISP being down due to various reasons. 

We still do not attempt to open ports on a status 3 as this is just a UPnP device which is not an IGD.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
