### PR TITLE
CMake: win32: fix API version, disable boost-cmake detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ pkg_check_modules (CURL REQUIRED libcurl)
 if(NOT APPLE)
     set(Boost_USE_STATIC_LIBS ON)  # cmake-lint: disable=C0103
 endif()
+if(WIN32)
+    # workaround to prevent link errors against icudata, icui18n
+    set(Boost_NO_BOOST_CMAKE ON) # cmake-lint: disable=C0103
+endif()
+
 find_package(Boost COMPONENTS log filesystem program_options REQUIRED)
 
 list(APPEND SUNSHINE_COMPILE_OPTIONS -Wall -Wno-missing-braces -Wno-maybe-uninitialized -Wno-sign-compare)
@@ -78,10 +83,6 @@ if(WIN32)
     set(CMAKE_RC_COMPILER windres)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CURL_STATIC_LDFLAGS} ${CURL_STATIC_CFLAGS}")
-
-    # WORKAROUND: /mingw64/include/_mingw.h r186 defines _WIN32_WINNT=0x601, but boost
-    #             is built against version 0x603 (BOOST_WINAPI_VERSION_WINBLUE) from r157 header.
-    ADD_DEFINITIONS(-DBOOST_USE_WINAPI_VERSION=BOOST_WINAPI_VERSION_WINBLUE)
 
     add_compile_definitions(SUNSHINE_PLATFORM="windows")
     add_subdirectory(tools)  # This is temporary, only tools for Windows are needed, for now


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

* Disable boost-cmake detection, as current cmake files in mingw reference non-existent libraries (icudata, icui18n)
* Remove WinAPI workaround (Boost is now built against latest mingw headers)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
