### PR TITLE
Provide ability to force a capture method via configuration.

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -752,6 +752,36 @@ hevc_mode
 
       hevc_mode = 2
 
+capture
+^^^^^^^
+
+**Description**
+   Force specific screen capture method. If set to automatic then Sunshine will attempt to find a capture method in the order of the table below, otherwise it will only attempt to capture via the method specified.
+
+   .. Caution:: Applies to Linux only.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   =========  ===========
+   Value      Description
+   =========  ===========
+   nvfbc      Use NVIDIA Frame Buffer Capture to capture direct to GPU memory. This is usually the fastest method for NVIDIA cards. For GeForce cards it will only work with drivers patched with `nvidia-patch <https://github.com/keylase/nvidia-patch/>`_ or `nvlax <https://github.com/keylase/nvidia-patch/>`_.
+   wlr        Capture for wlroots based Wayland compositors via DMA-BUF.
+   kms        DRM/KMS screen capture from the kernel. This requires that sunshine has cap_sys_admin capability. See :ref:`Linux Setup <about/usage:setup`.
+   x11        Uses XCB. This is the slowest and most CPU intensive so should be avoided if possible.
+   =========  ===========
+   
+**Default**
+   Automatic
+
+**Example**
+   .. code-block:: text
+
+      capture = kms
+      
 encoder
 ^^^^^^^
 

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -756,7 +756,7 @@ capture
 ^^^^^^^
 
 **Description**
-   Force specific screen capture method. If set to automatic then Sunshine will attempt to find a capture method in the order of the table below, otherwise it will only attempt to capture via the method specified.
+   Force specific screen capture method.
 
    .. Caution:: Applies to Linux only.
 
@@ -775,7 +775,7 @@ capture
    =========  ===========
    
 **Default**
-   Automatic
+   Automatic. Sunshine will use the first capture method available in the order of the table above.
 
 **Example**
    .. code-block:: text

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -770,7 +770,7 @@ capture
    =========  ===========
    nvfbc      Use NVIDIA Frame Buffer Capture to capture direct to GPU memory. This is usually the fastest method for NVIDIA cards. For GeForce cards it will only work with drivers patched with `nvidia-patch <https://github.com/keylase/nvidia-patch/>`_ or `nvlax <https://github.com/keylase/nvidia-patch/>`_.
    wlr        Capture for wlroots based Wayland compositors via DMA-BUF.
-   kms        DRM/KMS screen capture from the kernel. This requires that sunshine has cap_sys_admin capability. See :ref:`Linux Setup <about/usage:setup`.
+   kms        DRM/KMS screen capture from the kernel. This requires that sunshine has cap_sys_admin capability. See :ref:`Linux Setup <about/usage:setup>`.
    x11        Uses XCB. This is the slowest and most CPU intensive so should be avoided if possible.
    =========  ===========
    

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -768,9 +768,13 @@ capture
    =========  ===========
    Value      Description
    =========  ===========
-   nvfbc      Use NVIDIA Frame Buffer Capture to capture direct to GPU memory. This is usually the fastest method for NVIDIA cards. For GeForce cards it will only work with drivers patched with `nvidia-patch <https://github.com/keylase/nvidia-patch/>`_ or `nvlax <https://github.com/keylase/nvidia-patch/>`_.
+   nvfbc      Use NVIDIA Frame Buffer Capture to capture direct to GPU memory. This is usually the fastest method for
+              NVIDIA cards. For GeForce cards it will only work with drivers patched with
+              `nvidia-patch <https://github.com/keylase/nvidia-patch/>`_
+              or `nvlax <https://github.com/keylase/nvidia-patch/>`_.
    wlr        Capture for wlroots based Wayland compositors via DMA-BUF.
-   kms        DRM/KMS screen capture from the kernel. This requires that sunshine has cap_sys_admin capability. See :ref:`Linux Setup <about/usage:setup>`.
+   kms        DRM/KMS screen capture from the kernel. This requires that sunshine has cap_sys_admin capability.
+              See :ref:`Linux Setup <about/usage:setup>`.
    x11        Uses XCB. This is the slowest and most CPU intensive so should be avoided if possible.
    =========  ===========
    

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -351,7 +351,7 @@ video_t video {
     -1,
   }, // vt
 
-  {},  // capture method
+  {},  // capture
   {},  // encoder
   {},  // adapter_name
   {},  // output_name

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -351,6 +351,7 @@ video_t video {
     -1,
   }, // vt
 
+  {},  // capture method
   {},  // encoder
   {},  // adapter_name
   {},  // output_name
@@ -882,6 +883,7 @@ void apply_config(std::unordered_map<std::string, std::string> &&vars) {
   int_f(vars, "vt_software", video.vt.vt_require_sw, vt::force_software_from_view);
   int_f(vars, "vt_realtime", video.vt.vt_realtime, vt::rt_from_view);
 
+  string_f(vars, "capture", video.capture);
   string_f(vars, "encoder", video.encoder);
   string_f(vars, "adapter_name", video.adapter_name);
   string_f(vars, "output_name", video.output_name);

--- a/src/config.h
+++ b/src/config.h
@@ -52,6 +52,7 @@ struct video_t {
     int vt_coder;
   } vt;
 
+  std::string capture;;
   std::string encoder;
   std::string adapter_name;
   std::string output_name;

--- a/src/config.h
+++ b/src/config.h
@@ -52,7 +52,7 @@ struct video_t {
     int vt_coder;
   } vt;
 
-  std::string capture;;
+  std::string capture;
   std::string encoder;
   std::string adapter_name;
   std::string output_name;

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -561,7 +561,7 @@ std::unique_ptr<deinit_t> init() {
 #endif
 
   if(sources.none()) {
-    BOOST_LOG(error) << "Unable to initialize capture method";
+    BOOST_LOG(error) << "Unable to initialize capture method"sv;
     return nullptr;
   }
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -7,22 +7,22 @@
 
 // lib includes
 #include <arpa/inet.h>
+#include <boost/asio/ip/address.hpp>
+#include <boost/process.hpp>
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
 #include <netinet/udp.h>
 #include <pwd.h>
 #include <unistd.h>
-#include <boost/asio/ip/address.hpp>
-#include <boost/process.hpp>
 
 // local includes
 #include "graphics.h"
 #include "misc.h"
-#include "vaapi.h"
 #include "src/config.h"
 #include "src/main.h"
 #include "src/platform/common.h"
+#include "vaapi.h"
 
 #ifdef __GNUC__
 #define SUNSHINE_GNUC_EXTENSION __extension__

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -8,13 +8,15 @@
 
 #include <fstream>
 
+// local includes
 #include "graphics.h"
 #include "misc.h"
 #include "vaapi.h"
-
+#include "src/config.h"
 #include "src/main.h"
 #include "src/platform/common.h"
 
+// lib includes
 #include <boost/asio/ip/address.hpp>
 #include <boost/process.hpp>
 
@@ -518,34 +520,44 @@ std::unique_ptr<deinit_t> init() {
     window_system = window_system_e::X11;
   }
 #endif
+
 #ifdef SUNSHINE_BUILD_CUDA
-  if(verify_nvfbc()) {
-    sources[source::NVFBC] = true;
+  if(config::video.capture.empty() || config::video.capture == "nvfbc") {
+    if(verify_nvfbc()) {
+      sources[source::NVFBC] = true;
+    }
   }
 #endif
 #ifdef SUNSHINE_BUILD_WAYLAND
-  if(verify_wl()) {
-    sources[source::WAYLAND] = true;
+  if(config::video.capture.empty() || config::video.capture == "wlr") {
+    if(verify_wl()) {
+      sources[source::WAYLAND] = true;
+    }
   }
 #endif
 #ifdef SUNSHINE_BUILD_DRM
-  if(verify_kms()) {
-    if(window_system == window_system_e::WAYLAND) {
-      // On Wayland, using KMS, the cursor is unreliable.
-      // Hide it by default
-      display_cursor = false;
+  if(config::video.capture.empty() || config::video.capture == "kms") {
+    if(verify_kms()) {
+      if(window_system == window_system_e::WAYLAND) {
+        // On Wayland, using KMS, the cursor is unreliable.
+        // Hide it by default
+        display_cursor = false;
+      }
     }
 
     sources[source::KMS] = true;
   }
 #endif
 #ifdef SUNSHINE_BUILD_X11
-  if(verify_x11()) {
-    sources[source::X11] = true;
+  if(config::video.capture.empty() || config::video.capture == "x11") {
+    if(verify_x11()) {
+      sources[source::X11] = true;
+    }
   }
 #endif
 
   if(sources.none()) {
+    BOOST_LOG(error) << "Unable to initialize capture method";
     return nullptr;
   }
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file misc.cpp
+ */
+
+// standard includes
+#include <fstream>
+
+// lib includes
 #include <arpa/inet.h>
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -5,8 +13,8 @@
 #include <netinet/udp.h>
 #include <pwd.h>
 #include <unistd.h>
-
-#include <fstream>
+#include <boost/asio/ip/address.hpp>
+#include <boost/process.hpp>
 
 // local includes
 #include "graphics.h"
@@ -15,10 +23,6 @@
 #include "src/config.h"
 #include "src/main.h"
 #include "src/platform/common.h"
-
-// lib includes
-#include <boost/asio/ip/address.hpp>
-#include <boost/process.hpp>
 
 #ifdef __GNUC__
 #define SUNSHINE_GNUC_EXTENSION __extension__

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -591,7 +591,21 @@
           HEVC is more CPU-intensive to encode, so enabling this may reduce performance when using software encoding.
         </div>
       </div>
-      <!--Encoder -->
+      <!--Capture-->
+      <div class="mb-3" v-if="platform === 'linux'">
+        <label for="capture" class="form-label">Force a Specific Capture Method</label>
+        <select id="capture" class="form-select" v-model="config.capture">
+          <option value>Autodetect</option>
+          <option value="nvfbc">NvFBC</option>
+          <option value="wlr">wlroots</option>
+          <option value="kms">KMS</option>
+          <option value="x11">X11</option>
+        </select>
+        <div class="form-text">
+          Force a specific capture method, otherwise Sunshine will use the first one that works. NvFBC requires patched nvidia drivers.
+        </div>
+      </div>
+      <!--Encoder-->
       <div class="mb-3">
         <label for="encoder" class="form-label">Force a Specific Encoder</label>
         <select id="encoder" class="form-select" v-model="config.encoder">
@@ -911,6 +925,7 @@
     "amd_rc": "vbr_latency",
     "amd_usage": "ultralowlatency",
     "amd_vbaq": "enabled",
+    "capture": "",
     "controller": "enabled",
     "dwmflush": "enabled",
     "encoder": "",

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -595,7 +595,7 @@
       <div class="mb-3" v-if="platform === 'linux'">
         <label for="capture" class="form-label">Force a Specific Capture Method</label>
         <select id="capture" class="form-select" v-model="config.capture">
-          <option value>Autodetect</option>
+          <option value="">Autodetect</option>
           <option value="nvfbc">NvFBC</option>
           <option value="wlr">wlroots</option>
           <option value="kms">KMS</option>
@@ -609,7 +609,7 @@
       <div class="mb-3">
         <label for="encoder" class="form-label">Force a Specific Encoder</label>
         <select id="encoder" class="form-select" v-model="config.encoder">
-          <option value>Autodetect</option>
+          <option value="">Autodetect</option>
           <option value="nvenc" v-if="platform === 'windows' || platform === 'linux'">NVIDIA NVENC</option>
           <option value="quicksync" v-if="platform === 'windows'">Intel QuickSync</option>
           <option value="amdvce" v-if="platform === 'windows'">AMD AMF/VCE</option>


### PR DESCRIPTION
## Description
In Linux sunshine will test nvfbc, kms, wayland and x11 capture methods and will choose the first one that works in that order. This change allows you to force a specific one as long as it is available. If no capture method is found or if you select one that cannot be initialized, then an error message will be raised. 

Documentation update to follow.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
