### PR TITLE
Fix Windows masked cursor blending with GPU encoders

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -185,13 +185,15 @@ public:
 
   sampler_state_t sampler_linear;
 
-  blend_t blend_enable;
+  blend_t blend_alpha;
+  blend_t blend_invert;
   blend_t blend_disable;
 
   ps_t scene_ps;
   vs_t scene_vs;
 
-  gpu_cursor_t cursor;
+  gpu_cursor_t cursor_alpha;
+  gpu_cursor_t cursor_xor;
 
   texture2d_t last_frame_copy;
 };

--- a/src/utility.h
+++ b/src/utility.h
@@ -726,6 +726,9 @@ public:
   buffer_t(buffer_t &&o) noexcept : _els { o._els }, _buf { std::move(o._buf) } {
     o._els = 0;
   }
+  buffer_t(const buffer_t &o) : _els { o._els }, _buf { std::make_unique<T[]>(_els) } {
+    std::copy(o.begin(), o.end(), begin());
+  }
   buffer_t &operator=(buffer_t &&o) noexcept {
     std::swap(_els, o._els);
     std::swap(_buf, o._buf);


### PR DESCRIPTION
## Description
Blending of masked color and monochrome cursors was broken when using GPU accelerated encoding on Windows. Color masked cursors would be rendered completely transparently (no cursor at all) and monochrome masked cursors would not be blended with the display contents at all (using fixed colors instead).

This fixes the I-beam cursor when using High DPI (which is a masked color cursor) and the inverted cursor style (which uses monochrome cursors with inversion masks).

### Screenshot

### Issues Fixed or Closed
Fixes #513


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
