### PR TITLE
Replace frame capture busy loop with waitable timer

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -116,6 +116,7 @@ public:
 class display_base_t : public display_t {
 public:
   int init(int framerate, const std::string &display_name);
+  capture_e capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<img_t> img, bool *cursor) override;
 
   std::chrono::nanoseconds delay;
 
@@ -147,15 +148,14 @@ protected:
 
   const char *dxgi_format_to_string(DXGI_FORMAT format);
 
-  virtual int complete_img(img_t *img, bool dummy)                     = 0;
-  virtual std::vector<DXGI_FORMAT> get_supported_sdr_capture_formats() = 0;
+  virtual capture_e snapshot(img_t *img, std::chrono::milliseconds timeout, bool cursor_visible) = 0;
+  virtual int complete_img(img_t *img, bool dummy)                                               = 0;
+  virtual std::vector<DXGI_FORMAT> get_supported_sdr_capture_formats()                           = 0;
 };
 
 class display_ram_t : public display_base_t {
 public:
-  capture_e capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<img_t> img, bool *cursor) override;
-  capture_e snapshot(img_t *img, std::chrono::milliseconds timeout, bool cursor_visible);
-
+  virtual capture_e snapshot(img_t *img, std::chrono::milliseconds timeout, bool cursor_visible) override;
 
   std::shared_ptr<img_t> alloc_img() override;
   int dummy_img(img_t *img) override;
@@ -171,8 +171,7 @@ public:
 
 class display_vram_t : public display_base_t, public std::enable_shared_from_this<display_vram_t> {
 public:
-  capture_e capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<img_t> img, bool *cursor) override;
-  capture_e snapshot(img_t *img, std::chrono::milliseconds timeout, bool cursor_visible);
+  virtual capture_e snapshot(img_t *img, std::chrono::milliseconds timeout, bool cursor_visible) override;
 
   std::shared_ptr<img_t> alloc_img() override;
   int dummy_img(img_t *img_base) override;

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -165,37 +165,6 @@ void blend_cursor(const cursor_t &cursor, img_t &img) {
   }
 }
 
-capture_e display_ram_t::capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<::platf::img_t> img, bool *cursor) {
-  auto next_frame = std::chrono::steady_clock::now();
-
-  while(img) {
-    auto now = std::chrono::steady_clock::now();
-    while(next_frame > now) {
-      now = std::chrono::steady_clock::now();
-    }
-    next_frame = now + delay;
-
-    auto status = snapshot(img.get(), 1000ms, *cursor);
-    switch(status) {
-    case platf::capture_e::reinit:
-    case platf::capture_e::error:
-      return status;
-    case platf::capture_e::timeout:
-      img = snapshot_cb(img, false);
-      std::this_thread::sleep_for(1ms);
-      break;
-    case platf::capture_e::ok:
-      img = snapshot_cb(img, true);
-      break;
-    default:
-      BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';
-      return status;
-    }
-  }
-
-  return capture_e::ok;
-}
-
 capture_e display_ram_t::snapshot(::platf::img_t *img_base, std::chrono::milliseconds timeout, bool cursor_visible) {
   auto img = (img_t *)img_base;
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -698,37 +698,6 @@ public:
   device_ctx_t device_ctx;
 };
 
-capture_e display_vram_t::capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<::platf::img_t> img, bool *cursor) {
-  auto next_frame = std::chrono::steady_clock::now();
-
-  while(img) {
-    auto now = std::chrono::steady_clock::now();
-    while(next_frame > now) {
-      now = std::chrono::steady_clock::now();
-    }
-    next_frame = now + delay;
-
-    auto status = snapshot(img.get(), 1000ms, *cursor);
-    switch(status) {
-    case platf::capture_e::reinit:
-    case platf::capture_e::error:
-      return status;
-    case platf::capture_e::timeout:
-      img = snapshot_cb(img, false);
-      std::this_thread::sleep_for(1ms);
-      break;
-    case platf::capture_e::ok:
-      img = snapshot_cb(img, true);
-      break;
-    default:
-      BOOST_LOG(error) << "Unrecognized capture status ["sv << (int)status << ']';
-      return status;
-    }
-  }
-
-  return capture_e::ok;
-}
-
 bool set_cursor_texture(device_t::pointer device, gpu_cursor_t &cursor, util::buffer_t<std::uint8_t> &&cursor_img, DXGI_OUTDUPL_POINTER_SHAPE_INFO &shape_info) {
   // This cursor image may not be used
   if(cursor_img.size() == 0) {


### PR DESCRIPTION
## Description
This PR replaces the busy loop we were previously using to time frames on Windows with an implementation based on waitable timers, which can provide sub-millisecond wait precision (unlike regular `Sleep()`).

The previous busy loop would increase CPU usage on the capture thread proportional to the difference between the actual capture frame rate and the Moonlight client's selected frame rate. It could end up consuming a significant amount of CPU time which could impact system responsiveness and game performance, especially in CPU-bound scenarios (since the capture thread runs at a high priority). Ironically, attempts by users to reduce load on the system by streaming at a lower frame rate would have actually made the performance problem worse.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
