### PR TITLE
Fix hang on stream termination if no frames can be captured

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -216,7 +216,8 @@ enum class capture_e : int {
 class display_t {
 public:
   /**
-   * When display has a new image ready, this callback will be called with the new image.
+   * When display has a new image ready or a timeout occurs, this callback will be called with the image.
+   * If a frame was captured, frame_captured will be true. If a timeout occurred, it will be false.
    * 
    * On Break Request -->
    *    Returns nullptr
@@ -225,7 +226,7 @@ public:
    *    Returns the image object that should be filled next.
    *    This may or may not be the image send with the callback
    */
-  using snapshot_cb_t = std::function<std::shared_ptr<img_t>(std::shared_ptr<img_t> &img)>;
+  using snapshot_cb_t = std::function<std::shared_ptr<img_t>(std::shared_ptr<img_t> &img, bool frame_captured)>;
 
   display_t() noexcept : offset_x { 0 }, offset_y { 0 } {}
 

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -505,10 +505,10 @@ public:
       case platf::capture_e::error:
         return status;
       case platf::capture_e::timeout:
-        std::this_thread::sleep_for(1ms);
-        continue;
+        img = snapshot_cb(img, false);
+        break;
       case platf::capture_e::ok:
-        img = snapshot_cb(img);
+        img = snapshot_cb(img, true);
         break;
       default:
         BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -684,10 +684,10 @@ public:
       case platf::capture_e::error:
         return status;
       case platf::capture_e::timeout:
-        std::this_thread::sleep_for(1ms);
-        continue;
+        img = snapshot_cb(img, false);
+        break;
       case platf::capture_e::ok:
-        img = snapshot_cb(img);
+        img = snapshot_cb(img, true);
         break;
       default:
         BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';
@@ -805,10 +805,10 @@ public:
       case platf::capture_e::error:
         return status;
       case platf::capture_e::timeout:
-        std::this_thread::sleep_for(1ms);
-        continue;
+        img = snapshot_cb(img, false);
+        break;
       case platf::capture_e::ok:
-        img = snapshot_cb(img);
+        img = snapshot_cb(img, true);
         break;
       default:
         BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -134,9 +134,10 @@ public:
       case platf::capture_e::error:
         return status;
       case platf::capture_e::timeout:
-        continue;
+        img = snapshot_cb(img, false);
+        break;
       case platf::capture_e::ok:
-        img = snapshot_cb(img);
+        img = snapshot_cb(img, true);
         break;
       default:
         BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';
@@ -239,9 +240,10 @@ public:
       case platf::capture_e::error:
         return status;
       case platf::capture_e::timeout:
-        continue;
+        img = snapshot_cb(img, false);
+        break;
       case platf::capture_e::ok:
-        img = snapshot_cb(img);
+        img = snapshot_cb(img, true);
         break;
       default:
         BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -476,10 +476,10 @@ struct x11_attr_t : public display_t {
       case platf::capture_e::error:
         return status;
       case platf::capture_e::timeout:
-        std::this_thread::sleep_for(1ms);
-        continue;
+        img = snapshot_cb(img, false);
+        break;
       case platf::capture_e::ok:
-        img = snapshot_cb(img);
+        img = snapshot_cb(img, true);
         break;
       default:
         BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';
@@ -587,10 +587,10 @@ struct shm_attr_t : public x11_attr_t {
       case platf::capture_e::error:
         return status;
       case platf::capture_e::timeout:
-        std::this_thread::sleep_for(1ms);
-        continue;
+        img = snapshot_cb(img, false);
+        break;
       case platf::capture_e::ok:
-        img = snapshot_cb(img);
+        img = snapshot_cb(img, true);
         break;
       default:
         BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';

--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -60,11 +60,12 @@ struct av_display_t : public display_t {
       img_next->row_pitch   = CVPixelBufferGetBytesPerRow(pixelBuffer);
       img_next->pixel_pitch = img_next->row_pitch / img_next->width;
 
-      img_next = snapshot_cb(img_next);
+      img_next = snapshot_cb(img_next, true);
 
       return img_next != nullptr;
     }];
 
+    // FIXME: We should time out if an image isn't returned for a while
     dispatch_semaphore_wait(signal, DISPATCH_TIME_FOREVER);
 
     return capture_e::ok;

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -181,10 +181,11 @@ capture_e display_ram_t::capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<::
     case platf::capture_e::error:
       return status;
     case platf::capture_e::timeout:
+      img = snapshot_cb(img, false);
       std::this_thread::sleep_for(1ms);
-      continue;
+      break;
     case platf::capture_e::ok:
-      img = snapshot_cb(img);
+      img = snapshot_cb(img, true);
       break;
     default:
       BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -652,10 +652,11 @@ capture_e display_vram_t::capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<:
     case platf::capture_e::error:
       return status;
     case platf::capture_e::timeout:
+      img = snapshot_cb(img, false);
       std::this_thread::sleep_for(1ms);
-      continue;
+      break;
     case platf::capture_e::ok:
-      img = snapshot_cb(img);
+      img = snapshot_cb(img, true);
       break;
     default:
       BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';


### PR DESCRIPTION
## Description
While testing with #707, I discovered an issue that was causing stream termination hangs that would prevent a client from reconnecting (or with #707, cause Sunshine to terminate itself). The issue is that the only time `display_t::capture()` will return to the capture thread or invoke the callback is when a frame is successfully captured or an error or reinit occurs. If it's just a normal timeout, the capture function will loop forever trying to capture a frame.

To fix this, I added a parameter to the `snapshot_cb` callback that indicates whether a frame was captured or if this is a callback invocation caused by a timeout. Now that `snapshot_cb` is being invoked for timeouts, it can check if capture should stop and return `nullptr` to indicate that.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
