### PR TITLE
Free AVFrame before calling eglTerminate()

### DIFF
--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -386,11 +386,13 @@ public:
   va::display_t::pointer va_display;
   file_t file;
 
-  frame_t hwframe;
-
   gbm::gbm_t gbm;
   egl::display_t display;
   egl::ctx_t ctx;
+
+  // This must be destroyed before display_t to ensure the GPU
+  // driver is still loaded when vaDestroySurfaces() is called.
+  frame_t hwframe;
 
   egl::sws_t sws;
   egl::nv12_t nv12;


### PR DESCRIPTION
## Description
This fixes a EGL/VA-API destruction order issue exposed by my leak fix in #736.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #804
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
