### PR TITLE
Migrate Windows config files into specific config directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,9 @@ if(WIN32) # see options at: https://cmake.org/cmake/help/latest/cpack_gen/nsis.h
     install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/service/"
             DESTINATION "scripts"
             COMPONENT service)
+    install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/migration/"
+            DESTINATION "scripts"
+            COMPONENT assets)
 
     # Sunshine assets
     install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/"
@@ -548,12 +551,16 @@ if(WIN32) # see options at: https://cmake.org/cmake/help/latest/cpack_gen/nsis.h
     set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_NAME}")
 
     # Extra install commands
-    # Sets permissions on the installed folder so that we can write in it
+    # Restores permissions on the install directory
+    # Migrates config files from the root into the new config folder
+    # Sets permissions on the config folder so that we can write in it
     # Install service
     SET(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
             "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
         ExecWait '\\\"$SYSDIR\\\\cmd.exe\\\" /c \\\"start https://sunshinestream.readthedocs.io/\\\"'
-        ExecWait 'icacls \\\"$INSTDIR\\\" /grant:r Users:\\\(OI\\\)\\\(CI\\\)\\\(F\\\)'
+        ExecWait 'icacls \\\"$INSTDIR\\\" /reset'
+        ExecWait '\\\"$INSTDIR\\\\scripts\\\\migrate-config.bat\\\"'
+        ExecWait 'icacls \\\"$INSTDIR\\\\config\\\" /grant:r Users:\\\(OI\\\)\\\(CI\\\)\\\(F\\\)'
         ExecWait '\\\"$INSTDIR\\\\scripts\\\\add-firewall-rule.bat\\\"'
         ExecWait '\\\"$INSTDIR\\\\scripts\\\\install-service.bat\\\"'
         MessageBox MB_YESNO|MB_ICONQUESTION 'Do you want to add/update ViGEmBus (virtual controller support)?' \

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -33,7 +33,7 @@ location by modifying the configuration file.
    Docker      /config/
    Linux       ~/.config/sunshine/
    macOS       ~/.config/sunshine/
-   Windows     ./config/
+   Windows     %ProgramFiles%\\Sunshine\\config
    =========   ===========
 
 **Example**

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -29,7 +29,9 @@ namespace platf {
 using adapteraddrs_t = util::c_ptr<IP_ADAPTER_ADDRESSES>;
 
 std::filesystem::path appdata() {
-  return L"."sv;
+  WCHAR sunshine_path[MAX_PATH];
+  GetModuleFileNameW(NULL, sunshine_path, _countof(sunshine_path));
+  return std::filesystem::path { sunshine_path }.remove_filename() / L"config"sv;
 }
 
 std::string from_sockaddr(const sockaddr *const socket_address) {

--- a/src_assets/linux/assets/apps.json
+++ b/src_assets/linux/assets/apps.json
@@ -19,7 +19,6 @@
     },
     {
       "name": "Steam BigPicture",
-      "output": "steam.txt",
       "detached": [
         "setsid steam steam://open/bigpicture"
       ],

--- a/src_assets/macos/assets/apps.json
+++ b/src_assets/macos/assets/apps.json
@@ -9,7 +9,6 @@
     },
     {
       "name": "Steam BigPicture",
-      "output": "steam.txt",
       "detached": [
         "open steam://open/bigpicture"
       ],

--- a/src_assets/windows/assets/apps.json
+++ b/src_assets/windows/assets/apps.json
@@ -9,7 +9,6 @@
     },
     {
       "name": "Steam BigPicture",
-      "output": "steam.txt",
       "detached": [
         "steam steam://open/bigpicture"
       ],

--- a/src_assets/windows/misc/migration/migrate-config.bat
+++ b/src_assets/windows/misc/migration/migrate-config.bat
@@ -1,0 +1,43 @@
+@echo off
+
+rem Get sunshine root directory
+for %%I in ("%~dp0\..") do set "OLD_DIR=%%~fI"
+
+rem Create the config directory if it didn't already exist
+set "NEW_DIR=%OLD_DIR%\config"
+if not exist "%NEW_DIR%\" mkdir "%NEW_DIR%"
+
+rem Migrate all files that aren't already present in the config dir
+if exist "%OLD_DIR%\apps.json" (
+    if not exist "%NEW_DIR%\apps.json" (
+        move "%OLD_DIR%\apps.json" "%NEW_DIR%\apps.json"
+    )
+)
+if exist "%OLD_DIR%\sunshine.conf" (
+    if not exist "%NEW_DIR%\sunshine.conf" (
+        move "%OLD_DIR%\sunshine.conf" "%NEW_DIR%\sunshine.conf"
+    )
+)
+if exist "%OLD_DIR%\sunshine_state.json" (
+    if not exist "%NEW_DIR%\sunshine_state.json" (
+        move "%OLD_DIR%\sunshine_state.json" "%NEW_DIR%\sunshine_state.json"
+    )
+)
+
+rem Migrate the credentials directory
+if exist "%OLD_DIR%\credentials\" (
+    if not exist "%NEW_DIR%\credentials\" (
+        move "%OLD_DIR%\credentials" "%NEW_DIR%\"
+    )
+)
+
+rem Migrate the covers directory
+if exist "%OLD_DIR%\covers\" (
+    if not exist "%NEW_DIR%\covers\" (
+        move "%OLD_DIR%\covers" "%NEW_DIR%\"
+    )
+)
+
+rem Remove log files
+del "%OLD_DIR%\*.txt"
+del "%OLD_DIR%\*.log"

--- a/src_assets/windows/misc/migration/migrate-config.bat
+++ b/src_assets/windows/misc/migration/migrate-config.bat
@@ -35,6 +35,9 @@ rem Migrate the covers directory
 if exist "%OLD_DIR%\covers\" (
     if not exist "%NEW_DIR%\covers\" (
         move "%OLD_DIR%\covers" "%NEW_DIR%\"
+
+        rem Fix apps.json image path values that point at the old covers directory
+        powershell -c "(Get-Content '%NEW_DIR%\apps.json').replace('.\/covers\/', '.\/config\/covers\/') | Set-Content '%NEW_DIR%\apps.json'"
     )
 )
 


### PR DESCRIPTION
## Description
This moves config and other data files out of the root of our Program Files directory into a specific `config` directory. Only that new config directory has RW access for the Users group now.

I've tested this locally, but it would be nice for someone else to grab the installer from the CI job to make sure it all works seamlessly for them too.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
