### PR TITLE
windows: input: activate US keyboard layout for scancode mapping

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -177,6 +177,7 @@ struct input_raw_t {
 
   vigem_t *vigem;
   HKL keyboard_layout;
+  HKL active_layout;
 };
 
 input_t input() {
@@ -194,6 +195,13 @@ input_t input() {
   raw.keyboard_layout = LoadKeyboardLayoutA("00000409", 0);
   if(!raw.keyboard_layout || LOWORD(raw.keyboard_layout) != 0x409) {
     BOOST_LOG(warning) << "Unable to load US English keyboard layout for scancode translation. Keyboard input may not work in games."sv;
+    raw.keyboard_layout = NULL;
+  }
+
+  // Activate layout for current process only
+  raw.active_layout = ActivateKeyboardLayout(raw.keyboard_layout, KLF_SETFORPROCESS);
+  if(!raw.active_layout) {
+    BOOST_LOG(warning) << "Unable to activate US English keyboard layout for scancode translation. Keyboard input may not work in games."sv;
     raw.keyboard_layout = NULL;
   }
 


### PR DESCRIPTION
## Description
When installed as a service, scancode mapping for non-US keyboards will not work correctly on first boot if the user's Windows installation does not have the English (US) language & keyboard installed as a fallback, and/or the installation is configured to automatically log in.

On first boot, Sunshine does not translate the international keys correctly, and modifier keys such as ctrl/alt/shift will appear stuck after first press (which can be visually confirmed via the On-Screen Keyboard application). Restarting Sunshine after the desktop session has loaded fixes mapping on subsequent connections, indicating that the US locale is loaded but isn't activated correctly in Sunshine when the desktop session is not yet loaded.

This can be fixed by invoking `ActivateKeyboardLayout()` (scoped to Sunshine's process) after loading the US locale.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
