### PR TITLE
Avoid redundant padding fills in display_vram_t::convert()

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -300,8 +300,7 @@ blob_t compile_vertex_shader(LPCSTR file) {
 class hwdevice_t : public platf::hwdevice_t {
 public:
   int convert(platf::img_t &img_base) override {
-    auto &img         = (img_d3d_t &)img_base;
-    auto back_d3d_img = (img_d3d_t *)back_img.get();
+    auto &img = (img_d3d_t &)img_base;
 
     // Open the shared capture texture with our ID3D11Device
     if(share_img(&img_base)) {
@@ -315,24 +314,9 @@ public:
       return -1;
     }
 
-    // Even though this image will never have racing updates, we must acquire the
-    // keyed mutex for PSSetShaderResources() to succeed.
-    status = back_d3d_img->encoder_mutex->AcquireSync(0, INFINITE);
-    if(status != S_OK) {
-      img.encoder_mutex->ReleaseSync(0);
-      BOOST_LOG(error) << "Failed to acquire back_d3d_img mutex [0x"sv << util::hex(status).to_string_view() << ']';
-      return -1;
-    }
-
-    device_ctx->IASetInputLayout(input_layout.get());
-
-    _init_view_port(this->img.width, this->img.height);
     device_ctx->OMSetRenderTargets(1, &nv12_Y_rt, nullptr);
     device_ctx->VSSetShader(scene_vs.get(), nullptr, 0);
     device_ctx->PSSetShader(convert_Y_ps.get(), nullptr, 0);
-    device_ctx->PSSetShaderResources(0, 1, &back_d3d_img->encoder_input_res);
-    device_ctx->Draw(3, 0);
-
     device_ctx->RSSetViewports(1, &outY_view);
     device_ctx->PSSetShaderResources(0, 1, &img.encoder_input_res);
     device_ctx->Draw(3, 0);
@@ -341,20 +325,13 @@ public:
     // before rendering on the UV part of the image.
     device_ctx->Flush();
 
-    _init_view_port(this->img.width / 2, this->img.height / 2);
     device_ctx->OMSetRenderTargets(1, &nv12_UV_rt, nullptr);
     device_ctx->VSSetShader(convert_UV_vs.get(), nullptr, 0);
     device_ctx->PSSetShader(convert_UV_ps.get(), nullptr, 0);
-    device_ctx->PSSetShaderResources(0, 1, &back_d3d_img->encoder_input_res);
-    device_ctx->Draw(3, 0);
-
     device_ctx->RSSetViewports(1, &outUV_view);
-    device_ctx->PSSetShaderResources(0, 1, &img.encoder_input_res);
     device_ctx->Draw(3, 0);
-    device_ctx->Flush();
 
-    // Release encoder mutexes to allow capture code to reuse this image
-    back_d3d_img->encoder_mutex->ReleaseSync(0);
+    // Release encoder mutex to allow capture code to reuse this image
     img.encoder_mutex->ReleaseSync(0);
 
     return 0;
@@ -514,6 +491,12 @@ public:
       return -1;
     }
 
+    // Clear the RTVs to ensure the aspect ratio padding is black
+    const float y_black[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    device_ctx->ClearRenderTargetView(nv12_Y_rt.get(), y_black);
+    const float uv_black[] = { 0.5f, 0.5f, 0.5f, 0.5f };
+    device_ctx->ClearRenderTargetView(nv12_UV_rt.get(), uv_black);
+
     return 0;
   }
 
@@ -609,14 +592,6 @@ public:
 
     img.display = std::move(display);
 
-    // Color the background black, so that the padding for keeping the aspect ratio
-    // is black
-    back_img = img.display->alloc_img();
-    if(img.display->dummy_img(back_img.get()) || share_img(back_img.get())) {
-      BOOST_LOG(warning) << "Couldn't create an image to set background color to black"sv;
-      return -1;
-    }
-
     blend_disable = make_blend(device.get(), false, false);
     if(!blend_disable) {
       return -1;
@@ -649,20 +624,6 @@ public:
   }
 
 private:
-  void _init_view_port(float x, float y, float width, float height) {
-    D3D11_VIEWPORT view {
-      x, y,
-      width, height,
-      0.0f, 1.0f
-    };
-
-    device_ctx->RSSetViewports(1, &view);
-  }
-
-  void _init_view_port(float width, float height) {
-    _init_view_port(0.0f, 0.0f, width, height);
-  }
-
   int share_img(platf::img_t *img_base) {
     auto img = (img_d3d_t *)img_base;
 
@@ -721,9 +682,6 @@ public:
   // The image referenced by hwframe
   // The resulting image is stored here.
   img_d3d_t img;
-
-  // Clear nv12 render target to black
-  std::shared_ptr<img_t> back_img;
 
   vs_t convert_UV_vs;
   ps_t convert_UV_ps;


### PR DESCRIPTION
## Description
The implementation of `display_vram_t::convert()` was using a pre-allocated black ARGB dummy image to fill the entire image every frame. This effectively means we're doing 2x the amount of work in `convert()` than we should be, because we end up doing RGB->YUV on the dummy image, then doing RGB->YUV on the actual image data to draw right on top of the black image we just drew.

The result is a bunch of extra draw calls, state changes, mutex acquisition, etc. for every frame. We can replace all this work with a couple of `ClearRenderTargetView()` calls when we initially create the image.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
