### PR TITLE
Fix 7.1 surround channel mapping

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -92,7 +92,6 @@ constexpr std::uint8_t map_surround71[] {
   FRONT_RIGHT,
   FRONT_CENTER,
   LOW_FREQUENCY,
-  LOW_FREQUENCY,
   BACK_LEFT,
   BACK_RIGHT,
   SIDE_LEFT,


### PR DESCRIPTION
## Description
There was an extra LFE channel in the mapping array for the 7.1 surround sound setting that was causing channels to get swapped when streaming in 7.1 mode.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
