### PR TITLE
feat: implemented unicode input mode

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -281,6 +281,7 @@ jobs:
             sudo apt-get update -y
             sudo apt-get install -y \
               libboost-filesystem1.71-dev \
+              libboost-locale1.71-dev \
               libboost-log1.71-dev \
               libboost-regex1.71-dev \
               libboost-thread1.71-dev \
@@ -307,6 +308,7 @@ jobs:
             sudo apt-get install -y \
               cmake \
               libboost-filesystem-dev \
+              libboost-locale-dev \
               libboost-log-dev \
               libboost-thread-dev \
               libboost-program-options-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(WIN32)
     set(Boost_NO_BOOST_CMAKE ON) # cmake-lint: disable=C0103
 endif()
 
-find_package(Boost COMPONENTS log filesystem program_options locale REQUIRED)
+find_package(Boost COMPONENTS locale log filesystem program_options REQUIRED)
 
 list(APPEND SUNSHINE_COMPILE_OPTIONS -Wall -Wno-missing-braces -Wno-maybe-uninitialized -Wno-sign-compare)
 
@@ -790,6 +790,7 @@ elseif(UNIX)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                 ${CPACK_DEB_PLATFORM_PACKAGE_DEPENDS} \
                 libboost-filesystem${Boost_VERSION}, \
+                libboost-locale${Boost_VERSION}, \
                 libboost-log${Boost_VERSION}, \
                 libboost-program-options${Boost_VERSION}, \
                 libboost-thread${Boost_VERSION}, \
@@ -809,6 +810,7 @@ elseif(UNIX)
         set(CPACK_RPM_PACKAGE_REQUIRES "\
                 ${CPACK_RPM_PLATFORM_PACKAGE_REQUIRES} \
                 boost-filesystem >= ${Boost_VERSION}, \
+                boost-locale >= ${Boost_VERSION}, \
                 boost-log >= ${Boost_VERSION}, \
                 boost-program-options >= ${Boost_VERSION}, \
                 boost-thread >= ${Boost_VERSION}, \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(WIN32)
     set(Boost_NO_BOOST_CMAKE ON) # cmake-lint: disable=C0103
 endif()
 
-find_package(Boost COMPONENTS log filesystem program_options REQUIRED)
+find_package(Boost COMPONENTS log filesystem program_options locale REQUIRED)
 
 list(APPEND SUNSHINE_COMPILE_OPTIONS -Wall -Wno-missing-braces -Wno-maybe-uninitialized -Wno-sign-compare)
 

--- a/docker/debian-bullseye.dockerfile
+++ b/docker/debian-bullseye.dockerfile
@@ -25,6 +25,7 @@ apt-get install -y --no-install-recommends \
   cmake=3.18.4* \
   libavdevice-dev=7:4.3.* \
   libboost-filesystem-dev=1.74.0* \
+  libboost-locale-dev=1.74.0* \
   libboost-log-dev=1.74.0* \
   libboost-program-options-dev=1.74.0* \
   libboost-thread-dev=1.74.0* \

--- a/docker/ubuntu-20.04.dockerfile
+++ b/docker/ubuntu-20.04.dockerfile
@@ -26,6 +26,7 @@ apt-get install -y --no-install-recommends \
   g++-10=10.3.0* \
   libavdevice-dev=7:4.2.* \
   libboost-filesystem-dev=1.71.0* \
+  libboost-locale-dev=1.71.0* \
   libboost-log-dev=1.71.0* \
   libboost-program-options-dev=1.71.0* \
   libboost-thread-dev=1.71.0* \

--- a/docker/ubuntu-22.04.dockerfile
+++ b/docker/ubuntu-22.04.dockerfile
@@ -25,6 +25,7 @@ apt-get install -y --no-install-recommends \
   cmake=3.22.1* \
   libavdevice-dev=7:4.4.* \
   libboost-filesystem-dev=1.74.0* \
+  libboost-locale-dev=1.74.0* \
   libboost-log-dev=1.74.0* \
   libboost-program-options-dev=1.74.0* \
   libboost-thread-dev=1.74.0* \

--- a/docs/source/building/linux.rst
+++ b/docs/source/building/linux.rst
@@ -16,6 +16,7 @@ Install Requirements
           cmake \
           libavdevice-dev \
           libboost-filesystem-dev \
+          libboost-locale-dev \
           libboost-log-dev \
           libboost-program-options-dev \
           libboost-thread-dev \

--- a/docs/source/building/linux.rst
+++ b/docs/source/building/linux.rst
@@ -96,6 +96,7 @@ Install Requirements
           g++-10 \
           libavdevice-dev \
           libboost-filesystem-dev \
+          libboost-locale-dev \
           libboost-log-dev \
           libboost-thread-dev \
           libboost-program-options-dev \
@@ -143,6 +144,7 @@ Install Requirements
           cmake \
           libavdevice-dev \
           libboost-filesystem-dev \
+          libboost-locale-dev \
           libboost-log-dev \
           libboost-thread-dev \
           libboost-program-options-dev \

--- a/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
+++ b/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
@@ -33,7 +33,7 @@ modules:
     buildsystem: simple
     build-commands:
       - cd tools/build && bison -y -d -o src/engine/jamgram.cpp src/engine/jamgram.y
-      - ./bootstrap.sh --prefix=$FLATPAK_DEST --with-libraries=system,thread,log,program_options || cat bootstrap.log
+      - ./bootstrap.sh --prefix=$FLATPAK_DEST --with-libraries=locale,log,program_options,system,thread
       - ./b2 install variant=release link=shared runtime-link=shared cxxflags="$CXXFLAGS" linkflags="$LDFLAGS"
         -j $FLATPAK_BUILDER_N_JOBS
     sources:


### PR DESCRIPTION
## Description

This PR adds Unicode support for remote pasting in Linux using [Unicode input mode](https://en.wikipedia.org/wiki/Unicode_input).  

I've read around and this might not be supported on all combinations of DE, for example see: [kde#103788](https://bugs.kde.org/show_bug.cgi?id=103788) it works fine on my machine but maybe some Linux wizard can find a better solution.

I've introduced another Boost dependency: [Boost.locale](https://www.boost.org/doc/libs/1_81_0/libs/locale/doc/html/index.html) I've added it as a dependency where I could find it, but feel free to modify the PR if I've missed some.

### Issues Fixed or Closed
Fixes #760


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
