### PR TITLE
Restart the systemd service in case of a crash

### DIFF
--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -87,9 +87,13 @@ Sunshine needs access to `uinput` to create mouse and gamepad events.
 
             [Unit]
             Description=Sunshine self-hosted game stream host for Moonlight.
+            StartLimitIntervalSec=500
+            StartLimitBurst=5
 
             [Service]
             ExecStart=<see table>
+            Restart=on-failure
+            RestartSec=5s
             #Flatpak Only
             #ExecStop=flatpak kill dev.lizardbyte.sunshine
 

--- a/sunshine.service.in
+++ b/sunshine.service.in
@@ -1,8 +1,12 @@
 [Unit]
 Description=@PROJECT_DESCRIPTION@
+StartLimitIntervalSec=500
+StartLimitBurst=5
 
 [Service]
 ExecStart=@SUNSHINE_EXECUTABLE_PATH@
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
Make the systemd service restart itself in case of a crash. A restart is attempted 5 seconds after a crash is detected. Additionally, if the service is restarted more than 5 times in a 500 second interval it is considered as failed and no more restart attempts are going to be made.

## Description
Sunshine crashed when I attempted to connect to a desktop session.
Not sure what the actual crash was. Nothing suspicious in the output logs.
Maybe systemd keeps the core dumps somewhere. I will open a new ticket if I find out more about the issue.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
