### PR TITLE
Add CREATE_WAITABLE_TIMER_HIGH_RESOLUTION define to avoid compile errors for low system versions

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -24,6 +24,10 @@ using namespace std::literals;
 }
 namespace platf::dxgi {
 namespace bp = boost::process;
+// Avoid compilation errors for low system versions
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
 
 capture_e duplication_t::next_frame(DXGI_OUTDUPL_FRAME_INFO &frame_info, std::chrono::milliseconds timeout, resource_t::pointer *res_p) {
   auto capture_status = release_frame();


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Sunshine use CreateWaitableTimerEx api and CREATE_WAITABLE_TIMER_HIGH_RESOLUTION flag to replace busy loop frame capture
https://github.com/LizardByte/Sunshine/blob/0dfbcfdbc4a996fc6431387fd227525e7ec57684/src/platform/windows/display_base.cpp#L94-L103
As commented in the above code, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION is only available on higher versions of systems. The above code is able to handle version-compatible behavior correctly at runtime, but when I compile on a lower version of the system that will report the following error:
> error: 'CREATE_WAITABLE_TIMER_HIGH_RESOLUTION' was not declared in this scope; did you mean 'CREATE_WAITABLE_TIMER_MANUAL_RESET'

To avoid compile errors, we can add the following code just like https://github.com/python/cpython/issues/89592#issuecomment-1093932643
```c++
#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
#endif
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
