### PR TITLE
github: move feature requests to moonlight board

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,5 +9,5 @@ contact_links:
     url: https://app.lizardbyte.dev/support
     about: Official LizardByte support
   - name: Feature request
-    url: https://app.lizardbyte.dev/feedback
-    about: Share your suggestions or ideas to help us improve
+    url: https://ideas.moonlight-stream.org
+    about: Share your suggestions or ideas to help Moonlight and Sunshine improve


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Move feature requests to Moonlight request board.

Todo:
- [ ] exclude Sunshine from global replicator https://github.com/LizardByte/.github/blob/e01a23ddeb0ffed92b9be3d245e27f7674663d54/.github/workflows/global-replicator.yml#L88


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
