### PR TITLE
Add unused microphone port, rtsp udp fallback and fix audio/control name

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -13,6 +13,7 @@ namespace stream {
 constexpr auto VIDEO_STREAM_PORT = 9;
 constexpr auto CONTROL_PORT      = 10;
 constexpr auto AUDIO_STREAM_PORT = 11;
+constexpr auto MICROPHONE_STREAM_PORT = 13;
 
 struct session_t;
 struct config_t {

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -132,19 +132,22 @@ std::unique_ptr<platf::deinit_t> start() {
     }
   }
 
-  auto rtsp     = std::to_string(map_port(stream::RTSP_SETUP_PORT));
-  auto video    = std::to_string(map_port(stream::VIDEO_STREAM_PORT));
-  auto audio    = std::to_string(map_port(stream::AUDIO_STREAM_PORT));
-  auto control  = std::to_string(map_port(stream::CONTROL_PORT));
-  auto gs_http  = std::to_string(map_port(nvhttp::PORT_HTTP));
-  auto gs_https = std::to_string(map_port(nvhttp::PORT_HTTPS));
-  auto wm_http  = std::to_string(map_port(confighttp::PORT_HTTPS));
+  auto rtsp       = std::to_string(map_port(stream::RTSP_SETUP_PORT));
+  auto video      = std::to_string(map_port(stream::VIDEO_STREAM_PORT));
+  auto audio      = std::to_string(map_port(stream::AUDIO_STREAM_PORT));
+  auto microphone = std::to_string(map_port(stream::MICROPHONE_STREAM_PORT));
+  auto control    = std::to_string(map_port(stream::CONTROL_PORT));
+  auto gs_http    = std::to_string(map_port(nvhttp::PORT_HTTP));
+  auto gs_https   = std::to_string(map_port(nvhttp::PORT_HTTPS));
+  auto wm_http    = std::to_string(map_port(confighttp::PORT_HTTPS));
 
   std::vector<mapping_t> mappings {
     { rtsp, rtsp, "RTSP setup port"s, true },
+    { rtsp, rtsp, "Fallback RTSP setup port"s, false },
     { video, video, "Video stream port"s, false },
-    { audio, audio, "Control stream port"s, false },
-    { control, control, "Audio stream port"s, false },
+    { audio, audio, "Audio stream port"s, false },
+    { microphone, microphone, "Microphone stream port"s, false },
+    { control, control, "Control stream port"s, false },
     { gs_http, gs_http, "Gamestream http port"s, true },
     { gs_https, gs_https, "Gamestream https port"s, true },
   };


### PR DESCRIPTION
## Description
This PR adds the missing (and so far unused) microphone port `48002` (by default) and maps it via UPnP if enabled.
The RTSP fallback UDP port will now also be mapped via UPnPl.
A minor name swap between `control` and `audio` UPnP mappings has been corrected.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
