### PR TITLE
Use xdg-desktop-autostart.target for systemd service.

### DIFF
--- a/sunshine.service.in
+++ b/sunshine.service.in
@@ -2,6 +2,9 @@
 Description=@PROJECT_DESCRIPTION@
 StartLimitIntervalSec=500
 StartLimitBurst=5
+PartOf=graphical-session.target
+Wants=xdg-desktop-autostart.target
+After=xdg-desktop-autostart.target
 
 [Service]
 ExecStart=@SUNSHINE_EXECUTABLE_PATH@
@@ -9,4 +12,4 @@ Restart=on-failure
 RestartSec=5s
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=xdg-desktop-autostart.target


### PR DESCRIPTION
## Description
This fixes an issue where sunshine could randomly start before the window manager on wayland, causing the wm to error with Device or resource busy on the kms/dri device. This would prevent the desktop from running at all, and all you would see is a black screen. This seems to happen on both gnome and plasma when using wayland (I've only tested it on plasma).
The fix is simply to have the sunshine systemd service start after xdg-desktop-autostart.target, which happens when other autostart apps run, and that's always after the window manager is ready.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #334


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
