### PR TITLE
Fix a reference leak of hw_frames_ctx and prepare for QSV

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -17,6 +17,8 @@
 
 struct sockaddr;
 struct AVFrame;
+struct AVBufferRef;
+struct AVHWFramesContext;
 
 // Forward declarations of boost classes to avoid having to include boost headers
 // here, which results in issues with Windows.h and WinSock2.h include order.
@@ -196,12 +198,17 @@ struct hwdevice_t {
   /**
    * implementations must take ownership of 'frame'
    */
-  virtual int set_frame(AVFrame *frame) {
+  virtual int set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) {
     BOOST_LOG(error) << "Illegal call to hwdevice_t::set_frame(). Did you forget to override it?";
     return -1;
   };
 
   virtual void set_colorspace(std::uint32_t colorspace, std::uint32_t color_range) {};
+
+  /**
+   * Implementations may set parameters during initialization of the hwframes context
+   */
+  virtual void init_hwframes(AVHWFramesContext *frames) {};
 
   virtual ~hwdevice_t() = default;
 };

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -313,14 +313,15 @@ public:
     return 0;
   }
 
-  int set_frame(AVFrame *frame) override {
+  int set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) override {
     this->hwframe.reset(frame);
     this->frame = frame;
 
-    if(av_hwframe_get_buffer(frame->hw_frames_ctx, frame, 0)) {
-      BOOST_LOG(error) << "Couldn't get hwframe for VAAPI"sv;
-
-      return -1;
+    if(!frame->buf[0]) {
+      if(av_hwframe_get_buffer(hw_frames_ctx, frame, 0)) {
+        BOOST_LOG(error) << "Couldn't get hwframe for VAAPI"sv;
+        return -1;
+      }
     }
 
     va::DRMPRIMESurfaceDescriptor prime;

--- a/src/platform/macos/nv12_zero_device.cpp
+++ b/src/platform/macos/nv12_zero_device.cpp
@@ -53,7 +53,7 @@ int nv12_zero_device::convert(platf::img_t &img) {
   return result > 0 ? 0 : -1;
 }
 
-int nv12_zero_device::set_frame(AVFrame *frame) {
+int nv12_zero_device::set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) {
   this->frame = frame;
 
   av_frame.reset(frame);

--- a/src/platform/macos/nv12_zero_device.h
+++ b/src/platform/macos/nv12_zero_device.h
@@ -20,7 +20,7 @@ public:
   int init(void *display, resolution_fn_t resolution_fn, pixel_format_fn_t pixel_format_fn);
 
   int convert(img_t &img);
-  int set_frame(AVFrame *frame);
+  int set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx);
   void set_colorspace(std::uint32_t colorspace, std::uint32_t color_range);
 };
 


### PR DESCRIPTION
## Description
This is some plumbing work required for QuickSync. During the QuickSync work, I discovered a reference leak caused by `av_hwframe_get_buffer()` clobbering the reference that we already stored there in `frame->hw_frames_ctx`. To avoid this, we need to pass the `hw_frames_ctx` pointer into `set_frame()` rather than set it in the frame itself.

Since QuickSync will need a fixed size frame pool, I changed `display_vram_t` to use `av_hwframe_get_buffer()` rather than allocating a texture itself.

No behavior changes expected (other than fixing the reference leak with CUDA and VAAPI on Linux).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
