### PR TITLE
Support compiling for earlier releases of macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ elseif(APPLE)
             src/platform/macos/display.mm
             src/platform/macos/input.cpp
             src/platform/macos/microphone.mm
-            src/platform/macos/misc.cpp
+            src/platform/macos/misc.mm
             src/platform/macos/misc.h
             src/platform/macos/nv12_zero_device.cpp
             src/platform/macos/nv12_zero_device.h
@@ -620,6 +620,8 @@ endif()
 
 if(APPLE)
     target_link_options(sunshine PRIVATE LINKER:-sectcreate,__TEXT,__info_plist,${APPLE_PLIST_FILE})
+    # Tell linker to dynamically load these symbols at runtime, in case they're unavailable:
+    target_link_options(sunshine PRIVATE -Wl,-U,_CGPreflightScreenCaptureAccess -Wl,-U,_CGRequestScreenCaptureAccess)
 endif()
 
 foreach(flag IN LISTS SUNSHINE_COMPILE_OPTIONS)

--- a/src/platform/macos/av_audio.m
+++ b/src/platform/macos/av_audio.m
@@ -29,7 +29,6 @@
     return [AVCaptureDevice devicesWithMediaType:AVMediaTypeAudio];
 #pragma clang diagnostic pop
   }
-
 }
 
 + (NSArray<NSString *> *)microphoneNames {

--- a/src/platform/macos/av_audio.m
+++ b/src/platform/macos/av_audio.m
@@ -3,11 +3,33 @@
 @implementation AVAudio
 
 + (NSArray<AVCaptureDevice *> *)microphones {
-  AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInMicrophone,
-    AVCaptureDeviceTypeExternalUnknown]
-                                                                                                             mediaType:AVMediaTypeAudio
-                                                                                                              position:AVCaptureDevicePositionUnspecified];
-  return discoverySession.devices;
+
+  if([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:((NSOperatingSystemVersion) { 10, 15, 0 })]) {
+    // This will generate a warning about AVCaptureDeviceDiscoverySession being
+    // unavailable before macOS 10.15, but we have a guard to prevent it from
+    // being called on those earlier systems.
+    // Unfortunately the supported way to silence this warning, using @available,
+    // produces linker errors for __isPlatformVersionAtLeast, so we have to use
+    // a different method.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInMicrophone,
+      AVCaptureDeviceTypeExternalUnknown]
+                                                                                                               mediaType:AVMediaTypeAudio
+                                                                                                                position:AVCaptureDevicePositionUnspecified];
+    return discoverySession.devices;
+#pragma clang diagnostic pop
+  }
+  else {
+    // We're intentionally using a deprecated API here specifically for versions
+    // of macOS where it's not deprecated, so we can ignore any deprecation
+    // warnings:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [AVCaptureDevice devicesWithMediaType:AVMediaTypeAudio];
+#pragma clang diagnostic pop
+  }
+
 }
 
 + (NSArray<NSString *> *)microphoneNames {


### PR DESCRIPTION
## Description
These changes broaden the macOS versions that Sunshine can be compiled for. There are only a few places in the codebase where a macOS API function that requires macOS 10.15 or later is used, and this PR makes it so that these functions are weakly linked and avoids using them when running in macOS 10.14 and earlier.

The other issue with compiling on macOS 10.14 is that its version of libc++ doesn't support some of the later C++ features used throughout the codebase. However, this can be overcome by compiling with a newer installation of LLVM / clang and statically linking against its copy of libc++.

With the changes in this PR, I was able to get Sunshine to compile for macOS 10.12-10.14 by installing clang 15 using MacPorts (along with Sunshine's other dependencies) and then configuring it with the following `cmake` command:

    export CC=/opt/local/libexec/llvm-15/bin/clang
    export CXX=/opt/local/libexec/llvm-15/bin/clang++
    cmake \
        -DCMAKE_CXX_FLAGS="-nostdinc++ -nostdlib++ -isystem /opt/local/libexec/llvm-15/include/c++/v1 -I /opt/local/include -I /opt/local/libexec/openssl11/include" \
        -DCMAKE_EXE_LINKER_FLAGS="-nostdlib /opt/local/libexec/llvm-15/lib/libc++.a /opt/local/libexec/llvm-15/lib/libc++abi.a /usr/lib/libSystem.dylib" \
        -DBOOST_ROOT=/opt/local/libexec/boost/1.80 \
        -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 \
        /path/to/sunshine

(Note that I had to manually supply to paths for both boost and OpenSSL.)

Even if Sunshine will perform worse in them than the latest macOS releases, I think it's important to support older releases of macOS at least in some capacity (even if it requires the user to compile it themselves) since it's very useful for them to have a fully open source streaming solution, as well as there being a lot of reasons to avoid the newer releases of macOS, including lack of support for older macs, poorer options for customization, Apple's continuing agenda of removing user control, and them just generally being frustratingly buggy.

Personally I'm still running macOS 10.14 and have no intention of updating any time soon, if I can manage it! And I'd still like to use Sunshine if I can.

### Screenshot
N/A


### Issues Fixed or Closed
N/A


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
