### PR TITLE
fix submodule names

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,44 +1,44 @@
-[submodule "moonlight-common-c"]
+[submodule "third-party/moonlight-common-c"]
 	path = third-party/moonlight-common-c
 	url = https://github.com/moonlight-stream/moonlight-common-c.git
 	branch = master
-[submodule "Simple-Web-Server"]
+[submodule "third-party/Simple-Web-Server"]
 	path = third-party/Simple-Web-Server
 	url = https://gitlab.com/eidheim/Simple-Web-Server.git
 	branch = master
-[submodule "ViGEmClient"]
+[submodule "third-party/ViGEmClient"]
 	path = third-party/ViGEmClient
 	url = https://github.com/ViGEm/ViGEmClient
 	branch = master
-[submodule "miniupnp"]
+[submodule "third-party/miniupnp"]
 	path = third-party/miniupnp
 	url = https://github.com/miniupnp/miniupnp
 	branch = master
-[submodule "nv-codec-headers"]
+[submodule "third-party/nv-codec-headers"]
 	path = third-party/nv-codec-headers
 	url = https://github.com/FFmpeg/nv-codec-headers
 	branch = sdk/11.1
-[submodule "TPCircularBuffer"]
+[submodule "third-party/TPCircularBuffer"]
 	path = third-party/TPCircularBuffer
 	url = https://github.com/michaeltyson/TPCircularBuffer
 	branch = master
-[submodule "ffmpeg-windows-x86_64"]
+[submodule "third-party/ffmpeg-windows-x86_64"]
 	path = third-party/ffmpeg-windows-x86_64
 	url = https://github.com/LizardByte/build-deps
 	branch = ffmpeg-windows-x86_64
-[submodule "ffmpeg-macos-x86_64"]
+[submodule "third-party/ffmpeg-macos-x86_64"]
 	path = third-party/ffmpeg-macos-x86_64
 	url = https://github.com/LizardByte/build-deps
 	branch = ffmpeg-macos-x86_64
-[submodule "ffmpeg-linux-x86_64"]
+[submodule "third-party/ffmpeg-linux-x86_64"]
 	path = third-party/ffmpeg-linux-x86_64
 	url = https://github.com/LizardByte/build-deps
 	branch = ffmpeg-linux-x86_64
-[submodule "ffmpeg-linux-aarch64"]
+[submodule "third-party/ffmpeg-linux-aarch64"]
 	path = third-party/ffmpeg-linux-aarch64
 	url = https://github.com/LizardByte/build-deps
 	branch = ffmpeg-linux-aarch64
-[submodule "ffmpeg-macos-aarch64"]
+[submodule "third-party/ffmpeg-macos-aarch64"]
 	path = third-party/ffmpeg-macos-aarch64
 	url = https://github.com/LizardByte/build-deps
 	branch = ffmpeg-macos-aarch64


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This should fix issues with initializing submodules. I have been unable to initialize submodules at all until I made this change.

Todo:

- [x] Requires a small update to the `build-deps` workflow step that creates the PR against Sunshine


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Resolves this error
```txt
$ git submodule sync; git submodule update --recursive
Synchronizing submodule url for 'third-party/Simple-Web-Server'
Synchronizing submodule url for 'third-party/TPCircularBuffer'
Synchronizing submodule url for 'third-party/ViGEmClient'
Synchronizing submodule url for 'third-party/ffmpeg-linux-aarch64'
Synchronizing submodule url for 'third-party/ffmpeg-linux-x86_64'
Synchronizing submodule url for 'third-party/ffmpeg-macos-aarch64'
Synchronizing submodule url for 'third-party/ffmpeg-macos-x86_64'
Synchronizing submodule url for 'third-party/ffmpeg-windows-x86_64'
Synchronizing submodule url for 'third-party/miniupnp'
Synchronizing submodule url for 'third-party/moonlight-common-c'
Synchronizing submodule url for 'third-party/nv-codec-headers'
fatal: not a git repository: C:/Users/ReenigneArcher/Documents/GitHub/LizardByte/Sunshine/third-party/TPCircularBuffer/../../.git/modules/TPCircularBuffer
Failed to clone 'third-party/TPCircularBuffer'. Retry scheduled
fatal: not a git repository: C:/Users/ReenigneArcher/Documents/GitHub/LizardByte/Sunshine/third-party/miniupnp/../../.git/modules/miniupnp
Failed to clone 'third-party/miniupnp'. Retry scheduled
fatal: not a git repository: C:/Users/ReenigneArcher/Documents/GitHub/LizardByte/Sunshine/third-party/nv-codec-headers/../../.git/modules/nv-codec-headers
Failed to clone 'third-party/nv-codec-headers'. Retry scheduled
BUG: submodule considered for cloning, doesn't need cloning any more?
Submodule path 'third-party/Simple-Web-Server': checked out '2f29926dbbcd8a0425064d98c24f37ac50bd0b5b'
fatal: could not get a repository handle for submodule 'third-party/TPCircularBuffer'
```


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
