### PR TITLE
Linux/VAAPI: implement vaSyncBuffer stub for libva <2.9.0

### DIFF
--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -5,6 +5,17 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
+#include <va/va.h>
+#if !VA_CHECK_VERSION(1, 9, 0)
+/* vaSyncBuffer stub allows Sunshine built against libva <2.9.0
+   to link against ffmpeg on libva 2.9.0 or later */
+VAStatus vaSyncBuffer(
+  VADisplay dpy,
+  VABufferID buf_id,
+  uint64_t timeout_ns) {
+  return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+#endif
 }
 
 #include "graphics.h"


### PR DESCRIPTION
## Description
Implement `vaSyncBuffer()` stub for libva <2.9.0, which allows Ubuntu 20.04 builds of Sunshine to be linked against ffmpeg built against libva 2.9.0 or later.

The `vaSyncBuffer()` function is needed for the `async_depth` VAAPI encoder parameter to work correctly, which can reduce latency if GPU drivers support the interface.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
