### PR TITLE
changelog: fix parsing issue with single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ to the internet, or have ever uploaded your logs with verbose output to a public
 - (Misc) Rename "Steam BigPicture" to "Steam Big Picture" in default apps.json
 - (Security) Scrub basic authorization header from logs
 - (Linux) The systemd service will now restart in the event of a crash
-- (Video/KMS/Linux) Fixed error: "couldn't import RGB Image: 00003002 and 00003004"
+- (Video/KMS/Linux) Fixed error: `couldn't import RGB Image: 00003002 and 00003004`
 - (Video/Windows) Fix stream freezing triggered by the resolution changed
 - (Installer/Windows) Fixes silent installation and other miscellaneous improvements
 - (CPU) Significantly improved CPU usage


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The changelog parser does not like single quotes inside of double quotes, so replacing double quotes with backticks.

I have tested this locally in ACT and believe it resolves the issue.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
