### PR TITLE
Scrub basic auth header from logs

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -56,7 +56,7 @@ void print_req(const req_https_t &request) {
   BOOST_LOG(debug) << "DESTINATION :: "sv << request->path;
 
   for(auto &[name, val] : request->header) {
-    BOOST_LOG(debug) << name << " -- " << val;
+    BOOST_LOG(debug) << name << " -- " << (name == "Authorization" ? "CREDENTIALS REDACTED" : val);
   }
 
   BOOST_LOG(debug) << " [--] "sv;


### PR DESCRIPTION
## Description
Reported by DemonCat on Discord. The basic auth header is printed when loglevel is Debug, which could be an issue when a user submits their logs.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
