### PR TITLE
Implement horizontal scrolling and Sunshine detection for Moonlight

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -188,12 +188,20 @@ void print(PNV_SCROLL_PACKET packet) {
     << "--end mouse scroll packet--"sv;
 }
 
+void print(PSS_HSCROLL_PACKET packet) {
+  BOOST_LOG(debug)
+    << "--begin mouse hscroll packet--"sv << std::endl
+    << "scrollAmount ["sv << util::endian::big(packet->scrollAmount) << ']' << std::endl
+    << "--end mouse hscroll packet--"sv;
+}
+
 void print(PNV_KEYBOARD_PACKET packet) {
   BOOST_LOG(debug)
     << "--begin keyboard packet--"sv << std::endl
     << "keyAction ["sv << util::hex(packet->header.magic).to_string_view() << ']' << std::endl
     << "keyCode ["sv << util::hex(packet->keyCode).to_string_view() << ']' << std::endl
     << "modifiers ["sv << util::hex(packet->modifiers).to_string_view() << ']' << std::endl
+    << "flags ["sv << util::hex(packet->flags).to_string_view() << ']' << std::endl
     << "--end keyboard packet--"sv;
 }
 
@@ -237,6 +245,9 @@ void print(void *payload) {
     break;
   case SCROLL_MAGIC_GEN5:
     print((PNV_SCROLL_PACKET)payload);
+    break;
+  case SS_HSCROLL_MAGIC:
+    print((PSS_HSCROLL_PACKET)payload);
     break;
   case KEY_DOWN_EVENT_MAGIC:
   case KEY_UP_EVENT_MAGIC:
@@ -459,6 +470,10 @@ void passthrough(PNV_SCROLL_PACKET packet) {
   platf::scroll(platf_input, util::endian::big(packet->scrollAmt1));
 }
 
+void passthrough(PSS_HSCROLL_PACKET packet) {
+  platf::hscroll(platf_input, util::endian::big(packet->scrollAmount));
+}
+
 void passthrough(PNV_UNICODE_PACKET packet) {
   auto size = util::endian::big(packet->header.size) - sizeof(packet->header.magic);
   platf::unicode(platf_input, packet->text, size);
@@ -620,6 +635,9 @@ void passthrough_helper(std::shared_ptr<input_t> input, std::vector<std::uint8_t
     break;
   case SCROLL_MAGIC_GEN5:
     passthrough((PNV_SCROLL_PACKET)payload);
+    break;
+  case SS_HSCROLL_MAGIC:
+    passthrough((PSS_HSCROLL_PACKET)payload);
     break;
   case KEY_DOWN_EVENT_MAGIC:
   case KEY_UP_EVENT_MAGIC:

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -31,7 +31,8 @@
 using namespace std::literals;
 namespace nvhttp {
 
-constexpr auto VERSION     = "7.1.431.0";
+// The negative 4th version number tells Moonlight that this is Sunshine
+constexpr auto VERSION     = "7.1.431.-1";
 constexpr auto GFE_VERSION = "3.23.0.74";
 
 namespace fs = std::filesystem;

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -363,6 +363,7 @@ void move_mouse(input_t &input, int deltaX, int deltaY);
 void abs_mouse(input_t &input, const touch_port_t &touch_port, float x, float y);
 void button_mouse(input_t &input, int button, bool release);
 void scroll(input_t &input, int distance);
+void hscroll(input_t &input, int distance);
 void keyboard(input_t &input, uint16_t modcode, bool release);
 void gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state);
 void unicode(input_t &input, char *utf8, int size);

--- a/src/platform/linux/input.cpp
+++ b/src/platform/linux/input.cpp
@@ -982,6 +982,19 @@ void scroll(input_t &input, int high_res_distance) {
   libevdev_uinput_write_event(mouse, EV_SYN, SYN_REPORT, 0);
 }
 
+void hscroll(input_t &input, int high_res_distance) {
+  int distance = high_res_distance / 120;
+
+  auto mouse = ((input_raw_t *)input.get())->mouse_input.get();
+  if(!mouse) {
+    return;
+  }
+
+  libevdev_uinput_write_event(mouse, EV_REL, REL_HWHEEL, distance);
+  libevdev_uinput_write_event(mouse, EV_REL, REL_HWHEEL_HI_RES, high_res_distance);
+  libevdev_uinput_write_event(mouse, EV_SYN, SYN_REPORT, 0);
+}
+
 static keycode_t keysym(std::uint16_t modcode) {
   if(modcode <= keycodes.size()) {
     return keycodes[modcode];

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -417,6 +417,10 @@ void scroll(input_t &input, int high_res_distance) {
   CFRelease(upEvent);
 }
 
+void hscroll(input_t &input, int high_res_distance) {
+  // Unimplemented
+}
+
 input_t input() {
   input_t result { new macos_input_t() };
 

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -303,6 +303,18 @@ void scroll(input_t &input, int distance) {
   send_input(i);
 }
 
+void hscroll(input_t &input, int distance) {
+  INPUT i {};
+
+  i.type   = INPUT_MOUSE;
+  auto &mi = i.mi;
+
+  mi.dwFlags   = MOUSEEVENTF_HWHEEL;
+  mi.mouseData = distance;
+
+  send_input(i);
+}
+
 void keyboard(input_t &input, uint16_t modcode, bool release) {
   auto raw = (input_raw_t *)input.get();
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -399,13 +399,12 @@ session_t *control_server_t::get_session(const net::peer_t peer) {
 void control_server_t::call(std::uint16_t type, session_t *session, const std::string_view &payload) {
   auto cb = _map_type_cb.find(type);
   if(cb == std::end(_map_type_cb)) {
-    BOOST_LOG(warning)
+    BOOST_LOG(debug)
       << "type [Unknown] { "sv << util::hex(type).to_string_view() << " }"sv << std::endl
       << "---data---"sv << std::endl
       << util::hex_vec(payload) << std::endl
       << "---end data---"sv;
   }
-
   else {
     cb->second(session, payload);
   }


### PR DESCRIPTION
## Description
This PR implements a protocol extension for horizontal scroll events and an `appversion` change to allow Moonlight to distinguish Sunshine hosts in moonlight-common-c. Using a negative number for the 4th part of `appversion` should be safe for existing Moonlight clients while also ensuring that any past or future version of GFE will not collide.

I've also added protocol extension for sending keyboard events with non-normalized key codes and HDR metadata, but neither of those are implemented in Sunshine yet.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
