### PR TITLE
CMake: Default to Release build and stop hardcoding optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ option(SUNSHINE_CONFIGURE_FLATPAK "Configuration specific for Flatpak." OFF)
 option(SUNSHINE_CONFIGURE_PORTFILE "Configure macOS Portfile." OFF)
 option(SUNSHINE_CONFIGURE_ONLY "Configure special files only, then exit." OFF)
 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+endif()
+
 if(${SUNSHINE_CONFIGURE_APPIMAGE})
     configure_file(packaging/linux/sunshine.desktop sunshine.desktop @ONLY)
 elseif(${SUNSHINE_CONFIGURE_AUR})
@@ -495,13 +500,11 @@ include_directories(
 
 string(TOUPPER "x${CMAKE_BUILD_TYPE}" BUILD_TYPE)
 if("${BUILD_TYPE}" STREQUAL "XDEBUG")
-    list(APPEND SUNSHINE_COMPILE_OPTIONS -O0 -ggdb3)
     if(WIN32)
         set_source_files_properties(src/nvhttp.cpp PROPERTIES COMPILE_FLAGS -O2)
     endif()
 else()
     add_definitions(-DNDEBUG)
-    list(APPEND SUNSHINE_COMPILE_OPTIONS -O3)
 endif()
 
 # setup assets directory


### PR DESCRIPTION
## Description
CMake doesn't define a default `CMAKE_BUILD_TYPE`, so you end up with a build with no optimizations or debug info. We had worked around this issue by hardcoding optimization flags for Debug and non-Debug build types, but this was a hack and only worked for C++ and CUDA source (not C code, like `rs.c`). Fix this by defaulting `CMAKE_BUILD_TYPE` to `Release` if no build type is specified.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
