### PR TITLE
Rename 'Steam BigPicture' to 'Steam Big Picture' in apps.json

### DIFF
--- a/src_assets/linux/assets/apps.json
+++ b/src_assets/linux/assets/apps.json
@@ -18,7 +18,7 @@
       ]
     },
     {
-      "name": "Steam BigPicture",
+      "name": "Steam Big Picture",
       "detached": [
         "setsid steam steam://open/bigpicture"
       ],

--- a/src_assets/macos/assets/apps.json
+++ b/src_assets/macos/assets/apps.json
@@ -8,7 +8,7 @@
       "image-path": "desktop.png"
     },
     {
-      "name": "Steam BigPicture",
+      "name": "Steam Big Picture",
       "detached": [
         "open steam://open/bigpicture"
       ],

--- a/src_assets/windows/assets/apps.json
+++ b/src_assets/windows/assets/apps.json
@@ -8,7 +8,7 @@
       "image-path": "desktop.png"
     },
     {
-      "name": "Steam BigPicture",
+      "name": "Steam Big Picture",
       "detached": [
         "steam steam://open/bigpicture"
       ],


### PR DESCRIPTION
## Description
Rename 'Steam BigPicture' to 'Steam Big Picture' in apps.json, as Steam refers to it as either 'Big Picture' or 'Big Picture Mode'.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
