### PR TITLE
CMake: Windows: harden install by including zlib1.dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,8 @@ add_executable(sunshine ${SUNSHINE_TARGET_FILES})
 
 if(WIN32)
     set_target_properties(sunshine PROPERTIES LINK_SEARCH_START_STATIC 1)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+    find_library(ZLIB ZLIB1)
 endif()
 
 target_link_libraries(sunshine ${SUNSHINE_EXTERNAL_LIBRARIES} ${EXTRA_LIBS})
@@ -520,6 +522,9 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/node_modules"
 # Platform specific options
 if(WIN32) # see options at: https://cmake.org/cmake/help/latest/cpack_gen/nsis.html
     install(TARGETS sunshine RUNTIME DESTINATION "." COMPONENT application)
+
+    # Hardening: include zlib1.dll (loaded via LoadLibrary() in openssl's libcrypto.a)
+    install(FILES "${ZLIB}" DESTINATION "." COMPONENT application)
 
     # Adding tools
     install(TARGETS dxgi-info RUNTIME DESTINATION "tools" COMPONENT dxgi)


### PR DESCRIPTION
## Description

mingw's openssl library is built using the "zlib-dynamic" flag, which invokes LoadLibrary() of zlib1.dll during runtime to allow openssl to function if no zlib.dll is installed.

This is a problem because it prevents static linkage of zlib, thus opening a security vulnerability by which a malicious zlib1.dll can be loaded from any valid system dll search path.

Increase security by including the mingw version of zlib1.dll in the application path, which will override any other versions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
