### PR TITLE
Color conversion fixes and BT.2020 support

### DIFF
--- a/src/platform/linux/cuda.cu
+++ b/src/platform/linux/cuda.cu
@@ -322,6 +322,8 @@ void sws_t::set_colorspace(std::uint32_t colorspace, std::uint32_t color_range) 
     color_p = &video::colors[2];
     break;
   case 9: // SWS_CS_BT2020
+    color_p = &video::colors[4];
+    break;
   default:
     color_p = &video::colors[0];
   };

--- a/src/platform/linux/cuda.cu
+++ b/src/platform/linux/cuda.cu
@@ -143,7 +143,7 @@ inline __device__ float2 calcUV(float3 pixel, const video::color_t *const color_
   float v = dot(pixel, make_float3(vec_v)) + vec_v.w;
 
   u = u * color_matrix->range_uv.x + color_matrix->range_uv.y;
-  v = (v * color_matrix->range_uv.x + color_matrix->range_uv.y) * 224.0f / 256.0f + 0.0625f;
+  v = v * color_matrix->range_uv.x + color_matrix->range_uv.y;
 
   return make_float2(u, v);
 }

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -588,6 +588,8 @@ void sws_t::set_colorspace(std::uint32_t colorspace, std::uint32_t color_range) 
     color_p = &video::colors[2];
     break;
   case 9: // SWS_CS_BT2020
+    color_p = &video::colors[4];
+    break;
   default:
     BOOST_LOG(warning) << "Colorspace: ["sv << colorspace << "] not yet supported: switching to default"sv;
     color_p = &video::colors[0];

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -369,6 +369,8 @@ public:
       color_p = &::video::colors[2];
       break;
     case 9: // SWS_CS_BT2020
+      color_p = &::video::colors[4];
+      break;
     default:
       BOOST_LOG(warning) << "Colorspace: ["sv << colorspace << "] not yet supported: switching to default"sv;
       color_p = &::video::colors[0];

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1966,7 +1966,7 @@ platf::pix_fmt_e map_pix_fmt(AVPixelFormat fmt) {
   return platf::pix_fmt_e::unknown;
 }
 
-color_t make_color_matrix(float Cr, float Cb, float U_max, float V_max, float add_Y, float add_UV, const float2 &range_Y, const float2 &range_UV) {
+color_t make_color_matrix(float Cr, float Cb, const float2 &range_Y, const float2 &range_UV) {
   float Cg = 1.0f - Cr - Cb;
 
   float Cr_i = 1.0f - Cr;
@@ -1978,18 +1978,18 @@ color_t make_color_matrix(float Cr, float Cb, float U_max, float V_max, float ad
   float scale_y  = (range_Y[1] - range_Y[0]) / 256.0f;
   float scale_uv = (range_UV[1] - range_UV[0]) / 256.0f;
   return {
-    { Cr, Cg, Cb, add_Y },
-    { -(Cr * U_max / Cb_i), -(Cg * U_max / Cb_i), U_max, add_UV },
-    { V_max, -(Cg * V_max / Cr_i), -(Cb * V_max / Cr_i), add_UV },
+    { Cr, Cg, Cb, 0.0f },
+    { -(Cr * 0.5f / Cb_i), -(Cg * 0.5f / Cb_i), 0.5f, 0.5f },
+    { 0.5f, -(Cg * 0.5f / Cr_i), -(Cb * 0.5f / Cr_i), 0.5f },
     { scale_y, shift_y },
     { scale_uv, shift_uv },
   };
 }
 
 color_t colors[] {
-  make_color_matrix(0.299f, 0.114f, 0.436f, 0.615f, 0.0625, 0.5f, { 16.0f, 235.0f }, { 16.0f, 240.0f }),   // BT601 MPEG
-  make_color_matrix(0.299f, 0.114f, 0.5f, 0.5f, 0.0f, 0.5f, { 0.0f, 255.0f }, { 0.0f, 255.0f }),           // BT601 JPEG
-  make_color_matrix(0.2126f, 0.0722f, 0.436f, 0.615f, 0.0625, 0.5f, { 16.0f, 235.0f }, { 16.0f, 240.0f }), // BT701 MPEG
-  make_color_matrix(0.2126f, 0.0722f, 0.5f, 0.5f, 0.0f, 0.5f, { 0.0f, 255.0f }, { 0.0f, 255.0f }),         // BT701 JPEG
+  make_color_matrix(0.299f, 0.114f, { 16.0f, 235.0f }, { 16.0f, 240.0f }),   // BT601 MPEG
+  make_color_matrix(0.299f, 0.114f, { 0.0f, 255.0f }, { 0.0f, 255.0f }),     // BT601 JPEG
+  make_color_matrix(0.2126f, 0.0722f, { 16.0f, 235.0f }, { 16.0f, 240.0f }), // BT709 MPEG
+  make_color_matrix(0.2126f, 0.0722f, { 0.0f, 255.0f }, { 0.0f, 255.0f }),   // BT709 JPEG
 };
 } // namespace video

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1991,5 +1991,7 @@ color_t colors[] {
   make_color_matrix(0.299f, 0.114f, { 0.0f, 255.0f }, { 0.0f, 255.0f }),     // BT601 JPEG
   make_color_matrix(0.2126f, 0.0722f, { 16.0f, 235.0f }, { 16.0f, 240.0f }), // BT709 MPEG
   make_color_matrix(0.2126f, 0.0722f, { 0.0f, 255.0f }, { 0.0f, 255.0f }),   // BT709 JPEG
+  make_color_matrix(0.2627f, 0.0593f, { 16.0f, 235.0f }, { 16.0f, 240.0f }), // BT2020 MPEG
+  make_color_matrix(0.2627f, 0.0593f, { 0.0f, 255.0f }, { 0.0f, 255.0f }),   // BT2020 JPEG
 };
 } // namespace video

--- a/src/video.h
+++ b/src/video.h
@@ -72,7 +72,7 @@ struct __attribute__((__aligned__(16))) color_t {
   float2 range_uv;
 };
 
-extern color_t colors[4];
+extern color_t colors[6];
 
 void capture(
   safe::mail_t mail,

--- a/src_assets/linux/assets/shaders/opengl/ConvertUV.frag
+++ b/src_assets/linux/assets/shaders/opengl/ConvertUV.frag
@@ -31,5 +31,5 @@ void main() {
   u = u * range_uv.x + range_uv.y;
   v = v * range_uv.x + range_uv.y;
 
-  color = vec2(u, v * 224.0f / 256.0f + 0.0625);
+  color = vec2(u, v);
 }

--- a/src_assets/windows/assets/shaders/directx/ConvertUVPS.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ConvertUVPS.hlsl
@@ -29,5 +29,5 @@ float2 main_ps(FragTexWide input) : SV_Target
 	u = u * range_uv.x + range_uv.y;
 	v = v * range_uv.x + range_uv.y;
 
-	return float2(u, v * 224.0f/256.0f + 0.0625);
+	return float2(u, v);
 }

--- a/src_assets/windows/assets/shaders/directx/ConvertYPS.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ConvertYPS.hlsl
@@ -19,7 +19,7 @@ struct PS_INPUT
 float main_ps(PS_INPUT frag_in) : SV_Target
 {
 	float3 rgb = image.Sample(def_sampler, frag_in.tex, 0).rgb;
-	float y = dot(color_vec_y.xyz, rgb);
+	float y = dot(color_vec_y.xyz, rgb) + color_vec_y.w;
 
 	return y * range_y.x + range_y.y;
 }


### PR DESCRIPTION
## Description
This fixes color conversion errors with both limited and full range content and introduces BT.2020 support.

### Screenshot
Host and client titlebars perfectly blend together now when using the same accent color:
![image](https://user-images.githubusercontent.com/2695644/211167761-c1be2ade-d3a0-41d7-b19e-44eb90228f48.png)

### Issues Fixed or Closed
Fixes #300


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
