### PR TITLE
Add timers for snapshot/encode in verbose mode

### DIFF
--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -591,6 +591,7 @@ public:
   }
 
   platf::capture_e snapshot(platf::img_t *img, std::chrono::milliseconds timeout, bool cursor) {
+    auto start = std::chrono::steady_clock::now();
     if(cursor != cursor_visible) {
       auto status = reinit(cursor);
       if(status != platf::capture_e::ok) {
@@ -621,6 +622,10 @@ public:
     if(((img_t *)img)->tex.copy((std::uint8_t *)device_ptr, img->height, img->row_pitch)) {
       return platf::capture_e::error;
     }
+
+    auto stop = std::chrono::steady_clock::now();
+    std::chrono::duration<double> diff = stop-start;
+    BOOST_LOG(verbose) << "nvfbc snapshot in "sv << diff.count()*1000.0 << "ms"sv;
 
     return platf::capture_e::ok;
   }

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -707,6 +707,7 @@ public:
   }
 
   capture_e snapshot(img_t *img_out_base, std::chrono::milliseconds timeout, bool cursor) {
+    auto start = std::chrono::steady_clock::now();
     file_t fb_fd[4];
 
     egl::surface_descriptor_t sd;
@@ -730,6 +731,10 @@ public:
     if(cursor_opt && cursor) {
       cursor_opt->blend(*img_out_base, img_offset_x, img_offset_y);
     }
+
+    auto stop = std::chrono::steady_clock::now();
+    std::chrono::duration<double> diff = stop-start;
+    BOOST_LOG(verbose) << "kms snapshot in "sv << diff.count()*1000.0 << "ms"sv;
 
     return capture_e::ok;
   }


### PR DESCRIPTION
## Description
This PR measures the time to snapshot, convert and encode frames and log the information as verbose logging. Although it adds a very small amount of processing when running normally, I find the changes extremely useful for objectively comparing performance between different settings. This can also be useful to diagnose problems when people are not getting the performance we expect.

### Screenshot
n/a

### Issues Fixed or Closed
n/a

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
