### PR TITLE
Fix image leak of hardware parallel encoder on display reinit

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1574,6 +1574,12 @@ void capture_async(
   platf::adjust_thread_priority(platf::thread_priority_e::high);
 
   while(!shutdown_event->peek() && images->running()) {
+    // Free images that weren't consumed by the encoder before it quit.
+    // This is critical to allow the display_t to be freed correctly.
+    while(images->peek()) {
+      images->pop();
+    }
+
     // Wait for the main capture event when the display is being reinitialized
     if(ref->reinit_event.peek()) {
       std::this_thread::sleep_for(100ms);
@@ -1622,12 +1628,6 @@ void capture_async(
       std::move(hwdevice),
       ref->reinit_event, *ref->encoder_p,
       channel_data);
-
-    // Free images that weren't consumed by the encoder before it quit.
-    // This is critical to allow the display_t to be freed correctly.
-    while(images->peek()) {
-      images->pop();
-    }
   }
 }
 


### PR DESCRIPTION
## Description
When a reinit caused by a capture size change occurs via the Windows hardware encoder, the stream will freeze with `display_wp->use_count()` stuck at 2. Fix by ensuring pending images are freed before reinit event is checked.

To reproduce:
* Using an application that allows full-screen transition via alt-enter, continually enter and exit fullscreen whilst the application is configured to use a different resolution from the desktop. In my case, I used Sonic Mania @ 1360x768 with a desktop resolution of 1440p, and the freeze usually occurs within 10 successive resolution changes.
* Disabling DwmFlush appears to help reproduce the issue more quickly.

The freeze will occur when this line appears in the log:
```
[2023:01:24:02:01:26]: Info: Capture size changed [1360x768 -> 2560x1440]
```

Further debugging shows that `display_wp->use_count()` stays at 2, causing Sunshine to freeze as it is stuck in [this](https://github.com/LizardByte/Sunshine/blob/nightly/src/video.cpp#L839-L841) loop.

Pinging @cgutman, as it is related to: adbfd098ba3f0335ee4d848004a1ea27eeb3ec50. Please let me know if moving this breaks the original case it was intended to fix.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
