### PR TITLE
CMake: CPack: use correct Boost dependency versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,10 +789,10 @@ elseif(UNIX)
         set(CPACK_DEB_COMPONENT_INSTALL ON)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                 ${CPACK_DEB_PLATFORM_PACKAGE_DEPENDS} \
-                libboost-filesystem1.67.0 | libboost-filesystem1.71.0 | libboost-filesystem1.74.0, \
-                libboost-log1.67.0 | libboost-log1.71.0 | libboost-log1.74.0, \
-                libboost-program-options1.67.0 | libboost-program-options1.71.0 | libboost-program-options1.74.0, \
-                libboost-thread1.67.0 | libboost-thread1.71.0 | libboost-thread1.74.0, \
+                libboost-filesystem${Boost_VERSION}, \
+                libboost-log${Boost_VERSION}, \
+                libboost-program-options${Boost_VERSION}, \
+                libboost-thread${Boost_VERSION}, \
                 libcap2, \
                 libcurl4, \
                 libdrm2, \
@@ -808,10 +808,10 @@ elseif(UNIX)
                 openssl | libssl3")
         set(CPACK_RPM_PACKAGE_REQUIRES "\
                 ${CPACK_RPM_PLATFORM_PACKAGE_REQUIRES} \
-                boost-filesystem >= 1.67.0, \
-                boost-log >= 1.67.0, \
-                boost-program-options >= 1.67.0, \
-                boost-thread >= 1.67.0, \
+                boost-filesystem >= ${Boost_VERSION}, \
+                boost-log >= ${Boost_VERSION}, \
+                boost-program-options >= ${Boost_VERSION}, \
+                boost-thread >= ${Boost_VERSION}, \
                 libcap >= 2.22, \
                 libcurl >= 7.0, \
                 libdrm >= 2.4.97, \


### PR DESCRIPTION
## Description
CMake: CPack: use correct Boost dependency versions

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Fixes #916

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
