### PR TITLE
Fix origin_web_ui_allowed binding

### DIFF
--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -860,7 +860,7 @@
           this.config.origin_pin_allowed =
             this.config.origin_pin_allowed || "pc";
           this.config.origin_web_ui_allowed =
-            this.config.origin_web_manager_allowed || "lan";
+            this.config.origin_web_ui_allowed || "lan";
           this.config.hevc_mode = this.config.hevc_mode || 0;
           this.config.encoder = this.config.encoder || "";
           this.config.nv_preset = this.config.nv_preset || "p4";


### PR DESCRIPTION
## Description
This change fixes Vue binding for config.origin_web_ui_allowed (introduced in beb6bdfadb0c6d5aaa0c434320cd903b6e0c85cd). Without the change config value is always ignored and "Only LAN devices may access the web ui" is displayed instead.


### Screenshot
n/a


### Issues Fixed or Closed
n/a


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
