### PR TITLE
Move the check for UPnP enabled up to avoid error messages

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -91,6 +91,10 @@ static std::string_view status_string(int status) {
 }
 
 std::unique_ptr<platf::deinit_t> start() {
+  if(!config::sunshine.flags[config::flag::UPNP]) {
+    return nullptr;
+  }
+
   int err {};
 
   device_t device { upnpDiscover(2000, nullptr, nullptr, 0, IPv4, 2, &err) };
@@ -126,10 +130,6 @@ std::unique_ptr<platf::deinit_t> start() {
     if(config::nvhttp.external_ip.empty()) {
       config::nvhttp.external_ip = wan_addr.data();
     }
-  }
-
-  if(!config::sunshine.flags[config::flag::UPNP]) {
-    return nullptr;
   }
 
   auto rtsp     = std::to_string(map_port(stream::RTSP_SETUP_PORT));


### PR DESCRIPTION
## Description
This PR moves the check for the UPnP enable flag up to the top of the `start` function.
This way if someone disables UPnP it is truly disabled and does not try to find any UPnP device to begin with.


### Issues Fixed or Closed
(No issue was made for this)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
