### PR TITLE
revert windows build libpsl version lock

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -885,6 +885,7 @@ jobs:
             mingw-w64-x86_64-binutils
             mingw-w64-x86_64-boost
             mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-curl
             mingw-w64-x86_64-nsis
             mingw-w64-x86_64-openssl
             mingw-w64-x86_64-opus
@@ -892,18 +893,6 @@ jobs:
             nasm
             wget
             yasm
-
-      - name: pin libpsl
-        # libpsl is pinned until https://github.com/msys2/MINGW-packages/issues/14882 is resolved
-        # wget above is only necessary for this step
-        shell: msys2 {0}
-        run: |
-          # manually download and install libpsl
-          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-libpsl-0.21.1-4-any.pkg.tar.zst
-          pacman --noconfirm -U mingw-w64-x86_64-libpsl-0.21.1-4-any.pkg.tar.zst
-
-          # install curl
-          pacman --noconfirm -S mingw-w64-x86_64-curl
 
       - name: Install npm packages
         run: |


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Revert (#669) locking the libpsl version on Windows builds.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
