### PR TITLE
macOS gamepad support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,6 +652,7 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
 endif()
 
 if(APPLE)
+    target_link_libraries(sunshine "-framework IOKit")
     target_link_options(sunshine PRIVATE LINKER:-sectcreate,__TEXT,__info_plist,${APPLE_PLIST_FILE})
     # Tell linker to dynamically load these symbols at runtime, in case they're unavailable:
     target_link_options(sunshine PRIVATE -Wl,-U,_CGPreflightScreenCaptureAccess -Wl,-U,_CGRequestScreenCaptureAccess)

--- a/docs/source/about/installation.rst
+++ b/docs/source/about/installation.rst
@@ -188,8 +188,6 @@ Uninstall:
 
 macOS
 -----
-Sunshine on macOS is experimental. Other features may not work as expected.
-
 pkg
 ^^^
 .. Warning:: The `pkg` does not include runtime dependencies.

--- a/docs/source/about/installation.rst
+++ b/docs/source/about/installation.rst
@@ -188,6 +188,7 @@ Uninstall:
 
 macOS
 -----
+
 pkg
 ^^^
 .. Warning:: The `pkg` does not include runtime dependencies.

--- a/docs/source/about/installation.rst
+++ b/docs/source/about/installation.rst
@@ -188,7 +188,7 @@ Uninstall:
 
 macOS
 -----
-Sunshine on macOS is experimental. Gamepads do not work. Other features may not work as expected.
+Sunshine on macOS is experimental. Other features may not work as expected.
 
 pkg
 ^^^

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -152,8 +152,6 @@ Sunshine can only access microphones on macOS due to system limitations. To stre
 
 .. Note:: Command Keys are not forwarded by Moonlight. Right Option-Key is mapped to CMD-Key.
 
-.. Caution:: Gamepads are not currently supported.
-
 Configure autostart service
    **MacPorts**
       .. code-block:: bash

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -144,6 +144,8 @@ Sunshine needs access to `uinput` to create mouse and gamepad events.
 
 macOS
 ^^^^^
+For gamepad support, install `VirtualHID <https://github.com/kotleni/VirtualHID-macOS/releases/latest>`_
+
 Sunshine can only access microphones on macOS due to system limitations. To stream system audio use
 `Soundflower <https://github.com/mattingalls/Soundflower>`_ or
 `BlackHole <https://github.com/ExistentialAudio/BlackHole>`_.

--- a/docs/source/troubleshooting/macos.rst
+++ b/docs/source/troubleshooting/macos.rst
@@ -7,10 +7,10 @@ If you get this error:
     `Dynamic session lookup supported but failed: launchd did not provide a socket path, verify that
     org.freedesktop.dbus-session.plist is loaded!`
 
-Try this.
-    .. code-block:: bash
+   Try this.
+      .. code-block:: bash
 
-    launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
+         launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
 
 No gamepad detected
 -------------------

--- a/docs/source/troubleshooting/macos.rst
+++ b/docs/source/troubleshooting/macos.rst
@@ -19,6 +19,6 @@ No gamepad detected
 Unable to create HID device
 ---------------------------
 If you get this error:
-   `Gamepad: Unable to create HID device. May be fine if created previously.`
+    `Gamepad: Unable to create HID device. May be fine if created previously.`
 
    It's okay. It's just a warning.

--- a/docs/source/troubleshooting/macos.rst
+++ b/docs/source/troubleshooting/macos.rst
@@ -7,10 +7,10 @@ If you get this error:
     `Dynamic session lookup supported but failed: launchd did not provide a socket path, verify that
     org.freedesktop.dbus-session.plist is loaded!`
 
-   Try this.
-      .. code-block:: bash
+Try this.
+    .. code-block:: bash
 
-         launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
+    launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
 
 No gamepad detected
 -------------------

--- a/docs/source/troubleshooting/macos.rst
+++ b/docs/source/troubleshooting/macos.rst
@@ -11,3 +11,14 @@ If you get this error:
       .. code-block:: bash
 
          launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
+
+No gamepad detected
+-------------------
+#. Verify that you've installed `VirtualHID <https://github.com/kotleni/VirtualHID-macOS/releases/latest>`_.
+
+Unable to create HID device
+---------------------------
+If you get this error:
+   `Gamepad: Unable to create HID device. May be fine if created previously.`
+
+   It's okay. It's just a warning.

--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -63,3 +63,4 @@ notes-append "Run @PROJECT_NAME@ by executing 'sunshine <path to user config>', 
 notes-append "The config file will be created if it doesn't exist."
 notes-append "It is recommended to set a location for the apps file in the config."
 notes-append "See our documentation at 'https://docs.lizardbyte.dev/projects/sunshine/en/v@PROJECT_VERSION@/' for further info."
+notes-append "For gamepad support, install VirtualHID from 'https://github.com/kotleni/VirtualHID-macOS/releases/latest'

--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -62,5 +62,5 @@ pre-build {
 notes-append "Run @PROJECT_NAME@ by executing 'sunshine <path to user config>', e.g. 'sunshine ~/sunshine.conf' "
 notes-append "The config file will be created if it doesn't exist."
 notes-append "It is recommended to set a location for the apps file in the config."
+notes-append "For gamepad support, install VirtualHID from 'https://github.com/kotleni/VirtualHID-macOS/releases/latest'."
 notes-append "See our documentation at 'https://docs.lizardbyte.dev/projects/sunshine/en/v@PROJECT_VERSION@/' for further info."
-notes-append "For gamepad support, install VirtualHID from 'https://github.com/kotleni/VirtualHID-macOS/releases/latest'

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -15,7 +15,7 @@
 #define MULTICLICK_DELAY_NS 500000000
 
 // For gamepad emulation
-// https://github.com/kotleni/virthid-macos
+// https://github.com/kotleni/VirtualHID-macOS
 #define VIRTGAMEPAD_NAME "Sunshine Gamepad"
 #define VIRTGAMEPAD_SN "SG 0001"            // serial number
 #define SERVICE_NAME "it_kotleni_virthid"   // virthid service id

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -31,6 +31,8 @@
 #define GAMEPAD_BTN_Y (1 << 3)
 #define GAMEPAD_BTN_L (1 << 4)
 #define GAMEPAD_BTN_R (1 << 5)
+#define GAMEPAD_BTN_LT (1 << 6)
+#define GAMEPAD_BTN_RT (1 << 7)
 #define GAMEPAD_BTN_BACK (1 << 8)
 #define GAMEPAD_BTN_START (1 << 9)
 #define GAMEPAD_BTN_LS (1 << 10)
@@ -443,13 +445,15 @@ void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
   if(flags & DPAD_LEFT) gamepad.buttons |= GAMEPAD_BTN_LEFT;
   if(flags & DPAD_RIGHT) gamepad.buttons |= GAMEPAD_BTN_RIGHT;
 
+  // Map triggers
+  if(gamepad_state.lt > 0) gamepad.buttons |= GAMEPAD_BTN_LT;
+  if(gamepad_state.rt > 0) gamepad.buttons |= GAMEPAD_BTN_RT;
+
   // Map sticks
   gamepad.x  = gamepad_state.lsX;
   gamepad.y  = -gamepad_state.lsY;
   gamepad.rx = gamepad_state.rsX;
   gamepad.ry = -gamepad_state.rsY;
-  gamepad.z  = gamepad_state.lt;
-  gamepad.rz = gamepad_state.rt;
 
   kern_return_t ret = IOConnectCallScalarMethod(virtgamepad_connect, FOOHID_SEND, send, send_count, NULL, 0);
   if(ret != KERN_SUCCESS) {

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -16,77 +16,77 @@
 
 // For gamepad emulation
 // https://github.com/kotleni/VirtualHID-macOS
-#define VIRTGAMEPAD_NAME        "Sunshine Gamepad"
-#define VIRTGAMEPAD_SN          "SG 0001"             // serial number
-#define VIRTGAMEPAD_INPUT_COUNT 16                    // gamepad buttons count
-#define SERVICE_NAME            "it_kotleni_virthid"  // virthid service id
-#define FOOHID_CREATE           0                     // create selector
-#define FOOHID_SEND             2                     // send selector
+#define VIRTGAMEPAD_NAME "Sunshine Gamepad"
+#define VIRTGAMEPAD_SN "SG 0001"          // serial number
+#define VIRTGAMEPAD_INPUT_COUNT 16        // gamepad buttons count
+#define SERVICE_NAME "it_kotleni_virthid" // virthid service id
+#define FOOHID_CREATE 0                   // create selector
+#define FOOHID_SEND 2                     // send selector
 
 // Gamepad buttons
 #define GAMEPAD_ZEROBTNS  0
-#define GAMEPAD_BTN_A     (1 << 0)
-#define GAMEPAD_BTN_B     (1 << 1)
-#define GAMEPAD_BTN_X     (1 << 2)
-#define GAMEPAD_BTN_Y     (1 << 3)
-#define GAMEPAD_BTN_L     (1 << 4)
-#define GAMEPAD_BTN_R     (1 << 5)
-#define GAMEPAD_BTN_LT    (1 << 6)
-#define GAMEPAD_BTN_RT    (1 << 7)
-#define GAMEPAD_BTN_BACK  (1 << 8)
+#define GAMEPAD_BTN_A (1 << 0)
+#define GAMEPAD_BTN_B (1 << 1)
+#define GAMEPAD_BTN_X (1 << 2)
+#define GAMEPAD_BTN_Y (1 << 3)
+#define GAMEPAD_BTN_L (1 << 4)
+#define GAMEPAD_BTN_R (1 << 5)
+#define GAMEPAD_BTN_LT (1 << 6)
+#define GAMEPAD_BTN_RT (1 << 7)
+#define GAMEPAD_BTN_BACK (1 << 8)
 #define GAMEPAD_BTN_START (1 << 9)
-#define GAMEPAD_BTN_LS    (1 << 10)
-#define GAMEPAD_BTN_RS    (1 << 11)
-#define GAMEPAD_BTN_UP    (1 << 12)
-#define GAMEPAD_BTN_DOWN  (1 << 13)
-#define GAMEPAD_BTN_LEFT  (1 << 14)
+#define GAMEPAD_BTN_LS (1 << 10)
+#define GAMEPAD_BTN_RS (1 << 11)
+#define GAMEPAD_BTN_UP (1 << 12)
+#define GAMEPAD_BTN_DOWN (1 << 13)
+#define GAMEPAD_BTN_LEFT (1 << 14)
 #define GAMEPAD_BTN_RIGHT (1 << 15)
 
 // http://eleccelerator.com/tutorial-about-usb-hid-report-descriptors/
 // Used HIDTool to generate the data
 unsigned char gamepad_report_descriptor[] = {
-    0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
-    0x09, 0x05,                    // USAGE (Game Pad)
-    0xa1, 0x01,                    // COLLECTION (Application)
-    0xa1, 0x00,                    //   COLLECTION (Physical)
-    0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
-    0x09, 0x30,                    //     USAGE (X)
-    0x09, 0x31,                    //     USAGE (Y)
-    0x09, 0x33,                    //     USAGE (Rx)
-    0x09, 0x34,                    //     USAGE (Ry)
-    0x16, 0x00, 0x80,              //     LOGICAL_MINIMUM (-32768)
-    0x26, 0xff, 0x7f,              //     LOGICAL_MAXIMUM (32767)
-    0x75, 0x10,                    //     REPORT_SIZE (16)
-    0x95, 0x04,                    //     REPORT_COUNT (4)
-    0x81, 0x02,                    //     INPUT (Data,Var,Abs)
-    0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
-    0x09, 0x32,                    //     USAGE (Z)
-    0x09, 0x35,                    //     USAGE (Rz)
-    0x15, 0x00,                    //     LOGICAL_MINIMUM (0)
-    0x46, 0xff, 0x00,              //     PHYSICAL_MAXIMUM (255)
-    0x75, 0x08,                    //     REPORT_SIZE (8)
-    0x95, 0x02,                    //     REPORT_COUNT (2)
-    0x81, 0x02,                    //     INPUT (Data,Var,Abs)
-    0x05, 0x09,                    //     USAGE_PAGE (Button)
-    0x19, 0x01,                    //     USAGE_MINIMUM (Button 1)
-    0x29, 0x10,                    //     USAGE_MAXIMUM (Button 16)
-    0x15, 0x00,                    //     LOGICAL_MINIMUM (0)
-    0x25, 0x01,                    //     LOGICAL_MAXIMUM (1)
-    0x75, 0x01,                    //     REPORT_SIZE (1)
-    0x95, 0x10,                    //     REPORT_COUNT (16)
-    0x81, 0x02,                    //     INPUT (Data,Var,Abs)
-    0xc0,                          //     END_COLLECTION
-    0xc0                           // END_COLLECTION
+  0x05, 0x01,       // USAGE_PAGE (Generic Desktop)
+  0x09, 0x05,       // USAGE (Game Pad)
+  0xa1, 0x01,       // COLLECTION (Application)
+  0xa1, 0x00,       //   COLLECTION (Physical)
+  0x05, 0x01,       //     USAGE_PAGE (Generic Desktop)
+  0x09, 0x30,       //     USAGE (X)
+  0x09, 0x31,       //     USAGE (Y)
+  0x09, 0x33,       //     USAGE (Rx)
+  0x09, 0x34,       //     USAGE (Ry)
+  0x16, 0x00, 0x80, //     LOGICAL_MINIMUM (-32768)
+  0x26, 0xff, 0x7f, //     LOGICAL_MAXIMUM (32767)
+  0x75, 0x10,       //     REPORT_SIZE (16)
+  0x95, 0x04,       //     REPORT_COUNT (4)
+  0x81, 0x02,       //     INPUT (Data,Var,Abs)
+  0x05, 0x01,       //     USAGE_PAGE (Generic Desktop)
+  0x09, 0x32,       //     USAGE (Z)
+  0x09, 0x35,       //     USAGE (Rz)
+  0x15, 0x00,       //     LOGICAL_MINIMUM (0)
+  0x46, 0xff, 0x00, //     PHYSICAL_MAXIMUM (255)
+  0x75, 0x08,       //     REPORT_SIZE (8)
+  0x95, 0x02,       //     REPORT_COUNT (2)
+  0x81, 0x02,       //     INPUT (Data,Var,Abs)
+  0x05, 0x09,       //     USAGE_PAGE (Button)
+  0x19, 0x01,       //     USAGE_MINIMUM (Button 1)
+  0x29, 0x10,       //     USAGE_MAXIMUM (Button 16)
+  0x15, 0x00,       //     LOGICAL_MINIMUM (0)
+  0x25, 0x01,       //     LOGICAL_MAXIMUM (1)
+  0x75, 0x01,       //     REPORT_SIZE (1)
+  0x95, 0x10,       //     REPORT_COUNT (16)
+  0x81, 0x02,       //     INPUT (Data,Var,Abs)
+  0xc0,             //     END_COLLECTION
+  0xc0              // END_COLLECTION
 };
 
 struct gamepad_report_t {
-    int16_t x;
-    int16_t y;
-    int16_t rx;
-    int16_t ry;
-    uint8_t z;
-    uint8_t rz;
-    uint16_t buttons;
+  int16_t x;
+  int16_t y;
+  int16_t rx;
+  int16_t ry;
+  uint8_t z;
+  uint8_t rz;
+  uint16_t buttons;
 };
 
 io_iterator_t virtgamepad_iterator;
@@ -369,23 +369,23 @@ int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue) {
   // Get a reference to the IOService
   kern_return_t ret = IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching(SERVICE_NAME), &virtgamepad_iterator);
 
-  if (ret != KERN_SUCCESS) {
+  if(ret != KERN_SUCCESS) {
     BOOST_LOG(info) << "Gamepad: Unable to access IOService."sv;
     return 1;
   }
 
   // Iterate till success
   int found = 0;
-  while ((virtgamepad_service = IOIteratorNext(virtgamepad_iterator)) != IO_OBJECT_NULL) {
+  while((virtgamepad_service = IOIteratorNext(virtgamepad_iterator)) != IO_OBJECT_NULL) {
     ret = IOServiceOpen(virtgamepad_service, mach_task_self(), 0, &virtgamepad_connect);
-    if (ret == KERN_SUCCESS) {
+    if(ret == KERN_SUCCESS) {
       found = 1;
       break;
     }
 
     IOObjectRelease(virtgamepad_service);
   }
-    
+
   IOObjectRelease(virtgamepad_iterator);
 
   if(!found) {
@@ -394,17 +394,17 @@ int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue) {
   }
 
   // Fill up the input arguments.
-  virtgamepad_input[0] = (uint64_t) strdup(VIRTGAMEPAD_NAME);  // device name
-  virtgamepad_input[1] = strlen((char *)virtgamepad_input[0]);  // name length
-  virtgamepad_input[2] = (uint64_t) gamepad_report_descriptor;  // report descriptor
-  virtgamepad_input[3] = sizeof(gamepad_report_descriptor);  // report descriptor len
-  virtgamepad_input[4] = (uint64_t) strdup(VIRTGAMEPAD_SN);  // serial number
-  virtgamepad_input[5] = strlen((char *)virtgamepad_input[4]);  // serial number len
-  virtgamepad_input[6] = (uint64_t) 0xdead;  // vendor ID
-  virtgamepad_input[7] = (uint64_t) 0xbeef;  // device ID
+  virtgamepad_input[0] = (uint64_t)strdup(VIRTGAMEPAD_NAME);   // device name
+  virtgamepad_input[1] = strlen((char *)virtgamepad_input[0]); // name length
+  virtgamepad_input[2] = (uint64_t)gamepad_report_descriptor;  // report descriptor
+  virtgamepad_input[3] = sizeof(gamepad_report_descriptor);    // report descriptor len
+  virtgamepad_input[4] = (uint64_t)strdup(VIRTGAMEPAD_SN);     // serial number
+  virtgamepad_input[5] = strlen((char *)virtgamepad_input[4]); // serial number len
+  virtgamepad_input[6] = (uint64_t)0xdead;                     // vendor ID
+  virtgamepad_input[7] = (uint64_t)0xbeef;                     // device ID
 
   ret = IOConnectCallScalarMethod(virtgamepad_connect, FOOHID_CREATE, virtgamepad_input, VIRTGAMEPAD_INPUT_COUNT, NULL, 0);
-  if (ret != KERN_SUCCESS) {
+  if(ret != KERN_SUCCESS) {
     BOOST_LOG(info) << "Gamepad: Unable to create HID device. May be fine if created previously."sv;
   }
   return 0;
@@ -421,7 +421,7 @@ void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
   uint64_t send[send_count];
   send[0] = (uint64_t)virtgamepad_input[0];         // device name
   send[1] = strlen((char *)virtgamepad_input[0]);   // name length
-  send[2] = (uint64_t) &gamepad;                    // mouse struct
+  send[2] = (uint64_t)&gamepad;                     // mouse struct
   send[3] = sizeof(struct gamepad_report_t);        // mouse struct len
 
   auto flags = gamepad_state.buttonFlags;
@@ -430,28 +430,28 @@ void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
   gamepad.buttons = GAMEPAD_ZEROBTNS;
 
   // Map buttons
-  if(flags & LEFT_STICK)   gamepad.buttons |= GAMEPAD_BTN_LS;
-  if(flags & RIGHT_STICK)  gamepad.buttons |= GAMEPAD_BTN_RS;
-  if(flags & LEFT_BUTTON)  gamepad.buttons |= GAMEPAD_BTN_L;
+  if(flags & LEFT_STICK) gamepad.buttons |= GAMEPAD_BTN_LS;
+  if(flags & RIGHT_STICK) gamepad.buttons |= GAMEPAD_BTN_RS;
+  if(flags & LEFT_BUTTON) gamepad.buttons |= GAMEPAD_BTN_L;
   if(flags & RIGHT_BUTTON) gamepad.buttons |= GAMEPAD_BTN_R;
-  if(flags & START)        gamepad.buttons |= GAMEPAD_BTN_START;
-  if(flags & BACK)         gamepad.buttons |= GAMEPAD_BTN_BACK;
-  if(flags & A)            gamepad.buttons |= GAMEPAD_BTN_A;
-  if(flags & B)            gamepad.buttons |= GAMEPAD_BTN_B;
-  if(flags & X)            gamepad.buttons |= GAMEPAD_BTN_X;
-  if(flags & Y)            gamepad.buttons |= GAMEPAD_BTN_Y;
-  if(flags & DPAD_UP)      gamepad.buttons |= GAMEPAD_BTN_UP;
-  if(flags & DPAD_DOWN)    gamepad.buttons |= GAMEPAD_BTN_DOWN;
-  if(flags & DPAD_LEFT)    gamepad.buttons |= GAMEPAD_BTN_LEFT;
-  if(flags & DPAD_RIGHT)   gamepad.buttons |= GAMEPAD_BTN_RIGHT;
+  if(flags & START) gamepad.buttons |= GAMEPAD_BTN_START;
+  if(flags & BACK) gamepad.buttons |= GAMEPAD_BTN_BACK;
+  if(flags & A) gamepad.buttons |= GAMEPAD_BTN_A;
+  if(flags & B) gamepad.buttons |= GAMEPAD_BTN_B;
+  if(flags & X) gamepad.buttons |= GAMEPAD_BTN_X;
+  if(flags & Y) gamepad.buttons |= GAMEPAD_BTN_Y;
+  if(flags & DPAD_UP) gamepad.buttons |= GAMEPAD_BTN_UP;
+  if(flags & DPAD_DOWN) gamepad.buttons |= GAMEPAD_BTN_DOWN;
+  if(flags & DPAD_LEFT) gamepad.buttons |= GAMEPAD_BTN_LEFT;
+  if(flags & DPAD_RIGHT) gamepad.buttons |= GAMEPAD_BTN_RIGHT;
 
   // Map triggers
   if(gamepad_state.lt > 0) gamepad.buttons |= GAMEPAD_BTN_LT;
   if(gamepad_state.rt > 0) gamepad.buttons |= GAMEPAD_BTN_RT;
 
   // Map sticks
-  gamepad.x = gamepad_state.lsX;
-  gamepad.y = -gamepad_state.lsY;
+  gamepad.x  = gamepad_state.lsX;
+  gamepad.y  = -gamepad_state.lsY;
   gamepad.rx = gamepad_state.rsX;
   gamepad.ry = -gamepad_state.rsY;
 

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -31,8 +31,6 @@
 #define GAMEPAD_BTN_Y (1 << 3)
 #define GAMEPAD_BTN_L (1 << 4)
 #define GAMEPAD_BTN_R (1 << 5)
-#define GAMEPAD_BTN_LT (1 << 6)
-#define GAMEPAD_BTN_RT (1 << 7)
 #define GAMEPAD_BTN_BACK (1 << 8)
 #define GAMEPAD_BTN_START (1 << 9)
 #define GAMEPAD_BTN_LS (1 << 10)
@@ -445,15 +443,13 @@ void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
   if(flags & DPAD_LEFT) gamepad.buttons |= GAMEPAD_BTN_LEFT;
   if(flags & DPAD_RIGHT) gamepad.buttons |= GAMEPAD_BTN_RIGHT;
 
-  // Map triggers
-  if(gamepad_state.lt > 0) gamepad.buttons |= GAMEPAD_BTN_LT;
-  if(gamepad_state.rt > 0) gamepad.buttons |= GAMEPAD_BTN_RT;
-
   // Map sticks
   gamepad.x  = gamepad_state.lsX;
   gamepad.y  = -gamepad_state.lsY;
   gamepad.rx = gamepad_state.rsX;
   gamepad.ry = -gamepad_state.rsY;
+  gamepad.z  = gamepad_state.lt;
+  gamepad.rz = gamepad_state.rt;
 
   kern_return_t ret = IOConnectCallScalarMethod(virtgamepad_connect, FOOHID_SEND, send, send_count, NULL, 0);
   if(ret != KERN_SUCCESS) {

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -15,11 +15,11 @@
 #define MULTICLICK_DELAY_NS 500000000
 
 // For gamepad emulation
-// https://github.com/kotleni/VirtualHID-macOS
-#define VIRTGAMEPAD_NAME "Sunshine Gamepad"
-#define VIRTGAMEPAD_SN "SG 0001"          // serial number
-#define VIRTGAMEPAD_INPUT_COUNT 16        // gamepad buttons count
-#define SERVICE_NAME "it_kotleni_virthid" // virthid service id
+// https://github.com/kotleni/foohid
+#define VIRTGAMEPAD_NAME "DualShock 4"    // gamepad name (only device names supported by macos)
+#define VIRTGAMEPAD_SN "CUH-ZCT1x"        // serial number
+#define VIRTGAMEPAD_INPUT_COUNT 8         // device arguments count
+#define SERVICE_NAME "it_unbit_foohid"    // virthid service id
 #define FOOHID_CREATE 0                   // create selector
 #define FOOHID_SEND 2                     // send selector
 
@@ -400,8 +400,8 @@ int alloc_gamepad(input_t &input, int nr, rumble_queue_t rumble_queue) {
   virtgamepad_input[3] = sizeof(gamepad_report_descriptor);    // report descriptor len
   virtgamepad_input[4] = (uint64_t)strdup(VIRTGAMEPAD_SN);     // serial number
   virtgamepad_input[5] = strlen((char *)virtgamepad_input[4]); // serial number len
-  virtgamepad_input[6] = (uint64_t)0xdead;                     // vendor ID
-  virtgamepad_input[7] = (uint64_t)0xbeef;                     // device ID
+  virtgamepad_input[6] = (uint64_t)0x054c;                     // vendor ID
+  virtgamepad_input[7] = (uint64_t)0x05c4;                     // device ID
 
   ret = IOConnectCallScalarMethod(virtgamepad_connect, FOOHID_CREATE, virtgamepad_input, VIRTGAMEPAD_INPUT_COUNT, NULL, 0);
   if(ret != KERN_SUCCESS) {

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -16,7 +16,7 @@
 
 // For gamepad emulation
 // https://github.com/kotleni/foohid
-#define VIRTGAMEPAD_NAME "DualShock 4"    // gamepad name (only device names supported by macos)
+#define VIRTGAMEPAD_NAME "DualShock 4"    // gamepad name
 #define VIRTGAMEPAD_SN "CUH-ZCT1x"        // serial number
 #define VIRTGAMEPAD_INPUT_COUNT 8         // device arguments count
 #define SERVICE_NAME "it_unbit_foohid"    // virthid service id

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -24,7 +24,7 @@
 #define FOOHID_SEND 2                     // send selector
 
 // Gamepad buttons
-#define GAMEPAD_ZEROBTNS  0
+#define GAMEPAD_ZEROBTNS 0
 #define GAMEPAD_BTN_A (1 << 0)
 #define GAMEPAD_BTN_B (1 << 1)
 #define GAMEPAD_BTN_X (1 << 2)
@@ -419,10 +419,10 @@ void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state) {
   struct gamepad_report_t gamepad;
   uint32_t send_count = 4;
   uint64_t send[send_count];
-  send[0] = (uint64_t)virtgamepad_input[0];         // device name
-  send[1] = strlen((char *)virtgamepad_input[0]);   // name length
-  send[2] = (uint64_t)&gamepad;                     // mouse struct
-  send[3] = sizeof(struct gamepad_report_t);        // mouse struct len
+  send[0] = (uint64_t)virtgamepad_input[0];       // device name
+  send[1] = strlen((char *)virtgamepad_input[0]); // name length
+  send[2] = (uint64_t)&gamepad;                   // mouse struct
+  send[3] = sizeof(struct gamepad_report_t);      // mouse struct len
 
   auto flags = gamepad_state.buttonFlags;
 


### PR DESCRIPTION
## Description
Implemented gamepad support on macOS. This works with my  <a href="https://github.com/kotleni/VirtualHID-macOS">driver for virtual HID devices</a> (you can copy this repository for yourself, the code is not licensed). Vibration not supported. I also added the IOKit dependency (shipped with Xcode).

_Sunshine host tested on Macbook Air M1 (2020).
Tested on two clients (Moonlight-nx (Nintendo Switch), and Moonlight (iOS))._

### Screenshot
![](https://user-images.githubusercontent.com/38311102/211872734-407b4c49-9059-4d95-bb49-b52229eda738.png)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
