### PR TITLE
Fix divisor for YUV range

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1972,11 +1972,11 @@ color_t make_color_matrix(float Cr, float Cb, const float2 &range_Y, const float
   float Cr_i = 1.0f - Cr;
   float Cb_i = 1.0f - Cb;
 
-  float shift_y  = range_Y[0] / 256.0f;
-  float shift_uv = range_UV[0] / 256.0f;
+  float shift_y  = range_Y[0] / 255.0f;
+  float shift_uv = range_UV[0] / 255.0f;
 
-  float scale_y  = (range_Y[1] - range_Y[0]) / 256.0f;
-  float scale_uv = (range_UV[1] - range_UV[0]) / 256.0f;
+  float scale_y  = (range_Y[1] - range_Y[0]) / 255.0f;
+  float scale_uv = (range_UV[1] - range_UV[0]) / 255.0f;
   return {
     { Cr, Cg, Cb, 0.0f },
     { -(Cr * 0.5f / Cb_i), -(Cg * 0.5f / Cb_i), 0.5f, 0.5f },


### PR DESCRIPTION
## Description
One final fix for the color conversion code. The divisor for the color ranges should be 255 because 1.0f corresponds to 255 not 256.


### Screenshot
Winver dialog gray is a perfect match now:
![image](https://user-images.githubusercontent.com/2695644/211180707-e374ca0d-d56f-4ae1-bc10-2a057d98d9d0.png)

The pink titlebar is within rounding error:
![image](https://user-images.githubusercontent.com/2695644/211180835-15734e95-c37b-4842-a2d5-2d17a715cd2b.png)

Conhost background is perfect:
![image](https://user-images.githubusercontent.com/2695644/211180911-e1e48701-0b0e-4683-89fd-4385fe5f9a66.png)


### Issues Fixed or Closed
Fixes #300 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
