### PR TITLE
Implement HDR support for Windows

### DIFF
--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -257,6 +257,18 @@ Considerations
   instead it simply starts a stream.
 - For the Linux flatpak you must prepend commands with ``flatpak-spawn --host``.
 
+HDR Support
+-----------
+Streaming HDR content is supported for Windows hosts with NVIDIA, AMD, or Intel GPUs that support encoding HEVC Main 10.
+You must have an HDR-capable display or EDID emulator dongle connected to your host PC to activate HDR in Windows.
+
+- Ensure you enable the HDR option in your Moonlight client settings, otherwise the stream will be SDR.
+- A good HDR experience relies on proper HDR display calibration both in Windows and in game. HDR calibration can differ significantly between client and host displays.
+- We recommend calibrating the display by streaming the Windows HDR Calibration app to your client device and saving an HDR calibration profile to use while streaming.
+- You may also need to tune the brightness slider or HDR calibration options in game to the different HDR brightness capabilities of your client's display.
+- Older games that use NVIDIA-specific NVAPI HDR rather than native Windows 10 OS HDR support may not display in HDR.
+- Some GPUs can produce lower image quality or encoding performance when streaming in HDR compared to SDR.
+
 Tutorials
 ---------
 Tutorial videos are available `here <https://www.youtube.com/playlist?list=PLMYr5_xSeuXAbhxYHz86hA1eCDugoxXY0>`_.

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -151,6 +151,7 @@ protected:
   }
 
   const char *dxgi_format_to_string(DXGI_FORMAT format);
+  const char *colorspace_to_string(DXGI_COLOR_SPACE_TYPE type);
 
   virtual capture_e snapshot(img_t *img, std::chrono::milliseconds timeout, bool cursor_visible) = 0;
   virtual int complete_img(img_t *img, bool dummy)                                               = 0;

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -598,6 +598,23 @@ bool display_base_t::get_hdr_metadata(SS_HDR_METADATA &metadata) {
   DXGI_OUTPUT_DESC1 desc1;
   output6->GetDesc1(&desc1);
 
+  // The primaries reported here seem to correspond to scRGB (Rec. 709)
+  // which we then convert to Rec 2020 in our scRGB FP16 -> PQ shader
+  // prior to encoding. It's not clear to me if we're supposed to report
+  // the primaries of the original colorspace or the one we've converted
+  // it to, but let's just report Rec 2020 primaries and D65 white level
+  // to avoid confusing clients by reporting Rec 709 primaries with a
+  // Rec 2020 colorspace. It seems like most clients ignore the primaries
+  // in the metadata anyway (luminance range is most important).
+  desc1.RedPrimary[0]   = 0.708f;
+  desc1.RedPrimary[1]   = 0.292f;
+  desc1.GreenPrimary[0] = 0.170f;
+  desc1.GreenPrimary[1] = 0.797f;
+  desc1.BluePrimary[0]  = 0.131f;
+  desc1.BluePrimary[1]  = 0.046f;
+  desc1.WhitePoint[0]   = 0.3127f;
+  desc1.WhitePoint[1]   = 0.3290f;
+
   metadata.displayPrimaries[0].x = desc1.RedPrimary[0] * 50000;
   metadata.displayPrimaries[0].y = desc1.RedPrimary[1] * 50000;
   metadata.displayPrimaries[1].x = desc1.GreenPrimary[0] * 50000;

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -563,6 +563,25 @@ int display_base_t::init(const ::video::config_t &config, const std::string &dis
   BOOST_LOG(info) << "Desktop resolution ["sv << dup_desc.ModeDesc.Width << 'x' << dup_desc.ModeDesc.Height << ']';
   BOOST_LOG(info) << "Desktop format ["sv << dxgi_format_to_string(dup_desc.ModeDesc.Format) << ']';
 
+  dxgi::output6_t output6 {};
+  status = output->QueryInterface(IID_IDXGIOutput6, (void **)&output6);
+  if(SUCCEEDED(status)) {
+    DXGI_OUTPUT_DESC1 desc1;
+    output6->GetDesc1(&desc1);
+
+    BOOST_LOG(info)
+      << std::endl
+      << "Colorspace         : "sv << colorspace_to_string(desc1.ColorSpace) << std::endl
+      << "Bits Per Color     : "sv << desc1.BitsPerColor << std::endl
+      << "Red Primary        : ["sv << desc1.RedPrimary[0] << ',' << desc1.RedPrimary[1] << ']' << std::endl
+      << "Green Primary      : ["sv << desc1.GreenPrimary[0] << ',' << desc1.GreenPrimary[1] << ']' << std::endl
+      << "Blue Primary       : ["sv << desc1.BluePrimary[0] << ',' << desc1.BluePrimary[1] << ']' << std::endl
+      << "White Point        : ["sv << desc1.WhitePoint[0] << ',' << desc1.WhitePoint[1] << ']' << std::endl
+      << "Min Luminance      : "sv << desc1.MinLuminance << " nits"sv << std::endl
+      << "Max Luminance      : "sv << desc1.MaxLuminance << " nits"sv << std::endl
+      << "Max Full Luminance : "sv << desc1.MaxFullFrameLuminance << " nits"sv;
+  }
+
   // Capture format will be determined from the first call to AcquireNextFrame()
   capture_format = DXGI_FORMAT_UNKNOWN;
 
@@ -764,6 +783,43 @@ const char *format_str[] = {
 
 const char *display_base_t::dxgi_format_to_string(DXGI_FORMAT format) {
   return format_str[format];
+}
+
+const char *display_base_t::colorspace_to_string(DXGI_COLOR_SPACE_TYPE type) {
+  const char *type_str[] = {
+    "DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709",
+    "DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709",
+    "DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709",
+    "DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020",
+    "DXGI_COLOR_SPACE_RESERVED",
+    "DXGI_COLOR_SPACE_YCBCR_FULL_G22_NONE_P709_X601",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P601",
+    "DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P601",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P709",
+    "DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P709",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P2020",
+    "DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020",
+    "DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_TOPLEFT_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020",
+    "DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_FULL_GHLG_TOPLEFT_P2020",
+    "DXGI_COLOR_SPACE_RGB_STUDIO_G24_NONE_P709",
+    "DXGI_COLOR_SPACE_RGB_STUDIO_G24_NONE_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G24_LEFT_P709",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G24_LEFT_P2020",
+    "DXGI_COLOR_SPACE_YCBCR_STUDIO_G24_TOPLEFT_P2020",
+  };
+
+  if(type < ARRAYSIZE(type_str)) {
+    return type_str[type];
+  }
+  else {
+    return "UNKNOWN";
+  }
 }
 
 } // namespace platf::dxgi

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -820,8 +820,11 @@ void controlBroadcastThread(control_server_t *server) {
           send_rumble(session, rumble->id, rumble->lowfreq, rumble->highfreq);
         }
 
+        // Unlike rumble which we send as best-effort, HDR state messages are critical
+        // for proper functioning of some clients. We must wait to pop entries from
+        // the queue until we're sure we have a peer to send them to.
         auto &hdr_queue = session->control.hdr_queue;
-        while(hdr_queue->peek()) {
+        while(session->control.peer && hdr_queue->peek()) {
           auto hdr_info = hdr_queue->pop();
 
           send_hdr_mode(session, std::move(hdr_info));

--- a/src_assets/windows/assets/shaders/directx/ConvertUVPS_PQ.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ConvertUVPS_PQ.hlsl
@@ -1,0 +1,69 @@
+Texture2D image : register(t0);
+
+SamplerState def_sampler : register(s0);
+
+struct FragTexWide {
+    float3 uuv : TEXCOORD0;
+};
+
+cbuffer ColorMatrix : register(b0) {
+    float4 color_vec_y;
+    float4 color_vec_u;
+    float4 color_vec_v;
+    float2 range_y;
+    float2 range_uv;
+};
+
+float3 NitsToPQ(float3 L)
+{
+    // Constants from SMPTE 2084 PQ
+    static const float m1 = 2610.0 / 4096.0 / 4;
+    static const float m2 = 2523.0 / 4096.0 * 128;
+    static const float c1 = 3424.0 / 4096.0;
+    static const float c2 = 2413.0 / 4096.0 * 32;
+    static const float c3 = 2392.0 / 4096.0 * 32;
+
+    float3 Lp = pow(saturate(L / 10000.0), m1);
+    return pow((c1 + c2 * Lp) / (1 + c3 * Lp), m2);
+}
+
+float3 Rec709toRec2020(float3 rec709)
+{
+    static const float3x3 ConvMat =
+    {
+        0.627402, 0.329292, 0.043306,
+        0.069095, 0.919544, 0.011360,
+        0.016394, 0.088028, 0.895578
+    };
+    return mul(ConvMat, rec709);
+}
+
+float3 scRGBTo2100PQ(float3 rgb)
+{
+    // Convert from Rec 709 primaries (used by scRGB) to Rec 2020 primaries (used by Rec 2100)
+    rgb = Rec709toRec2020(rgb);
+
+    // 1.0f is defined as 80 nits in the scRGB colorspace
+    rgb *= 80;
+
+    // Apply the PQ transfer function on the raw color values in nits
+    return NitsToPQ(rgb);
+}
+
+//--------------------------------------------------------------------------------------
+// Pixel Shader
+//--------------------------------------------------------------------------------------
+float2 main_ps(FragTexWide input) : SV_Target
+{
+    float3 rgb_left = scRGBTo2100PQ(image.Sample(def_sampler, input.uuv.xz).rgb);
+    float3 rgb_right = scRGBTo2100PQ(image.Sample(def_sampler, input.uuv.yz).rgb);
+    float3 rgb = (rgb_left + rgb_right) * 0.5;
+
+    float u = dot(color_vec_u.xyz, rgb) + color_vec_u.w;
+    float v = dot(color_vec_v.xyz, rgb) + color_vec_v.w;
+
+    u = u * range_uv.x + range_uv.y;
+    v = v * range_uv.x + range_uv.y;
+
+    return float2(u, v);
+}

--- a/src_assets/windows/assets/shaders/directx/ConvertYPS_PQ.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ConvertYPS_PQ.hlsl
@@ -1,0 +1,62 @@
+Texture2D image : register(t0);
+
+SamplerState def_sampler : register(s0);
+
+cbuffer ColorMatrix : register(b0) {
+    float4 color_vec_y;
+    float4 color_vec_u;
+    float4 color_vec_v;
+    float2 range_y;
+    float2 range_uv;
+};
+
+struct PS_INPUT
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD;
+};
+
+float3 NitsToPQ(float3 L)
+{
+    // Constants from SMPTE 2084 PQ
+    static const float m1 = 2610.0 / 4096.0 / 4;
+    static const float m2 = 2523.0 / 4096.0 * 128;
+    static const float c1 = 3424.0 / 4096.0;
+    static const float c2 = 2413.0 / 4096.0 * 32;
+    static const float c3 = 2392.0 / 4096.0 * 32;
+
+    float3 Lp = pow(saturate(L / 10000.0), m1);
+    return pow((c1 + c2 * Lp) / (1 + c3 * Lp), m2);
+}
+
+float3 Rec709toRec2020(float3 rec709)
+{
+    static const float3x3 ConvMat =
+    {
+        0.627402, 0.329292, 0.043306,
+        0.069095, 0.919544, 0.011360,
+        0.016394, 0.088028, 0.895578
+    };
+    return mul(ConvMat, rec709);
+}
+
+float3 scRGBTo2100PQ(float3 rgb)
+{
+    // Convert from Rec 709 primaries (used by scRGB) to Rec 2020 primaries (used by Rec 2100)
+    rgb = Rec709toRec2020(rgb);
+
+    // 1.0f is defined as 80 nits in the scRGB colorspace
+    rgb *= 80;
+
+    // Apply the PQ transfer function on the raw color values in nits
+    return NitsToPQ(rgb);
+}
+
+float main_ps(PS_INPUT frag_in) : SV_Target
+{
+    float3 rgb = scRGBTo2100PQ(image.Sample(def_sampler, frag_in.tex, 0).rgb);
+
+    float y = dot(color_vec_y.xyz, rgb) + color_vec_y.w;
+
+    return y * range_y.x + range_y.y;
+}

--- a/src_assets/windows/assets/shaders/directx/ScenePS_NW.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ScenePS_NW.hlsl
@@ -1,0 +1,22 @@
+Texture2D image : register(t0);
+
+SamplerState def_sampler : register(s0);
+
+struct PS_INPUT
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD;
+};
+
+cbuffer SdrScaling : register(b0) {
+    float scale_factor;
+};
+
+float4 main_ps(PS_INPUT frag_in) : SV_Target
+{
+    float4 rgba = image.Sample(def_sampler, frag_in.tex, 0);
+
+    rgba.rgb = rgba.rgb * scale_factor;
+
+    return rgba;
+}


### PR DESCRIPTION
## Description
The title pretty much says it all. This adds support for streaming HDR content from a Windows host.

I've tested this successfully with NVIDIA (RTX 2080), AMD (RX 6700 XT), and Intel (12600K IGP) GPUs. AMD and NVIDIA  encoders had no trouble encoding HEVC Main 10 in HDR at 4K 60 FPS, but Intel QuickSync seemed to struggle with HEVC Main 10 with notably degraded image quality compared to HEVC Main profile (this impacted both SDR and HDR modes).

### Screenshot
I'd attach one but I can't find a screenshot utility that handles HDR content properly

### Issues Fixed or Closed
Resolves #376

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
