### PR TITLE
Fix streaming to multiple clients from hardware encoder on Windows

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -195,6 +195,8 @@ public:
   gpu_cursor_t cursor_xor;
 
   texture2d_t last_frame_copy;
+
+  std::atomic<uint32_t> next_image_id;
 };
 } // namespace platf::dxgi
 


### PR DESCRIPTION
## Description
#668 broke the multi-client streaming scenario because it assumes a single `img_t` is shared between a single capture device and a single encoding device. When using multiple clients, there is a new `hwdevice_t` for each independent stream, so there can be an arbitrary number of encoding devices sharing a single capture texture. This PR fixes this issue by keeping a map of encoder image context structures in the `hwdevice_t`, so each separate encoding device can open the same capture texture and mutex properly.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #795
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
