### PR TITLE
Use #pragma once header guards

### DIFF
--- a/src/audio.h
+++ b/src/audio.h
@@ -1,8 +1,8 @@
-#ifndef SUNSHINE_AUDIO_H
-#define SUNSHINE_AUDIO_H
+#pragma once
 
 #include "thread_safe.h"
 #include "utility.h"
+
 namespace audio {
 enum stream_config_e : int {
   STEREO,
@@ -43,5 +43,3 @@ using buffer_t = util::buffer_t<std::uint8_t>;
 using packet_t = std::pair<void *, buffer_t>;
 void capture(safe::mail_t mail, config_t config, void *channel_data);
 } // namespace audio
-
-#endif

--- a/src/cbs.h
+++ b/src/cbs.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_CBS_H
-#define SUNSHINE_CBS_H
+#pragma once
 
 #include "utility.h"
 
@@ -30,5 +29,3 @@ h264_t make_sps_h264(const AVCodecContext *ctx, const AVPacket *packet);
  */
 bool validate_sps(const AVPacket *packet, int codec_id);
 } // namespace cbs
-
-#endif

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_CONFIG_H
-#define SUNSHINE_CONFIG_H
+#pragma once
 
 #include <bitset>
 #include <chrono>
@@ -140,4 +139,3 @@ extern sunshine_t sunshine;
 int parse(int argc, char *argv[]);
 std::unordered_map<std::string, std::string> parse_config(const std::string_view &file_content);
 } // namespace config
-#endif

--- a/src/confighttp.h
+++ b/src/confighttp.h
@@ -1,7 +1,4 @@
-// Created by loki on 6/3/19.
-
-#ifndef SUNSHINE_CONFIGHTTP_H
-#define SUNSHINE_CONFIGHTTP_H
+#pragma once
 
 #include <functional>
 #include <string>
@@ -15,5 +12,3 @@ namespace confighttp {
 constexpr auto PORT_HTTPS = 1;
 void start();
 } // namespace confighttp
-
-#endif // SUNSHINE_CONFIGHTTP_H

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -1,7 +1,4 @@
-// Created by loki on 6/1/19.
-
-#ifndef SUNSHINE_CRYPTO_H
-#define SUNSHINE_CRYPTO_H
+#pragma once
 
 #include <array>
 #include <openssl/evp.h>
@@ -131,5 +128,3 @@ public:
 };
 } // namespace cipher
 } // namespace crypto
-
-#endif //SUNSHINE_CRYPTO_H

--- a/src/httpcommon.h
+++ b/src/httpcommon.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "network.h"
 #include "thread_safe.h"
 

--- a/src/input.h
+++ b/src/input.h
@@ -1,7 +1,4 @@
-// Created by loki on 6/20/19.
-
-#ifndef SUNSHINE_INPUT_H
-#define SUNSHINE_INPUT_H
+#pragma once
 
 #include <functional>
 
@@ -29,5 +26,3 @@ struct touch_port_t : public platf::touch_port_t {
   float scalar_inv;
 };
 } // namespace input
-
-#endif // SUNSHINE_INPUT_H

--- a/src/main.h
+++ b/src/main.h
@@ -1,7 +1,4 @@
-// Created by loki on 12/22/19.
-
-#ifndef SUNSHINE_MAIN_H
-#define SUNSHINE_MAIN_H
+#pragma once
 
 #include <filesystem>
 #include <string_view>
@@ -54,4 +51,3 @@ MAIL(rumble);
 MAIL(hdr);
 #undef MAIL
 } // namespace mail
-#endif // SUNSHINE_MAIN_H

--- a/src/move_by_copy.h
+++ b/src/move_by_copy.h
@@ -1,5 +1,4 @@
-#ifndef DOSSIER_MOVE_BY_COPY_H
-#define DOSSIER_MOVE_BY_COPY_H
+#pragma once
 
 #include <utility>
 namespace util {
@@ -48,4 +47,3 @@ MoveByCopy<T> const_cmove(const T &movable) {
   return MoveByCopy<T>(std::move(const_cast<T &>(movable)));
 }
 } // namespace util
-#endif

--- a/src/network.h
+++ b/src/network.h
@@ -1,7 +1,4 @@
-// Created by loki on 12/27/19.
-
-#ifndef SUNSHINE_NETWORK_H
-#define SUNSHINE_NETWORK_H
+#pragma once
 
 #include <tuple>
 
@@ -29,5 +26,3 @@ net_e from_address(const std::string_view &view);
 
 host_t host_create(ENetAddress &addr, std::size_t peers, std::uint16_t port);
 } // namespace net
-
-#endif // SUNSHINE_NETWORK_H

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -1,7 +1,4 @@
-// Created by loki on 6/3/19.
-
-#ifndef SUNSHINE_NVHTTP_H
-#define SUNSHINE_NVHTTP_H
+#pragma once
 
 #include "thread_safe.h"
 #include <string>
@@ -14,5 +11,3 @@ void start();
 bool pin(std::string pin);
 void erase_all_clients();
 } // namespace nvhttp
-
-#endif // SUNSHINE_NVHTTP_H

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -1,9 +1,4 @@
-//
-// Created by loki on 6/21/19.
-//
-
-#ifndef SUNSHINE_COMMON_H
-#define SUNSHINE_COMMON_H
+#pragma once
 
 #include <bitset>
 #include <filesystem>
@@ -398,5 +393,3 @@ namespace publish {
 
 std::vector<std::string_view> &supported_gamepads();
 } // namespace platf
-
-#endif //SUNSHINE_COMMON_H

--- a/src/platform/linux/cuda.h
+++ b/src/platform/linux/cuda.h
@@ -1,5 +1,4 @@
-#if !defined(SUNSHINE_PLATFORM_CUDA_H) && defined(SUNSHINE_BUILD_CUDA)
-#define SUNSHINE_PLATFORM_CUDA_H
+#pragma once
 
 #include <memory>
 #include <optional>
@@ -103,5 +102,3 @@ public:
   float scale;
 };
 } // namespace cuda
-
-#endif

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_PLATFORM_LINUX_OPENGL_H
-#define SUNSHINE_PLATFORM_LINUX_OPENGL_H
+#pragma once
 
 #include <optional>
 #include <string_view>
@@ -315,5 +314,3 @@ public:
 
 bool fail();
 } // namespace egl
-
-#endif

--- a/src/platform/linux/misc.h
+++ b/src/platform/linux/misc.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_PLATFORM_MISC_H
-#define SUNSHINE_PLATFORM_MISC_H
+#pragma once
 
 #include <unistd.h>
 #include <vector>
@@ -27,5 +26,3 @@ int load(void *handle, const std::vector<std::tuple<apiproc *, const char *>> &f
 void *handle(const std::vector<const char *> &libs);
 
 } // namespace dyn
-
-#endif

--- a/src/platform/linux/vaapi.h
+++ b/src/platform/linux/vaapi.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_VAAPI_H
-#define SUNSHINE_VAAPI_H
+#pragma once
 
 #include "misc.h"
 #include "src/platform/common.h"
@@ -24,4 +23,3 @@ bool validate(int fd);
 
 int init();
 } // namespace va
-#endif

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_WAYLAND_H
-#define SUNSHINE_WAYLAND_H
+#pragma once
 
 #include <bitset>
 
@@ -211,6 +210,4 @@ inline std::vector<std::unique_ptr<monitor_t>> monitors(const char *display_name
 
 inline int init() { return -1; }
 } // namespace wl
-#endif
-
 #endif

--- a/src/platform/linux/x11grab.h
+++ b/src/platform/linux/x11grab.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_X11_GRAB
-#define SUNSHINE_X11_GRAB
+#pragma once
 
 #include <optional>
 
@@ -56,5 +55,3 @@ public:
 xdisplay_t make_display() { return nullptr; }
 #endif
 } // namespace platf::x11
-
-#endif

--- a/src/platform/macos/av_audio.h
+++ b/src/platform/macos/av_audio.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_PLATFORM_AV_AUDIO_H
-#define SUNSHINE_PLATFORM_AV_AUDIO_H
+#pragma once
 
 #import <AVFoundation/AVFoundation.h>
 
@@ -22,5 +21,3 @@
 - (int)setupMicrophone:(AVCaptureDevice *)device sampleRate:(UInt32)sampleRate frameSize:(UInt32)frameSize channels:(UInt8)channels;
 
 @end
-
-#endif //SUNSHINE_PLATFORM_AV_AUDIO_H

--- a/src/platform/macos/av_img_t.h
+++ b/src/platform/macos/av_img_t.h
@@ -1,5 +1,4 @@
-#ifndef av_img_t_h
-#define av_img_t_h
+#pragma once
 
 #include "src/platform/common.h"
 
@@ -14,5 +13,3 @@ struct av_img_t : public img_t {
   ~av_img_t();
 };
 } // namespace platf
-
-#endif /* av_img_t_h */

--- a/src/platform/macos/av_video.h
+++ b/src/platform/macos/av_video.h
@@ -1,8 +1,6 @@
-#ifndef SUNSHINE_PLATFORM_AV_VIDEO_H
-#define SUNSHINE_PLATFORM_AV_VIDEO_H
+#pragma once
 
 #import <AVFoundation/AVFoundation.h>
-
 
 struct CaptureSession {
   AVCaptureVideoDataOutput *output;
@@ -39,5 +37,3 @@ typedef bool (^FrameCallbackBlock)(CMSampleBufferRef);
 - (dispatch_semaphore_t)capture:(FrameCallbackBlock)frameCallback;
 
 @end
-
-#endif //SUNSHINE_PLATFORM_AV_VIDEO_H

--- a/src/platform/macos/misc.h
+++ b/src/platform/macos/misc.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_PLATFORM_MISC_H
-#define SUNSHINE_PLATFORM_MISC_H
+#pragma once
 
 #include <vector>
 
@@ -12,5 +11,3 @@ int load(void *handle, const std::vector<std::tuple<apiproc *, const char *>> &f
 void *handle(const std::vector<const char *> &libs);
 
 } // namespace dyn
-
-#endif

--- a/src/platform/macos/nv12_zero_device.h
+++ b/src/platform/macos/nv12_zero_device.h
@@ -1,5 +1,4 @@
-#ifndef vtdevice_h
-#define vtdevice_h
+#pragma once
 
 #include "src/platform/common.h"
 
@@ -25,5 +24,3 @@ public:
 };
 
 } // namespace platf
-
-#endif /* vtdevice_h */

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -1,9 +1,4 @@
-//
-// Created by loki on 4/23/20.
-//
-
-#ifndef SUNSHINE_DISPLAY_H
-#define SUNSHINE_DISPLAY_H
+#pragma once
 
 #include <d3d11.h>
 #include <d3d11_4.h>
@@ -207,5 +202,3 @@ public:
   std::atomic<uint32_t> next_image_id;
 };
 } // namespace platf::dxgi
-
-#endif

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -1,5 +1,4 @@
-#ifndef SUNSHINE_WINDOWS_MISC_H
-#define SUNSHINE_WINDOWS_MISC_H
+#pragma once
 
 #include <string_view>
 #include <windows.h>
@@ -9,5 +8,3 @@ namespace platf {
 void print_status(const std::string_view &prefix, HRESULT status);
 HDESK syncThreadDesktop();
 } // namespace platf
-
-#endif

--- a/src/process.h
+++ b/src/process.h
@@ -1,7 +1,4 @@
-// Created by loki on 12/14/19.
-
-#ifndef SUNSHINE_PROCESS_H
-#define SUNSHINE_PROCESS_H
+#pragma once
 
 #ifndef __kernel_entry
 #define __kernel_entry
@@ -111,4 +108,3 @@ std::optional<proc::proc_t> parse(const std::string &file_name);
 
 extern proc_t proc;
 } // namespace proc
-#endif // SUNSHINE_PROCESS_H

--- a/src/round_robin.h
+++ b/src/round_robin.h
@@ -1,5 +1,4 @@
-#ifndef KITTY_UTIL_ITERATOR_H
-#define KITTY_UTIL_ITERATOR_H
+#pragma once
 
 #include <iterator>
 
@@ -152,5 +151,3 @@ round_robin_t<V, It> make_round_robin(It begin, It end) {
   return round_robin_t<V, It>(begin, end);
 }
 } // namespace util
-
-#endif

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -1,7 +1,4 @@
-// Created by loki on 2/2/20.
-
-#ifndef SUNSHINE_RTSP_H
-#define SUNSHINE_RTSP_H
+#pragma once
 
 #include <atomic>
 
@@ -24,5 +21,3 @@ int session_count();
 void rtpThread();
 
 } // namespace stream
-
-#endif // SUNSHINE_RTSP_H

--- a/src/stream.h
+++ b/src/stream.h
@@ -1,7 +1,4 @@
-// Created by loki on 6/5/19.
-
-#ifndef SUNSHINE_STREAM_H
-#define SUNSHINE_STREAM_H
+#pragma once
 
 #include <boost/asio.hpp>
 
@@ -44,5 +41,3 @@ void join(session_t &session);
 state_e state(session_t &session);
 } // namespace session
 } // namespace stream
-
-#endif // SUNSHINE_STREAM_H

--- a/src/sync.h
+++ b/src/sync.h
@@ -1,7 +1,4 @@
-// Created by loki on 16-4-19.
-
-#ifndef SUNSHINE_SYNC_H
-#define SUNSHINE_SYNC_H
+#pragma once
 
 #include <array>
 #include <mutex>
@@ -88,6 +85,3 @@ private:
 };
 
 } // namespace util
-
-
-#endif // SUNSHINE_SYNC_H

--- a/src/task_pool.h
+++ b/src/task_pool.h
@@ -1,5 +1,4 @@
-#ifndef KITTY_TASK_POOL_H
-#define KITTY_TASK_POOL_H
+#pragma once
 
 #include <chrono>
 #include <deque>
@@ -242,4 +241,3 @@ private:
   }
 };
 } // namespace util
-#endif

--- a/src/thread_pool.h
+++ b/src/thread_pool.h
@@ -1,5 +1,4 @@
-#ifndef KITTY_THREAD_POOL_H
-#define KITTY_THREAD_POOL_H
+#pragma once
 
 #include "task_pool.h"
 #include <thread>
@@ -118,4 +117,3 @@ public:
   }
 };
 } // namespace util
-#endif

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -1,7 +1,4 @@
-// Created by loki on 6/10/19.
-
-#ifndef SUNSHINE_THREAD_SAFE_H
-#define SUNSHINE_THREAD_SAFE_H
+#pragma once
 
 #include <atomic>
 #include <condition_variable>
@@ -505,5 +502,3 @@ inline void cleanup(mail_raw_t *mail) {
   mail->cleanup();
 }
 } // namespace safe
-
-#endif // SUNSHINE_THREAD_SAFE_H

--- a/src/upnp.h
+++ b/src/upnp.h
@@ -1,10 +1,7 @@
-#ifndef SUNSHINE_UPNP_H
-#define SUNSHINE_UPNP_H
+#pragma once
 
 #include "platform/common.h"
 
 namespace upnp {
 [[nodiscard]] std::unique_ptr<platf::deinit_t> start();
 }
-
-#endif

--- a/src/utility.h
+++ b/src/utility.h
@@ -1,5 +1,4 @@
-#ifndef UTILITY_H
-#define UTILITY_H
+#pragma once
 
 #include <algorithm>
 #include <condition_variable>
@@ -928,4 +927,3 @@ template<class T>
 inline auto big(T x) { return endian_helper<T>::big(x); }
 } // namespace endian
 } // namespace util
-#endif

--- a/src/uuid.h
+++ b/src/uuid.h
@@ -1,7 +1,4 @@
-// Created by loki on 8-2-19.
-
-#ifndef T_MAN_UUID_H
-#define T_MAN_UUID_H
+#pragma once
 
 #include <random>
 
@@ -74,4 +71,3 @@ union uuid_t {
   }
 };
 } // namespace util
-#endif // T_MAN_UUID_H

--- a/src/video.h
+++ b/src/video.h
@@ -1,7 +1,4 @@
-// Created by loki on 6/9/19.
-
-#ifndef SUNSHINE_VIDEO_H
-#define SUNSHINE_VIDEO_H
+#pragma once
 
 #include "input.h"
 #include "platform/common.h"
@@ -91,5 +88,3 @@ void capture(
 
 int init();
 } // namespace video
-
-#endif // SUNSHINE_VIDEO_H


### PR DESCRIPTION
## Description
Simply use `#pragma once` header guards instead of the `ifndef` traditional guards used in most of the source. Since the files have been shuffled around + renamed through the years, most of them are out of date with the traditional naming scheme. `#pragma once` is succinct, supported by virtually every compiler on earth, and increases readability.

I have an alternate commit that fixes all the current header guards + adds missing ones, but `#pragma once` is so very nice :)

### Screenshot
N/A

### Issues Fixed or Closed
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
