### PR TITLE
archlinux: disable downlaod timeout

### DIFF
--- a/docker/archlinux.dockerfile
+++ b/docker/archlinux.dockerfile
@@ -11,7 +11,7 @@ FROM ${BASE}:${TAG} AS sunshine-base
 RUN <<_DEPS
 #!/bin/bash
 set -e
-pacman -Syu --noconfirm \
+pacman -Syu --disable-download-timeout --noconfirm \
   archlinux-keyring
 _DEPS
 
@@ -38,7 +38,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN <<_DEPS
 #!/bin/bash
 set -e
-pacman -Syu --noconfirm \
+pacman -Syu --disable-download-timeout --noconfirm \
   base-devel \
   cmake \
   cuda \
@@ -102,7 +102,7 @@ COPY --link --from=artifacts /sunshine.pkg.tar.zst /
 RUN <<_INSTALL_SUNSHINE
 #!/bin/bash
 set -e
-pacman -U --noconfirm \
+pacman -U --disable-download-timeout --noconfirm \
   /sunshine.pkg.tar.zst
 _INSTALL_SUNSHINE
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Disable download timeout for archlinux dockerfile build to solve the below error which occurs randomly.

```txt
Operation too slow. Less than 1 bytes/sec transferred the last 10 seconds
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
