### PR TITLE
Improve robustness of encoder selection

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1029,9 +1029,11 @@ std::optional<session_t> make_session(const encoder_t &encoder, const config_t &
     ctx->bit_rate    = bitrate;
     ctx->rc_min_rate = bitrate;
 
-    if(!hardware && ctx->slices > 1) {
+    if(!hardware && (ctx->slices > 1 || config.videoFormat != 0)) {
       // Use a larger rc_buffer_size for software encoding when slices are enabled,
       // because libx264 can severely degrade quality if the buffer is too small.
+      // libx265 encounters this issue more frequently, so always scale the
+      // buffer by 1.5x for software HEVC encoding.
       ctx->rc_buffer_size = bitrate / ((config.framerate * 10) / 15);
     }
     else {


### PR DESCRIPTION
## Description
Rework encoder selection logic to avoid terminating Sunshine if the preferred encoder is not available or doesn't meet the HDR requirement selected. This ensures it's not possible to accidentally set an encoder that's not supported on your system and prevent Sunshine from starting again without manual config file modification.

The old logic was:
1. If a specific encoder is requested, use that encoder. If that encoder doesn't pass validation or doesn't support HDR when requested, fail to start.
2. If an encoder with HDR support is requested and passes validation, use that encoder. If no encoder with HDR support is available, fail to start.
3. If no specific encoder was requested and HDR encoding was not required, use the first working encoder.
4. Else, fail to start.

The new logic is:
1. If a specific encoder is requested and that encoder passes validation, use the specified encoder.
2. If an encoder with HDR support is requested and one is available, use the first working encoder with HDR support.
3. If any encoder passes validation, use the first working encoder.
4. Else, fail to start.

I also made a small fix for #692 based on testing with libx265 during this work. libx265 encoding still has issues but this makes it much better (and restores pre-#692 levels of functionality).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
