### PR TITLE
Add support for global prep commands

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -107,6 +107,20 @@ log_path
 
       log_path = sunshine.log
 
+global_prep_cmd
+^^^^^^^^^^^^^^^
+
+**Description**
+   A list of commands to be run before/after all applications. If any of the prep-commands fail, starting the application is aborted.
+
+**Default**
+   ``[]``
+
+**Example**
+   .. code-block:: text
+
+      global_prep_cmd = [{"do":"nircmd.exe setdisplay 1280 720 32 144","undo":"nircmd.exe setdisplay 2560 1440 32 144"}]
+
 Controls
 --------
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -426,8 +426,8 @@ sunshine_t sunshine {
   platf::appdata().string() + "/sunshine.conf", // config file
   {},                                           // cmd args
   47989,
-  platf::appdata().string() + "/sunshine.log", // log file,
-  {}
+  platf::appdata().string() + "/sunshine.log",  // log file
+  {},                                           // prep commands
 };
 
 bool endline(char ch) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -428,8 +428,8 @@ sunshine_t sunshine {
   platf::appdata().string() + "/sunshine.conf", // config file
   {},                                           // cmd args
   47989,
-  platf::appdata().string() + "/sunshine.log",  // log file
-  {},                                           // prep commands
+  platf::appdata().string() + "/sunshine.log", // log file
+  {},                                          // prep commands
 };
 
 bool endline(char ch) {
@@ -768,7 +768,7 @@ void list_prep_cmd_f(std::unordered_map<std::string, std::string> &vars, const s
   string_f(vars, name, string);
 
   std::stringstream jsonStream;
-  
+
   // We need to add a wrapping object to make it valid JSON, otherwise ptree cannot parse it.
   jsonStream << "{\"prep_cmd\":" << string << "}";
 
@@ -776,13 +776,12 @@ void list_prep_cmd_f(std::unordered_map<std::string, std::string> &vars, const s
   boost::property_tree::read_json(jsonStream, jsonTree);
 
   for(auto &[_, prep_cmd] : jsonTree.get_child("prep_cmd"s)) {
-    auto do_cmd = prep_cmd.get<std::string>("do"s);
+    auto do_cmd   = prep_cmd.get<std::string>("do"s);
     auto undo_cmd = prep_cmd.get<std::string>("undo"s);
     
     input.emplace_back(
       std::move(do_cmd),
-      std::move(undo_cmd)
-    );
+      std::move(undo_cmd));
   }
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -778,7 +778,7 @@ void list_prep_cmd_f(std::unordered_map<std::string, std::string> &vars, const s
   for(auto &[_, prep_cmd] : jsonTree.get_child("prep_cmd"s)) {
     auto do_cmd   = prep_cmd.get<std::string>("do"s);
     auto undo_cmd = prep_cmd.get<std::string>("undo"s);
-    
+
     input.emplace_back(
       std::move(do_cmd),
       std::move(undo_cmd));

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/asio.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/json.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 

--- a/src/config.h
+++ b/src/config.h
@@ -118,6 +118,13 @@ enum flag_e : std::size_t {
 };
 }
 
+struct prep_cmd_t {
+  prep_cmd_t(std::string &&do_cmd, std::string &&undo_cmd) : do_cmd(std::move(do_cmd)), undo_cmd(std::move(undo_cmd)) {}
+  explicit prep_cmd_t(std::string &&do_cmd) : do_cmd(std::move(do_cmd)) {}
+  std::string do_cmd;
+  std::string undo_cmd;
+};
+
 struct sunshine_t {
   int min_log_level;
   std::bitset<flag::FLAG_SIZE> flags;
@@ -137,6 +144,8 @@ struct sunshine_t {
 
   std::uint16_t port;
   std::string log_file;
+  
+  std::vector<prep_cmd_t> prep_cmds;
 };
 
 extern video_t video;

--- a/src/config.h
+++ b/src/config.h
@@ -144,7 +144,7 @@ struct sunshine_t {
 
   std::uint16_t port;
   std::string log_file;
-  
+
   std::vector<prep_cmd_t> prep_cmds;
 };
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -489,6 +489,45 @@ void uploadCover(resp_https_t response, req_https_t request) {
   outputTree.put("path", path);
 }
 
+void savePrepCmd(resp_https_t response, req_https_t request) {
+  if(!authenticate(response, request)) return;
+
+  print_req(request);
+
+  std::stringstream ss;
+  ss << request->content.rdbuf();
+
+  pt::ptree outputTree;
+  auto g = util::fail_guard([&]() {
+    std::ostringstream data;
+
+    pt::write_json(data, outputTree);
+    response->write(data.str());
+  });
+
+  pt::ptree inputTree, fileTree;
+
+  BOOST_LOG(fatal) << config::stream.file_apps;
+  try {
+    pt::read_json(ss, inputTree);
+    pt::read_json(config::stream.file_apps, fileTree);
+    fileTree.erase("global-prep-cmd");
+    fileTree.push_back(std::make_pair("global-prep-cmd", inputTree));
+    pt::write_json(config::stream.file_apps, fileTree);
+  }
+  catch(std::exception &e) {
+    BOOST_LOG(warning) << "saveGlobalPrepCmd: "sv << e.what();
+
+    outputTree.put("status", "false");
+    outputTree.put("error", "Invalid Input JSON");
+    return;
+  }
+
+  outputTree.put("status", "true");
+  proc::refresh(config::stream.file_apps);
+}
+
+
 void getConfig(resp_https_t response, req_https_t request) {
   if(!authenticate(response, request)) return;
 
@@ -719,6 +758,7 @@ void start() {
   server.resource["^/api/apps$"]["GET"]                    = getApps;
   server.resource["^/api/logs$"]["GET"]                    = getLogs;
   server.resource["^/api/apps$"]["POST"]                   = saveApp;
+  server.resource["^/api/apps/prep$"]["POST"]              = savePrepCmd;
   server.resource["^/api/config$"]["GET"]                  = getConfig;
   server.resource["^/api/config$"]["POST"]                 = saveConfig;
   server.resource["^/api/restart$"]["POST"]                = restart;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -18,11 +18,11 @@
 #include <openssl/evp.h>
 #include <openssl/sha.h>
 
+#include "config.h"
 #include "crypto.h"
 #include "main.h"
 #include "platform/common.h"
 #include "utility.h"
-#include "config.h"
 
 #ifdef _WIN32
 // _SH constants for _wfsopen()
@@ -465,7 +465,7 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
       auto working_dir         = app_node.get_optional<std::string>("working-dir"s);
 
       std::vector<proc::cmd_t> prep_cmds;
-      if (!exclude_global_prep.value_or(false)) {
+      if(!exclude_global_prep.value_or(false)) {
         prep_cmds.reserve(config::sunshine.prep_cmds.size());
         for(auto &prep_cmd : config::sunshine.prep_cmds) {
           auto do_cmd   = parse_env_val(this_env, prep_cmd.do_cmd);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -124,7 +124,7 @@ int proc_t::execute(int app_id) {
   });
 
   // Execute global prep commands if enabled
-  if (_app.include_global_prep)
+  if (!_app.exclude_global_prep)
   {
     for(; _global_prep_it != std::end(_prep_cmds); ++_global_prep_it) {
       auto &cmd = _global_prep_it->do_cmd;
@@ -258,7 +258,7 @@ void proc_t::terminate() {
   }
   
   // Execute global prep commands if enabled
-  if (_app.include_global_prep)
+  if (!_app.exclude_global_prep)
   {
     for(; _global_prep_it != _global_prep_begin; --_global_prep_it) {
       auto &cmd = (_global_prep_it - 1)->undo_cmd;
@@ -539,7 +539,7 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
 
       auto prep_nodes_opt      = app_node.get_child_optional("prep-cmd"s);
       auto detached_nodes_opt  = app_node.get_child_optional("detached"s);
-      auto include_global_prep = app_node.get_optional<bool>("include-global-prep-cmd"s);
+      auto exclude_global_prep = app_node.get_optional<bool>("exclude-global-prep-cmd"s);
       auto output              = app_node.get_optional<std::string>("output"s);
       auto name                = parse_env_val(this_env, app_node.get<std::string>("name"s));
       auto cmd                 = app_node.get_optional<std::string>("cmd"s);
@@ -590,8 +590,8 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
         ctx.image_path = parse_env_val(this_env, *image_path);
       }
 
-      if(include_global_prep) {
-        ctx.include_global_prep = *include_global_prep;
+      if(exclude_global_prep) {
+        ctx.exclude_global_prep = *exclude_global_prep;
       }
 
       auto possible_ids = calculate_app_id(name, ctx.image_path, i++);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -218,7 +218,7 @@ void proc_t::terminate() {
     if(ec) {
       BOOST_LOG(warning) << "System: "sv << ec.message();
     }
-    
+
     if(ret != 0) {
       BOOST_LOG(warning) << "Return code ["sv << ret << ']';
     }
@@ -440,8 +440,8 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
   try {
     pt::read_json(file_name, tree);
 
-    auto &apps_node            = tree.get_child("apps"s);
-    auto &env_vars             = tree.get_child("env"s);
+    auto &apps_node = tree.get_child("apps"s);
+    auto &env_vars  = tree.get_child("env"s);
 
     auto this_env = boost::this_process::environment();
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -531,10 +531,6 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
         ctx.image_path = parse_env_val(this_env, *image_path);
       }
 
-      if(exclude_global_prep) {
-        ctx.exclude_global_prep = *exclude_global_prep;
-      }
-
       auto possible_ids = calculate_app_id(name, ctx.image_path, i++);
       if(ids.count(std::get<0>(possible_ids)) == 0) {
         // Avoid using index to generate id if possible

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -49,6 +49,14 @@ void process_end(bp::child &proc, bp::group &proc_handle) {
   proc.wait();
 }
 
+int exe_with_full_privs(const std::string &cmd, bp::environment &env, file_t &file, std::error_code &ec) {
+  if(!file) {
+    return bp::system(cmd, env, bp::std_out > bp::null, bp::std_err > bp::null, ec);
+  }
+
+  return bp::system(cmd, env, bp::std_out > file.get(), bp::std_err > file.get(), ec);
+}
+
 boost::filesystem::path find_working_directory(const std::string &cmd, bp::environment &env) {
   // Parse the raw command string into parts to get the actual command portion
 #ifdef _WIN32
@@ -80,7 +88,7 @@ boost::filesystem::path find_working_directory(const std::string &cmd, bp::envir
 }
 
 int proc_t::execute(int app_id) {
-  // Ensure starting from a clean slate.
+  // Ensure starting from a clean slate
   terminate();
 
   auto iter = std::find_if(_apps.begin(), _apps.end(), [&app_id](const auto app) {
@@ -92,25 +100,25 @@ int proc_t::execute(int app_id) {
     return 404;
   }
 
-  _app_id = app_id;
-  _app   = *iter;
+  _app_id    = app_id;
+  auto &proc = *iter;
 
-  _app_prep_begin = std::begin(_app.prep_cmds);
-  _app_prep_it    = _app_prep_begin;
+  _undo_begin = std::begin(proc.prep_cmds);
+  _undo_it    = _undo_begin;
 
-  if(!_app.output.empty() && _app.output != "null"sv) {
+  if(!proc.output.empty() && proc.output != "null"sv) {
 #ifdef _WIN32
     // fopen() interprets the filename as an ANSI string on Windows, so we must convert it
     // to UTF-16 and use the wchar_t variants for proper Unicode log file path support.
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
-    auto woutput = converter.from_bytes(_app.output);
+    auto woutput = converter.from_bytes(proc.output);
 
     // Use _SH_DENYNO to allow us to open this log file again for writing even if it is
     // still open from a previous execution. This is required to handle the case of a
     // detached process executing again while the previous process is still running.
     _pipe.reset(_wfsopen(woutput.c_str(), L"a", _SH_DENYNO));
 #else
-    _pipe.reset(fopen(_app.output.c_str(), "a"));
+    _pipe.reset(fopen(proc.output.c_str(), "a"));
 #endif
   }
 
@@ -120,23 +128,16 @@ int proc_t::execute(int app_id) {
     terminate();
   });
 
-  // Execute app prep commands                 
-  for(; _app_prep_it != std::end(_app.prep_cmds); ++_app_prep_it) {
-    auto &cmd = _app_prep_it->do_cmd;
+  for(; _undo_it != std::end(proc.prep_cmds); ++_undo_it) {
+    auto &cmd = _undo_it->do_cmd;
 
-    boost::filesystem::path working_dir = _app.working_dir.empty() ?
-                                            find_working_directory(cmd, _env) :
-                                            boost::filesystem::path(_app.working_dir);
-    BOOST_LOG(info) << "Executing Do Cmd: ["sv << cmd << ']';
-    auto child = platf::run_unprivileged(cmd, working_dir, _env, _pipe.get(), ec, nullptr);
+    BOOST_LOG(info) << "Executing: ["sv << cmd << ']';
+    auto ret = exe_with_full_privs(cmd, _env, _pipe, ec);
 
     if(ec) {
       BOOST_LOG(error) << "Couldn't run ["sv << cmd << "]: System: "sv << ec.message();
       return -1;
     }
-
-    child.wait();
-    auto ret = child.exit_code();
 
     if(ret != 0) {
       BOOST_LOG(error) << '[' << cmd << "] failed with code ["sv << ret << ']';
@@ -144,10 +145,10 @@ int proc_t::execute(int app_id) {
     }
   }
 
-  for(auto &cmd : _app.detached) {
-    boost::filesystem::path working_dir = _app.working_dir.empty() ?
+  for(auto &cmd : proc.detached) {
+    boost::filesystem::path working_dir = proc.working_dir.empty() ?
                                             find_working_directory(cmd, _env) :
-                                            boost::filesystem::path(_app.working_dir);
+                                            boost::filesystem::path(proc.working_dir);
     BOOST_LOG(info) << "Spawning ["sv << cmd << "] in ["sv << working_dir << ']';
     auto child = platf::run_unprivileged(cmd, working_dir, _env, _pipe.get(), ec, nullptr);
     if(ec) {
@@ -158,18 +159,18 @@ int proc_t::execute(int app_id) {
     }
   }
 
-  if(_app.cmd.empty()) {
+  if(proc.cmd.empty()) {
     BOOST_LOG(info) << "Executing [Desktop]"sv;
     placebo = true;
   }
   else {
-    boost::filesystem::path working_dir = _app.working_dir.empty() ?
-                                            find_working_directory(_app.cmd, _env) :
-                                            boost::filesystem::path(_app.working_dir);
-    BOOST_LOG(info) << "Executing: ["sv << _app.cmd << "] in ["sv << working_dir << ']';
-    _process = platf::run_unprivileged(_app.cmd, working_dir, _env, _pipe.get(), ec, &_process_handle);
+    boost::filesystem::path working_dir = proc.working_dir.empty() ?
+                                            find_working_directory(proc.cmd, _env) :
+                                            boost::filesystem::path(proc.working_dir);
+    BOOST_LOG(info) << "Executing: ["sv << proc.cmd << "] in ["sv << working_dir << ']';
+    _process = platf::run_unprivileged(proc.cmd, working_dir, _env, _pipe.get(), ec, &_process_handle);
     if(ec) {
-      BOOST_LOG(warning) << "Couldn't run ["sv << _app.cmd << "]: System: "sv << ec.message();
+      BOOST_LOG(warning) << "Couldn't run ["sv << proc.cmd << "]: System: "sv << ec.message();
       return -1;
     }
   }
@@ -202,26 +203,21 @@ void proc_t::terminate() {
   _process_handle = bp::group();
   _app_id         = -1;
 
-  for(; _app_prep_it != _app_prep_begin; --_app_prep_it) {
-    auto &cmd = (_app_prep_it - 1)->undo_cmd;
+  for(; _undo_it != _undo_begin; --_undo_it) {
+    auto &cmd = (_undo_it - 1)->undo_cmd;
 
     if(cmd.empty()) {
       continue;
     }
 
-    boost::filesystem::path working_dir = _app.working_dir.empty() ?
-                                            find_working_directory(cmd, _env) :
-                                            boost::filesystem::path(_app.working_dir);
-    BOOST_LOG(info) << "Executing Undo Cmd: ["sv << cmd << ']';
-    auto child = platf::run_unprivileged(cmd, working_dir, _env, _pipe.get(), ec, nullptr);
+    BOOST_LOG(info) << "Executing: ["sv << cmd << ']';
+
+    auto ret = exe_with_full_privs(cmd, _env, _pipe, ec);
 
     if(ec) {
       BOOST_LOG(warning) << "System: "sv << ec.message();
     }
     
-    child.wait();    
-    auto ret = child.exit_code();
-
     if(ret != 0) {
       BOOST_LOG(warning) << "Return code ["sv << ret << ']';
     }
@@ -452,8 +448,6 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
     for(auto &[name, val] : env_vars) {
       this_env[name] = parse_env_val(this_env, val.get_value<std::string>());
     }
-
-    
 
     std::set<std::string> ids;
     std::vector<proc::ctx_t> apps;

--- a/src/process.h
+++ b/src/process.h
@@ -39,8 +39,6 @@ struct cmd_t {
  *    filename -- The output of the commands are appended to filename
  */
 struct ctx_t {
-  ctx_t() : include_global_prep(true) {}
-
   std::vector<cmd_t> prep_cmds;
 
   /**
@@ -57,7 +55,7 @@ struct ctx_t {
   std::string output;
   std::string image_path;
   std::string id;
-  bool include_global_prep;
+  bool exclude_global_prep;
 };
 
 class proc_t {

--- a/src/process.h
+++ b/src/process.h
@@ -64,11 +64,9 @@ public:
 
   proc_t(
     boost::process::environment &&env,
-    std::vector<ctx_t> &&apps,
-    std::vector<proc::cmd_t> &&prep_cmds) : _app_id(0),
+    std::vector<ctx_t> &&apps) : _app_id(0),
                                  _env(std::move(env)),
-                                 _apps(std::move(apps)),
-                                 _prep_cmds(std::move(prep_cmds)) {}
+                                 _apps(std::move(apps)) {}
 
   int execute(int app_id);
 
@@ -91,7 +89,6 @@ private:
   boost::process::environment _env;
   std::vector<ctx_t> _apps;
   ctx_t _app;
-  std::vector<proc::cmd_t> _prep_cmds;
 
   // If no command associated with _app_id, yet it's still running
   bool placebo {};
@@ -102,8 +99,6 @@ private:
   file_t _pipe;
   std::vector<cmd_t>::const_iterator _app_prep_it;
   std::vector<cmd_t>::const_iterator _app_prep_begin;
-  std::vector<cmd_t>::const_iterator _global_prep_it;
-  std::vector<cmd_t>::const_iterator _global_prep_begin;
 };
 
 /**

--- a/src/process.h
+++ b/src/process.h
@@ -13,19 +13,12 @@
 #include <boost/process.hpp>
 
 #include "utility.h"
+#include "config.h"
 
 namespace proc {
 using file_t = util::safe_ptr_v2<FILE, int, fclose>;
 
-struct cmd_t {
-  cmd_t(std::string &&do_cmd, std::string &&undo_cmd) : do_cmd(std::move(do_cmd)), undo_cmd(std::move(undo_cmd)) {}
-  explicit cmd_t(std::string &&do_cmd) : do_cmd(std::move(do_cmd)) {}
-
-  std::string do_cmd;
-
-  // Executed when proc_t has finished running, meant to reverse 'do_cmd' if applicable
-  std::string undo_cmd;
-};
+typedef config::prep_cmd_t cmd_t;
 /*
  * pre_cmds -- guaranteed to be executed unless any of the commands fail.
  * detached -- commands detached from Sunshine

--- a/src/process.h
+++ b/src/process.h
@@ -87,7 +87,6 @@ private:
 
   boost::process::environment _env;
   std::vector<ctx_t> _apps;
-  ctx_t _app;
 
   // If no command associated with _app_id, yet it's still running
   bool placebo {};
@@ -96,8 +95,8 @@ private:
   boost::process::group _process_handle;
 
   file_t _pipe;
-  std::vector<cmd_t>::const_iterator _app_prep_it;
-  std::vector<cmd_t>::const_iterator _app_prep_begin;
+  std::vector<cmd_t>::const_iterator _undo_it;
+  std::vector<cmd_t>::const_iterator _undo_begin;
 };
 
 /**

--- a/src/process.h
+++ b/src/process.h
@@ -55,7 +55,6 @@ struct ctx_t {
   std::string output;
   std::string image_path;
   std::string id;
-  bool exclude_global_prep;
 };
 
 class proc_t {

--- a/src/process.h
+++ b/src/process.h
@@ -12,8 +12,8 @@
 
 #include <boost/process.hpp>
 
-#include "utility.h"
 #include "config.h"
+#include "utility.h"
 
 namespace proc {
 using file_t = util::safe_ptr_v2<FILE, int, fclose>;

--- a/src/process.h
+++ b/src/process.h
@@ -39,6 +39,8 @@ struct cmd_t {
  *    filename -- The output of the commands are appended to filename
  */
 struct ctx_t {
+  ctx_t() : include_global_prep(true) {}
+
   std::vector<cmd_t> prep_cmds;
 
   /**
@@ -55,6 +57,7 @@ struct ctx_t {
   std::string output;
   std::string image_path;
   std::string id;
+  bool include_global_prep;
 };
 
 class proc_t {
@@ -63,9 +66,11 @@ public:
 
   proc_t(
     boost::process::environment &&env,
-    std::vector<ctx_t> &&apps) : _app_id(0),
+    std::vector<ctx_t> &&apps,
+    std::vector<proc::cmd_t> &&prep_cmds) : _app_id(0),
                                  _env(std::move(env)),
-                                 _apps(std::move(apps)) {}
+                                 _apps(std::move(apps)),
+                                 _prep_cmds(std::move(prep_cmds)) {}
 
   int execute(int app_id);
 
@@ -87,6 +92,8 @@ private:
 
   boost::process::environment _env;
   std::vector<ctx_t> _apps;
+  ctx_t _app;
+  std::vector<proc::cmd_t> _prep_cmds;
 
   // If no command associated with _app_id, yet it's still running
   bool placebo {};
@@ -95,8 +102,10 @@ private:
   boost::process::group _process_handle;
 
   file_t _pipe;
-  std::vector<cmd_t>::const_iterator _undo_it;
-  std::vector<cmd_t>::const_iterator _undo_begin;
+  std::vector<cmd_t>::const_iterator _app_prep_it;
+  std::vector<cmd_t>::const_iterator _app_prep_begin;
+  std::vector<cmd_t>::const_iterator _global_prep_it;
+  std::vector<cmd_t>::const_iterator _global_prep_begin;
 };
 
 /**

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -3,73 +3,271 @@
     <h1>Applications</h1>
     <div>Applications are refreshed only when Client is restarted</div>
   </div>
-  <div class="card p-4">
-    <table class="table">
-      <thead>
-        <tr>
-          <th scope="col">Name</th>
-          <th scope="col">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="(app,i) in apps" :key="i">
-          <td>{{app.name}}</td>
-          <td>
-            <button class="btn btn-primary" @click="editApp(i)">Edit</button>
-            <button class="btn btn-danger" @click="showDeleteForm(i)">
-              Delete
+  <div class="form">
+    <!--Header-->
+    <ul class="nav nav-tabs">
+      <li class="nav-item" v-for="tab in tabs" :key="tab.id">
+        <a
+          class="nav-link"
+          :class="{'active': tab.id === currentTab}"
+          href="#"
+          @click="currentTab = tab.id"
+          >{{tab.name}}</a
+        >
+      </li>
+    </ul>
+    <!--Applications Tab-->
+    <div v-if="currentTab === 'apps'" class="config-page">
+      <div class="card p-4">
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(app,i) in apps" :key="i">
+              <td>{{app.name}}</td>
+              <td>
+                <button class="btn btn-primary" @click="editApp(i)">Edit</button>
+                <button class="btn btn-danger" @click="showDeleteForm(i)">
+                  Delete
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="edit-form card mt-2" v-if="showEditForm">
+        <div class="p-4">
+          <!--name-->
+          <div class="mb-3">
+            <label for="appName" class="form-label">Application Name</label>
+            <input
+              type="text"
+              class="form-control"
+              id="appName"
+              aria-describedby="appNameHelp"
+              v-model="editForm.name"
+            />
+            <div id="appNameHelp" class="form-text">
+              Application Name, as shown on Moonlight
+            </div>
+          </div>
+          <!--output-->
+          <div class="mb-3">
+            <label for="appOutput" class="form-label">Output</label>
+            <input
+              type="text"
+              class="form-control monospace"
+              id="appOutput"
+              aria-describedby="appOutputHelp"
+              v-model="editForm.output"
+            />
+            <div id="appOutputHelp" class="form-text">
+              The file where the output of the command is stored, if it is not
+              specified, the output is ignored
+            </div>
+          </div>
+          <!--prep-cmd-->
+          <div class="mb-3 d-flex flex-column">
+            <div class="mb-3">
+              <label for="includeGlobalPrep" class="form-label">Global Prep Commands</label>
+              <select id="includeGlobalPrep" class="form-select" v-model="editForm['include-global-prep-cmd']">
+                <option v-for="val in [true, false]" :value="val">{{ val ? 'Enabled' : 'Disabled' }}</option>
+              </select>
+              <div class="form-text">
+                Enable/Disable the execution of Global Prep Commands for this application.
+              </div>
+            </div>
+            <label for="appName" class="form-label">Command Preparations</label>
+            <div class="form-text">
+              A list of commands to be run before/after this application. <br />
+              If any of the prep-commands fail, starting the application is aborted
+            </div>
+            <table v-if="editForm['prep-cmd'].length > 0">
+              <thead>
+                <th class="precmd-head">Do</th>
+                <th class="precmd-head">Undo</th>
+                <th style="width: 48px"></th>
+              </thead>
+              <tbody>
+                <tr v-for="(c,i) in editForm['prep-cmd']">
+                  <td>
+                    <input
+                      type="text"
+                      class="form-control monospace"
+                      v-model="c.do"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      class="form-control monospace"
+                      v-model="c.undo"
+                    />
+                  </td>
+                  <td>
+                    <button
+                      class="btn btn-danger"
+                      @click="editForm['prep-cmd'].splice(i,1)"
+                    >
+                      &times;
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <button
+              class="mt-2 btn btn-success"
+              style="margin: 0 auto"
+              @click="addPrepCmd"
+            >
+              &plus; Add
             </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="edit-form card mt-2" v-if="showEditForm">
-    <div class="p-4">
-      <!--name-->
-      <div class="mb-3">
-        <label for="appName" class="form-label">Application Name</label>
-        <input
-          type="text"
-          class="form-control"
-          id="appName"
-          aria-describedby="appNameHelp"
-          v-model="editForm.name"
-        />
-        <div id="appNameHelp" class="form-text">
-          Application Name, as shown on Moonlight
+          </div>
+          <!--detatched-->
+          <div class="mb-3">
+            <label for="appName" class="form-label">Detached Commands</label>
+            <div
+              v-for="(c,i) in editForm.detached"
+              class="d-flex justify-content-between my-2"
+            >
+              <pre>{{c}}</pre>
+              <button
+                class="btn btn-danger mx-2"
+                @click="editForm.detached.splice(i,1)"
+              >
+                &times;
+              </button>
+            </div>
+            <div class="d-flex justify-content-between">
+              <input
+                type="text"
+                class="form-control monospace"
+                v-model="detachedCmd"
+              />
+              <button
+                class="btn btn-success mx-2"
+                @click="editForm.detached.push(detachedCmd);detachedCmd = '';"
+              >
+                +
+              </button>
+            </div>
+            <div class="form-text">
+              A list of commands to be run and forgotten about
+            </div>
+          </div>
+          <!--command-->
+          <div class="mb-3">
+            <label for="appCmd" class="form-label">Command</label>
+            <input
+              type="text"
+              class="form-control monospace"
+              id="appCmd"
+              aria-describedby="appCmdHelp"
+              v-model="editForm.cmd"
+            />
+            <div id="appCmdHelp" class="form-text">
+              The main application, if it is not specified, a processs is started
+              that sleeps indefinitely
+            </div>
+          </div>
+          <!--working dir-->
+          <div class="mb-3">
+            <label for="appWorkingDir" class="form-label">Working Directory</label>
+            <input
+              type="text"
+              class="form-control monospace"
+              id="appWorkingDir"
+              aria-describedby="appWorkingDirHelp"
+              v-model="editForm['working-dir']"
+            />
+            <div id="appWorkingDirHelp" class="form-text">
+              The working directory that should be passed to the process.
+              For example, some applications use the working directory to search for configuration files.
+              If not set, Sunshine will default to the parent directory of the command
+            </div>
+          </div>
+          <!-- Image path -->
+          <div class="mb-3">
+            <label for="appImagePath" class="form-label">Image</label>
+            <div class="input-group dropup">
+              <input
+                  type="text"
+                  class="form-control monospace"
+                  id="appImagePath"
+                  aria-describedby="appImagePathHelp"
+                  v-model="editForm['image-path']"
+              />
+              <button class="btn btn-secondary dropdown-toggle" type="button" id="findCoverToggle" data-bs-toggle="dropdown"
+                      data-bs-auto-close="outside" aria-expanded="false" v-dropdown-show="showCoverFinder"
+                      ref="coverFinderDropdown">
+                Find Cover
+              </button>
+              <div class="dropdown-menu dropdown-menu-end w-50 cover-finder overflow-hidden"
+                  aria-labelledby="findCoverToggle">
+                <div class="modal-header">
+                  <h4 class="modal-title">Covers Found</h4>
+                  <button type="button" class="btn-close" aria-label="Close" @click="closeCoverFinder"></button>
+                </div>
+                <div class="modal-body cover-results px-3 pt-3" :class="{ busy: coverFinderBusy }">
+                  <div class="row">
+                    <div v-if="coverSearching" class="col-12 col-sm-6 col-lg-4 mb-3">
+                      <div class="cover-container">
+                        <div class="spinner-border" role="status">
+                          <span class="visually-hidden">Loading...</span>
+                        </div>
+                      </div>
+                    </div>
+                    <div v-for="(cover,i) in coverCandidates" :key="i" class="col-12 col-sm-6 col-lg-4 mb-3"
+                        @click="useCover(cover)">
+                      <div class="cover-container result">
+                        <img class="rounded" :src="cover.url"/>
+                      </div>
+                      <label class="d-block text-nowrap text-center text-truncate">
+                        {{cover.name}}
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div id="appImagePathHelp" class="form-text">
+              Application icon/picture/image path that will be sent to client. Image must be a PNG file.
+              If not set, Sunshine will send default box image.
+            </div>
+          </div>
+          <!--buttons-->
+          <div class="d-flex">
+            <button @click="showEditForm = false" class="btn btn-secondary m-2">
+              Cancel
+            </button>
+            <button class="btn btn-primary m-2" @click="save">Save</button>
+          </div>
         </div>
       </div>
-      <!--output-->
-      <div class="mb-3">
-        <label for="appOutput" class="form-label">Output</label>
-        <input
-          type="text"
-          class="form-control monospace"
-          id="appOutput"
-          aria-describedby="appOutputHelp"
-          v-model="editForm.output"
-        />
-        <div id="appOutputHelp" class="form-text">
-          The file where the output of the command is stored, if it is not
-          specified, the output is ignored
-        </div>
+      <div class="mt-2" v-else>
+        <button class="btn btn-primary" @click="newApp">+ Add New</button>
       </div>
-      <!--prep-cmd-->
+    </div>
+    <!--Global Prep Commands Tab-->
+    <div v-if="currentTab === 'global-prep'" class="config-page">
       <div class="mb-3 d-flex flex-column">
-        <label for="appName" class="form-label">Command Preparations</label>
+        <label class="form-label">Command Preparations</label>
         <div class="form-text">
-          A list of commands to be run before/after the application. <br />
-          If any of the prep-commands fail, starting the application is aborted
+          A list of commands to be run before/after all applications. <br />
+          If any of the prep-commands fail, starting the application is aborted.
         </div>
-        <table v-if="editForm['prep-cmd'].length > 0">
+        <table v-if="globalPrepCmd.length > 0">
           <thead>
             <th class="precmd-head">Do</th>
             <th class="precmd-head">Undo</th>
             <th style="width: 48px"></th>
           </thead>
           <tbody>
-            <tr v-for="(c,i) in editForm['prep-cmd']">
+            <tr v-for="(c,i) in globalPrepCmd">
               <td>
                 <input
                   type="text"
@@ -87,7 +285,7 @@
               <td>
                 <button
                   class="btn btn-danger"
-                  @click="editForm['prep-cmd'].splice(i,1)"
+                  @click="globalPrepCmd.splice(i,1)"
                 >
                   &times;
                 </button>
@@ -98,134 +296,13 @@
         <button
           class="mt-2 btn btn-success"
           style="margin: 0 auto"
-          @click="addPrepCmd"
+          @click="addGlobalPrepCmd"
         >
           &plus; Add
         </button>
       </div>
-      <!--detatched-->
-      <div class="mb-3">
-        <label for="appName" class="form-label">Detached Commands</label>
-        <div
-          v-for="(c,i) in editForm.detached"
-          class="d-flex justify-content-between my-2"
-        >
-          <pre>{{c}}</pre>
-          <button
-            class="btn btn-danger mx-2"
-            @click="editForm.detached.splice(i,1)"
-          >
-            &times;
-          </button>
-        </div>
-        <div class="d-flex justify-content-between">
-          <input
-            type="text"
-            class="form-control monospace"
-            v-model="detachedCmd"
-          />
-          <button
-            class="btn btn-success mx-2"
-            @click="editForm.detached.push(detachedCmd);detachedCmd = '';"
-          >
-            +
-          </button>
-        </div>
-        <div class="form-text">
-          A list of commands to be run and forgotten about
-        </div>
-      </div>
-      <!--command-->
-      <div class="mb-3">
-        <label for="appCmd" class="form-label">Command</label>
-        <input
-          type="text"
-          class="form-control monospace"
-          id="appCmd"
-          aria-describedby="appCmdHelp"
-          v-model="editForm.cmd"
-        />
-        <div id="appCmdHelp" class="form-text">
-          The main application, if it is not specified, a processs is started
-          that sleeps indefinitely
-        </div>
-      </div>
-      <!--working dir-->
-      <div class="mb-3">
-        <label for="appWorkingDir" class="form-label">Working Directory</label>
-        <input
-          type="text"
-          class="form-control monospace"
-          id="appWorkingDir"
-          aria-describedby="appWorkingDirHelp"
-          v-model="editForm['working-dir']"
-        />
-        <div id="appWorkingDirHelp" class="form-text">
-          The working directory that should be passed to the process.
-          For example, some applications use the working directory to search for configuration files.
-          If not set, Sunshine will default to the parent directory of the command
-        </div>
-      </div>
-      <!-- Image path -->
-      <div class="mb-3">
-        <label for="appImagePath" class="form-label">Image</label>
-        <div class="input-group dropup">
-          <input
-              type="text"
-              class="form-control monospace"
-              id="appImagePath"
-              aria-describedby="appImagePathHelp"
-              v-model="editForm['image-path']"
-          />
-          <button class="btn btn-secondary dropdown-toggle" type="button" id="findCoverToggle" data-bs-toggle="dropdown"
-                  data-bs-auto-close="outside" aria-expanded="false" v-dropdown-show="showCoverFinder"
-                  ref="coverFinderDropdown">
-            Find Cover
-          </button>
-          <div class="dropdown-menu dropdown-menu-end w-50 cover-finder overflow-hidden"
-               aria-labelledby="findCoverToggle">
-            <div class="modal-header">
-              <h4 class="modal-title">Covers Found</h4>
-              <button type="button" class="btn-close" aria-label="Close" @click="closeCoverFinder"></button>
-            </div>
-            <div class="modal-body cover-results px-3 pt-3" :class="{ busy: coverFinderBusy }">
-              <div class="row">
-                <div v-if="coverSearching" class="col-12 col-sm-6 col-lg-4 mb-3">
-                  <div class="cover-container">
-                    <div class="spinner-border" role="status">
-                      <span class="visually-hidden">Loading...</span>
-                    </div>
-                  </div>
-                </div>
-                <div v-for="(cover,i) in coverCandidates" :key="i" class="col-12 col-sm-6 col-lg-4 mb-3"
-                     @click="useCover(cover)">
-                  <div class="cover-container result">
-                    <img class="rounded" :src="cover.url"/>
-                  </div>
-                  <label class="d-block text-nowrap text-center text-truncate">
-                    {{cover.name}}
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div id="appImagePathHelp" class="form-text">
-          Application icon/picture/image path that will be sent to client. Image must be a PNG file.
-          If not set, Sunshine will send default box image.
-        </div>
-      </div>
-      <!--buttons-->
-      <div class="d-flex">
-        <button @click="showEditForm = false" class="btn btn-secondary m-2">
-          Cancel
-        </button>
-        <button class="btn btn-primary m-2" @click="save">Save</button>
-      </div>
+      <button class="btn btn-primary m-2" @click="savePrepCmd">Save</button>
     </div>
-  </div>
-  <div class="mt-2" v-else>
-    <button class="btn btn-primary" @click="newApp">+ Add New</button>
   </div>
 </div>
 
@@ -241,12 +318,24 @@
     data() {
       return {
         apps: [],
+        globalPrepCmd: [],
         showEditForm: false,
         editForm: null,
         detachedCmd: "",
         coverSearching: false,
         coverFinderBusy: false,
         coverCandidates: [],
+        currentTab: "apps",
+        tabs: [
+          {
+            id: "apps",
+            name: "Applications",
+          },
+          {
+            id: "global-prep",
+            name: "Global Prep Commands",
+          }
+        ],
       };
     },
     created() {
@@ -255,6 +344,7 @@
         .then((r) => {
           console.log(r);
           this.apps = r.apps;
+          this.globalPrepCmd = r["global-prep-cmd"];
         });
     },
     methods: {
@@ -264,6 +354,7 @@
           output: "",
           cmd: [],
           index: -1,
+          "include-global-prep-cmd": true,
           "prep-cmd": [],
           detached: [],
           "image-path": ""
@@ -278,6 +369,8 @@
           this.$set(this.editForm, "prep-cmd", []);
         if (this.editForm["detached"] === undefined)
           this.$set(this.editForm, "detached", []);
+        if (this.editForm["include-global-prep-cmd"] === undefined)
+          this.$set(this.editForm, "include-global-prep-cmd", true);
         this.showEditForm = true;
       },
       showDeleteForm(id) {
@@ -292,6 +385,12 @@
       },
       addPrepCmd() {
         this.editForm["prep-cmd"].push({
+          do: "",
+          undo: "",
+        });
+      },
+      addGlobalPrepCmd() {
+        this.globalPrepCmd.push({
           do: "",
           undo: "",
         });
@@ -384,6 +483,14 @@
           if (r.status == 200) document.location.reload();
         });
       },
+      savePrepCmd() {
+        fetch("/api/apps/prep", {
+          method: "POST",
+          body: JSON.stringify(this.globalPrepCmd),
+        }).then((r) => {
+          if (r.status == 200) document.location.reload();
+        });
+      },
     },
   });
 </script>
@@ -436,6 +543,12 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  .config-page {
+    padding: 1em;
+    border: 1px solid #dee2e6;
+    border-top: none;
   }
 
 </style>

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -3,271 +3,82 @@
     <h1>Applications</h1>
     <div>Applications are refreshed only when Client is restarted</div>
   </div>
-  <div class="form">
-    <!--Header-->
-    <ul class="nav nav-tabs">
-      <li class="nav-item" v-for="tab in tabs" :key="tab.id">
-        <a
-          class="nav-link"
-          :class="{'active': tab.id === currentTab}"
-          href="#"
-          @click="currentTab = tab.id"
-          >{{tab.name}}</a
-        >
-      </li>
-    </ul>
-    <!--Applications Tab-->
-    <div v-if="currentTab === 'apps'" class="config-page">
-      <div class="card p-4">
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col">Name</th>
-              <th scope="col">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(app,i) in apps" :key="i">
-              <td>{{app.name}}</td>
-              <td>
-                <button class="btn btn-primary" @click="editApp(i)">Edit</button>
-                <button class="btn btn-danger" @click="showDeleteForm(i)">
-                  Delete
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="edit-form card mt-2" v-if="showEditForm">
-        <div class="p-4">
-          <!--name-->
-          <div class="mb-3">
-            <label for="appName" class="form-label">Application Name</label>
-            <input
-              type="text"
-              class="form-control"
-              id="appName"
-              aria-describedby="appNameHelp"
-              v-model="editForm.name"
-            />
-            <div id="appNameHelp" class="form-text">
-              Application Name, as shown on Moonlight
-            </div>
-          </div>
-          <!--output-->
-          <div class="mb-3">
-            <label for="appOutput" class="form-label">Output</label>
-            <input
-              type="text"
-              class="form-control monospace"
-              id="appOutput"
-              aria-describedby="appOutputHelp"
-              v-model="editForm.output"
-            />
-            <div id="appOutputHelp" class="form-text">
-              The file where the output of the command is stored, if it is not
-              specified, the output is ignored
-            </div>
-          </div>
-          <!--prep-cmd-->
-          <div class="mb-3 d-flex flex-column">
-            <div class="mb-3">
-              <label for="excludeGlobalPrep" class="form-label">Global Prep Commands</label>
-              <select id="excludeGlobalPrep" class="form-select" v-model="editForm['exclude-global-prep-cmd']">
-                <option v-for="val in [false, true]" :value="val">{{ !val ? 'Enabled' : 'Disabled' }}</option>
-              </select>
-              <div class="form-text">
-                Enable/Disable the execution of Global Prep Commands for this application.
-              </div>
-            </div>
-            <label for="appName" class="form-label">Command Preparations</label>
-            <div class="form-text">
-              A list of commands to be run before/after this application. <br />
-              If any of the prep-commands fail, starting the application is aborted
-            </div>
-            <table v-if="editForm['prep-cmd'].length > 0">
-              <thead>
-                <th class="precmd-head">Do</th>
-                <th class="precmd-head">Undo</th>
-                <th style="width: 48px"></th>
-              </thead>
-              <tbody>
-                <tr v-for="(c,i) in editForm['prep-cmd']">
-                  <td>
-                    <input
-                      type="text"
-                      class="form-control monospace"
-                      v-model="c.do"
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="text"
-                      class="form-control monospace"
-                      v-model="c.undo"
-                    />
-                  </td>
-                  <td>
-                    <button
-                      class="btn btn-danger"
-                      @click="editForm['prep-cmd'].splice(i,1)"
-                    >
-                      &times;
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <button
-              class="mt-2 btn btn-success"
-              style="margin: 0 auto"
-              @click="addPrepCmd"
-            >
-              &plus; Add
+  <div class="card p-4">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Name</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(app,i) in apps" :key="i">
+          <td>{{app.name}}</td>
+          <td>
+            <button class="btn btn-primary" @click="editApp(i)">Edit</button>
+            <button class="btn btn-danger" @click="showDeleteForm(i)">
+              Delete
             </button>
-          </div>
-          <!--detatched-->
-          <div class="mb-3">
-            <label for="appName" class="form-label">Detached Commands</label>
-            <div
-              v-for="(c,i) in editForm.detached"
-              class="d-flex justify-content-between my-2"
-            >
-              <pre>{{c}}</pre>
-              <button
-                class="btn btn-danger mx-2"
-                @click="editForm.detached.splice(i,1)"
-              >
-                &times;
-              </button>
-            </div>
-            <div class="d-flex justify-content-between">
-              <input
-                type="text"
-                class="form-control monospace"
-                v-model="detachedCmd"
-              />
-              <button
-                class="btn btn-success mx-2"
-                @click="editForm.detached.push(detachedCmd);detachedCmd = '';"
-              >
-                +
-              </button>
-            </div>
-            <div class="form-text">
-              A list of commands to be run and forgotten about
-            </div>
-          </div>
-          <!--command-->
-          <div class="mb-3">
-            <label for="appCmd" class="form-label">Command</label>
-            <input
-              type="text"
-              class="form-control monospace"
-              id="appCmd"
-              aria-describedby="appCmdHelp"
-              v-model="editForm.cmd"
-            />
-            <div id="appCmdHelp" class="form-text">
-              The main application, if it is not specified, a processs is started
-              that sleeps indefinitely
-            </div>
-          </div>
-          <!--working dir-->
-          <div class="mb-3">
-            <label for="appWorkingDir" class="form-label">Working Directory</label>
-            <input
-              type="text"
-              class="form-control monospace"
-              id="appWorkingDir"
-              aria-describedby="appWorkingDirHelp"
-              v-model="editForm['working-dir']"
-            />
-            <div id="appWorkingDirHelp" class="form-text">
-              The working directory that should be passed to the process.
-              For example, some applications use the working directory to search for configuration files.
-              If not set, Sunshine will default to the parent directory of the command
-            </div>
-          </div>
-          <!-- Image path -->
-          <div class="mb-3">
-            <label for="appImagePath" class="form-label">Image</label>
-            <div class="input-group dropup">
-              <input
-                  type="text"
-                  class="form-control monospace"
-                  id="appImagePath"
-                  aria-describedby="appImagePathHelp"
-                  v-model="editForm['image-path']"
-              />
-              <button class="btn btn-secondary dropdown-toggle" type="button" id="findCoverToggle" data-bs-toggle="dropdown"
-                      data-bs-auto-close="outside" aria-expanded="false" v-dropdown-show="showCoverFinder"
-                      ref="coverFinderDropdown">
-                Find Cover
-              </button>
-              <div class="dropdown-menu dropdown-menu-end w-50 cover-finder overflow-hidden"
-                  aria-labelledby="findCoverToggle">
-                <div class="modal-header">
-                  <h4 class="modal-title">Covers Found</h4>
-                  <button type="button" class="btn-close" aria-label="Close" @click="closeCoverFinder"></button>
-                </div>
-                <div class="modal-body cover-results px-3 pt-3" :class="{ busy: coverFinderBusy }">
-                  <div class="row">
-                    <div v-if="coverSearching" class="col-12 col-sm-6 col-lg-4 mb-3">
-                      <div class="cover-container">
-                        <div class="spinner-border" role="status">
-                          <span class="visually-hidden">Loading...</span>
-                        </div>
-                      </div>
-                    </div>
-                    <div v-for="(cover,i) in coverCandidates" :key="i" class="col-12 col-sm-6 col-lg-4 mb-3"
-                        @click="useCover(cover)">
-                      <div class="cover-container result">
-                        <img class="rounded" :src="cover.url"/>
-                      </div>
-                      <label class="d-block text-nowrap text-center text-truncate">
-                        {{cover.name}}
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div id="appImagePathHelp" class="form-text">
-              Application icon/picture/image path that will be sent to client. Image must be a PNG file.
-              If not set, Sunshine will send default box image.
-            </div>
-          </div>
-          <!--buttons-->
-          <div class="d-flex">
-            <button @click="showEditForm = false" class="btn btn-secondary m-2">
-              Cancel
-            </button>
-            <button class="btn btn-primary m-2" @click="save">Save</button>
-          </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="edit-form card mt-2" v-if="showEditForm">
+    <div class="p-4">
+      <!--name-->
+      <div class="mb-3">
+        <label for="appName" class="form-label">Application Name</label>
+        <input
+          type="text"
+          class="form-control"
+          id="appName"
+          aria-describedby="appNameHelp"
+          v-model="editForm.name"
+        />
+        <div id="appNameHelp" class="form-text">
+          Application Name, as shown on Moonlight
         </div>
       </div>
-      <div class="mt-2" v-else>
-        <button class="btn btn-primary" @click="newApp">+ Add New</button>
+      <!--output-->
+      <div class="mb-3">
+        <label for="appOutput" class="form-label">Output</label>
+        <input
+          type="text"
+          class="form-control monospace"
+          id="appOutput"
+          aria-describedby="appOutputHelp"
+          v-model="editForm.output"
+        />
+        <div id="appOutputHelp" class="form-text">
+          The file where the output of the command is stored, if it is not
+          specified, the output is ignored
+        </div>
       </div>
-    </div>
-    <!--Global Prep Commands Tab-->
-    <div v-if="currentTab === 'global-prep'" class="config-page">
+      <!--prep-cmd-->
       <div class="mb-3 d-flex flex-column">
-        <label class="form-label">Command Preparations</label>
-        <div class="form-text">
-          A list of commands to be run before/after all applications. <br />
-          If any of the prep-commands fail, starting the application is aborted.
+        <div class="mb-3">
+          <label for="excludeGlobalPrep" class="form-label">Global Prep Commands</label>
+          <select id="excludeGlobalPrep" class="form-select" v-model="editForm['exclude-global-prep-cmd']">
+            <option v-for="val in [false, true]" :value="val">{{ !val ? 'Enabled' : 'Disabled' }}</option>
+          </select>
+          <div class="form-text">
+            Enable/Disable the execution of Global Prep Commands for this application.
+          </div>
         </div>
-        <table v-if="globalPrepCmd.length > 0">
+        <label for="appName" class="form-label">Command Preparations</label>
+        <div class="form-text">
+          A list of commands to be run before/after this application. <br />
+          If any of the prep-commands fail, starting the application is aborted
+        </div>
+        <table v-if="editForm['prep-cmd'].length > 0">
           <thead>
             <th class="precmd-head">Do</th>
             <th class="precmd-head">Undo</th>
             <th style="width: 48px"></th>
           </thead>
           <tbody>
-            <tr v-for="(c,i) in globalPrepCmd">
+            <tr v-for="(c,i) in editForm['prep-cmd']">
               <td>
                 <input
                   type="text"
@@ -285,7 +96,7 @@
               <td>
                 <button
                   class="btn btn-danger"
-                  @click="globalPrepCmd.splice(i,1)"
+                  @click="editForm['prep-cmd'].splice(i,1)"
                 >
                   &times;
                 </button>
@@ -296,13 +107,134 @@
         <button
           class="mt-2 btn btn-success"
           style="margin: 0 auto"
-          @click="addGlobalPrepCmd"
+          @click="addPrepCmd"
         >
           &plus; Add
         </button>
       </div>
-      <button class="btn btn-primary m-2" @click="savePrepCmd">Save</button>
+      <!--detatched-->
+      <div class="mb-3">
+        <label for="appName" class="form-label">Detached Commands</label>
+        <div
+          v-for="(c,i) in editForm.detached"
+          class="d-flex justify-content-between my-2"
+        >
+          <pre>{{c}}</pre>
+          <button
+            class="btn btn-danger mx-2"
+            @click="editForm.detached.splice(i,1)"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="d-flex justify-content-between">
+          <input
+            type="text"
+            class="form-control monospace"
+            v-model="detachedCmd"
+          />
+          <button
+            class="btn btn-success mx-2"
+            @click="editForm.detached.push(detachedCmd);detachedCmd = '';"
+          >
+            +
+          </button>
+        </div>
+        <div class="form-text">
+          A list of commands to be run and forgotten about
+        </div>
+      </div>
+      <!--command-->
+      <div class="mb-3">
+        <label for="appCmd" class="form-label">Command</label>
+        <input
+          type="text"
+          class="form-control monospace"
+          id="appCmd"
+          aria-describedby="appCmdHelp"
+          v-model="editForm.cmd"
+        />
+        <div id="appCmdHelp" class="form-text">
+          The main application, if it is not specified, a processs is started
+          that sleeps indefinitely
+        </div>
+      </div>
+      <!--working dir-->
+      <div class="mb-3">
+        <label for="appWorkingDir" class="form-label">Working Directory</label>
+        <input
+          type="text"
+          class="form-control monospace"
+          id="appWorkingDir"
+          aria-describedby="appWorkingDirHelp"
+          v-model="editForm['working-dir']"
+        />
+        <div id="appWorkingDirHelp" class="form-text">
+          The working directory that should be passed to the process.
+          For example, some applications use the working directory to search for configuration files.
+          If not set, Sunshine will default to the parent directory of the command
+        </div>
+      </div>
+      <!-- Image path -->
+      <div class="mb-3">
+        <label for="appImagePath" class="form-label">Image</label>
+        <div class="input-group dropup">
+          <input
+              type="text"
+              class="form-control monospace"
+              id="appImagePath"
+              aria-describedby="appImagePathHelp"
+              v-model="editForm['image-path']"
+          />
+          <button class="btn btn-secondary dropdown-toggle" type="button" id="findCoverToggle" data-bs-toggle="dropdown"
+                  data-bs-auto-close="outside" aria-expanded="false" v-dropdown-show="showCoverFinder"
+                  ref="coverFinderDropdown">
+            Find Cover
+          </button>
+          <div class="dropdown-menu dropdown-menu-end w-50 cover-finder overflow-hidden"
+              aria-labelledby="findCoverToggle">
+            <div class="modal-header">
+              <h4 class="modal-title">Covers Found</h4>
+              <button type="button" class="btn-close" aria-label="Close" @click="closeCoverFinder"></button>
+            </div>
+            <div class="modal-body cover-results px-3 pt-3" :class="{ busy: coverFinderBusy }">
+              <div class="row">
+                <div v-if="coverSearching" class="col-12 col-sm-6 col-lg-4 mb-3">
+                  <div class="cover-container">
+                    <div class="spinner-border" role="status">
+                      <span class="visually-hidden">Loading...</span>
+                    </div>
+                  </div>
+                </div>
+                <div v-for="(cover,i) in coverCandidates" :key="i" class="col-12 col-sm-6 col-lg-4 mb-3"
+                    @click="useCover(cover)">
+                  <div class="cover-container result">
+                    <img class="rounded" :src="cover.url"/>
+                  </div>
+                  <label class="d-block text-nowrap text-center text-truncate">
+                    {{cover.name}}
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="appImagePathHelp" class="form-text">
+          Application icon/picture/image path that will be sent to client. Image must be a PNG file.
+          If not set, Sunshine will send default box image.
+        </div>
+      </div>
+      <!--buttons-->
+      <div class="d-flex">
+        <button @click="showEditForm = false" class="btn btn-secondary m-2">
+          Cancel
+        </button>
+        <button class="btn btn-primary m-2" @click="save">Save</button>
+      </div>
     </div>
+  </div>
+  <div class="mt-2" v-else>
+    <button class="btn btn-primary" @click="newApp">+ Add New</button>
   </div>
 </div>
 
@@ -318,24 +250,12 @@
     data() {
       return {
         apps: [],
-        globalPrepCmd: [],
         showEditForm: false,
         editForm: null,
         detachedCmd: "",
         coverSearching: false,
         coverFinderBusy: false,
-        coverCandidates: [],
-        currentTab: "apps",
-        tabs: [
-          {
-            id: "apps",
-            name: "Applications",
-          },
-          {
-            id: "global-prep",
-            name: "Global Prep Commands",
-          }
-        ],
+        coverCandidates: []
       };
     },
     created() {
@@ -344,7 +264,6 @@
         .then((r) => {
           console.log(r);
           this.apps = r.apps;
-          this.globalPrepCmd = r["global-prep-cmd"];
         });
     },
     methods: {
@@ -354,7 +273,6 @@
           output: "",
           cmd: [],
           index: -1,
-          "exclude-global-prep-cmd": false,
           "prep-cmd": [],
           detached: [],
           "image-path": ""
@@ -369,8 +287,6 @@
           this.$set(this.editForm, "prep-cmd", []);
         if (this.editForm["detached"] === undefined)
           this.$set(this.editForm, "detached", []);
-        if (this.editForm["exclude-global-prep-cmd"] === undefined)
-          this.$set(this.editForm, "exclude-global-prep-cmd", false);
         this.showEditForm = true;
       },
       showDeleteForm(id) {
@@ -385,12 +301,6 @@
       },
       addPrepCmd() {
         this.editForm["prep-cmd"].push({
-          do: "",
-          undo: "",
-        });
-      },
-      addGlobalPrepCmd() {
-        this.globalPrepCmd.push({
           do: "",
           undo: "",
         });
@@ -479,14 +389,6 @@
         fetch("/api/apps", {
           method: "POST",
           body: JSON.stringify(this.editForm),
-        }).then((r) => {
-          if (r.status == 200) document.location.reload();
-        });
-      },
-      savePrepCmd() {
-        fetch("/api/apps/prep", {
-          method: "POST",
-          body: JSON.stringify(this.globalPrepCmd),
         }).then((r) => {
           if (r.status == 200) document.location.reload();
         });

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -73,9 +73,9 @@
           <!--prep-cmd-->
           <div class="mb-3 d-flex flex-column">
             <div class="mb-3">
-              <label for="includeGlobalPrep" class="form-label">Global Prep Commands</label>
-              <select id="includeGlobalPrep" class="form-select" v-model="editForm['include-global-prep-cmd']">
-                <option v-for="val in [true, false]" :value="val">{{ val ? 'Enabled' : 'Disabled' }}</option>
+              <label for="excludeGlobalPrep" class="form-label">Global Prep Commands</label>
+              <select id="excludeGlobalPrep" class="form-select" v-model="editForm['exclude-global-prep-cmd']">
+                <option v-for="val in [false, true]" :value="val">{{ !val ? 'Enabled' : 'Disabled' }}</option>
               </select>
               <div class="form-text">
                 Enable/Disable the execution of Global Prep Commands for this application.
@@ -354,7 +354,7 @@
           output: "",
           cmd: [],
           index: -1,
-          "include-global-prep-cmd": true,
+          "exclude-global-prep-cmd": false,
           "prep-cmd": [],
           detached: [],
           "image-path": ""
@@ -369,8 +369,8 @@
           this.$set(this.editForm, "prep-cmd", []);
         if (this.editForm["detached"] === undefined)
           this.$set(this.editForm, "detached", []);
-        if (this.editForm["include-global-prep-cmd"] === undefined)
-          this.$set(this.editForm, "include-global-prep-cmd", true);
+        if (this.editForm["exclude-global-prep-cmd"] === undefined)
+          this.$set(this.editForm, "exclude-global-prep-cmd", false);
         this.showEditForm = true;
       },
       showDeleteForm(id) {

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -999,6 +999,7 @@
     "vt_coder": "auto",
     "vt_realtime": "enabled",
     "vt_software": "auto",
+    "global_prep_cmd": "[]",
   }
 
   new Vue({

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -213,10 +213,58 @@
           <option value="disabled">Disabled</option>
           <option value="enabled">Enabled</option>
         </select>
+        <div class="form-text">
+          It may be possible that you cannot send the Windows Key from Moonlight directly.<br />
+          In those cases it may be useful to make Sunshine think the Right Alt key is the Windows key
+        </div>
       </div>
-      <div class="form-text">
-        It may be possible that you cannot send the Windows Key from Moonlight directly.<br />
-        In those cases it may be useful to make Sunshine think the Right Alt key is the Windows key
+      <!-- Global Prep Commands -->
+      <div class="mb-3 d-flex flex-column">
+        <label class="form-label">Command Preparations</label>
+        <div class="form-text">
+          A list of commands to be run before/after all applications. <br />
+          If any of the prep-commands fail, starting the application is aborted.
+        </div>
+        <table v-if="global_prep_cmd.length > 0">
+          <thead>
+            <th>Do</th>
+            <th>Undo</th>
+            <th style="width: 48px"></th>
+          </thead>
+          <tbody>
+            <tr v-for="(c,i) in global_prep_cmd">
+              <td>
+                <input
+                  type="text"
+                  class="form-control monospace"
+                  v-model="c.do"
+                />
+              </td>
+              <td>
+                <input
+                  type="text"
+                  class="form-control monospace"
+                  v-model="c.undo"
+                />
+              </td>
+              <td>
+                <button
+                  class="btn btn-danger"
+                  @click="global_prep_cmd.splice(i,1)"
+                >
+                  &times;
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <button
+          class="mt-2 btn btn-success"
+          style="margin: 0 auto"
+          @click="add_global_prep_cmd"
+        >
+          &plus; Add
+        </button>
       </div>
     </div>
     <!--Files Tab-->
@@ -967,6 +1015,7 @@
         currentTab: "general",
         resIn: "",
         fpsIn: "",
+        global_prep_cmd: [],
         tabs: [
           {
             id: "general",
@@ -1061,6 +1110,9 @@
           let resolutions = [];
           res.split(",").forEach((r) => resolutions.push(r.trim()));
           this.resolutions = resolutions;
+          
+          this.config.global_prep_cmd = this.config.global_prep_cmd || [];
+          this.global_prep_cmd = JSON.parse(this.config.global_prep_cmd);
         });
     },
     methods: {
@@ -1075,6 +1127,7 @@
           "]";
         // remove quotes from values in fps
         this.config.fps = JSON.stringify(this.fps).replace(/"/g, "");
+        this.config.global_prep_cmd = JSON.stringify(this.global_prep_cmd);
       },
       save() {
         this.saved = false;
@@ -1133,6 +1186,12 @@
               if (r.status === 200) this.restarted = true;
             });
           }
+        });
+      },
+      add_global_prep_cmd() {
+        this.global_prep_cmd.push({
+          do: "",
+          undo: "",
         });
       },
     },


### PR DESCRIPTION
## Description
Add the ability to add a global set of Prep Commands that will run for _all_ applications. Global prep configuration is accessible in the UI through new tab on Applications page. Users can also enabled/disabled execution of global commands on a per applications basis. Default is Enabled.


### Screenshot
Global Command Preparations on Configuration -> General page
![image](https://user-images.githubusercontent.com/3165068/224569624-81edf3da-5575-4a4a-b401-61cd20d98695.png)

Per-App Toggle of global prep command execution
![image](https://user-images.githubusercontent.com/3165068/221370581-1e35e5ff-9bff-43ce-a0f0-139941dd62e9.png)


### Issues Fixed or Closed
NA


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
