### PR TITLE
qodana: use workflow dispatch

### DIFF
--- a/.github/workflows/ci-qodana.yml
+++ b/.github/workflows/ci-qodana.yml
@@ -86,8 +86,8 @@ jobs:
 
           echo "reports_markdown=$REPORTS_MARKDOWN" >> $GITHUB_OUTPUT
 
-      - name: Setup initial notification client payload
-        id: client_payload
+      - name: Setup initial notification inputs
+        id: inputs
         if: >-
           startsWith(github.event_name, 'pull_request') &&
           steps.prepare.outputs.files != ''
@@ -106,26 +106,44 @@ jobs:
           # escape json control characters
           message=$(jq -n --arg message "$message" '$message' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
 
-          client_payload=$(echo '{
+          secondary_inputs=$(echo '{
             "issue_message": "'"${message}"'",
             "issue_message_id": "'"qodana"'",
-            "issue_number": "'"${{ github.event.number }}"'"
+            "issue_number": "'"${{ github.event.number }}"'",
+            "issue_repo_owner": "'"${{ github.repository_owner }}"'",
+            "issue_repo_name": "'"${{ github.event.repository.name }}"'"
+          }' | jq -r .)
+
+          #escape json control characters
+          secondary_inputs=$(jq -n --arg secondary_inputs "$secondary_inputs" '$secondary_inputs' \
+            | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+
+          echo $secondary_inputs
+
+          # secondary input as string, not JSON
+          # todo - change dispatch_ref to master instead of nightly
+          primary_inputs=$(echo '{
+            "dispatch_repository": "'"${{ github.repository_owner }}/.github"'",
+            "dispatch_workflow": "'"dispatch-issue-comment.yml"'",
+            "dispatch_ref": "'"nightly"'",
+            "dispatch_inputs": "'"${secondary_inputs}"'"
           }' | jq -c .)
 
-          echo $client_payload
-          echo $client_payload | jq .
-          echo "client_payload=$client_payload" >> $GITHUB_OUTPUT
+          echo $primary_inputs
+          echo $primary_inputs | jq .
+          echo "primary_inputs=$primary_inputs" >> $GITHUB_OUTPUT
 
-      - name: Repository Dispatch
+      - name: Workflow Dispatch
         if: >-
           startsWith(github.event_name, 'pull_request') &&
           steps.prepare.outputs.files != ''
-        uses: peter-evans/repository-dispatch@v2.1.1
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        continue-on-error: true  # this might error if the workflow is not found, but we still want to run the next job
         with:
-          token: ${{ secrets.GH_BOT_TOKEN }}
-          repository: ${{ github.repository_owner }}/.github
-          event-type: issue-pr-comment
-          client-payload: ${{ steps.client_payload.outputs.client_payload }}
+          ref: ${{ github.base_ref || github.ref_name }}  # base ref for PR and branch name for push
+          workflow: dispatcher.yml
+          inputs: ${{ steps.inputs.outputs.primary_inputs }}
+          token: ${{ github.token }}
 
     outputs:
       destination: ${{ steps.prepare.outputs.destination }}
@@ -219,8 +237,8 @@ jobs:
     name: Dispatch Qodana
     if: ${{ needs.qodana_initial_check.outputs.files != '' }}
     steps:
-      - name: Setup client payload
-        id: client_payload
+      - name: Setup qodana publish inputs
+        id: inputs
         run: |
           # get the artifacts
           artifacts=${{ toJson(steps.artifacts.outputs.result) }}
@@ -233,7 +251,7 @@ jobs:
           destination=${{ needs.qodana_initial_check.outputs.destination }}
 
           # client payload
-          client_payload=$(echo '{
+          secondary_inputs=$(echo '{
             "destination": "'"${destination}"'",
             "ref": "'"${{ github.ref }}"'",
             "repo": "'"${{ github.repository }}"'",
@@ -241,16 +259,30 @@ jobs:
             "run_id": "'"${{ github.run_id }}"'",
             "reports_markdown": "'"${{ needs.qodana_initial_check.outputs.reports_markdown }}"'",
             "status": "'"${{ needs.qodana.outputs.qodana_status }}"'"
+          }' | jq -r .)
+
+          #escape json control characters
+          secondary_inputs=$(jq -n --arg secondary_inputs "$secondary_inputs" '$secondary_inputs' \
+            | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+
+          echo $secondary_inputs
+
+          primary_inputs=$(echo '{
+            "dispatch_repository": "'"${{ github.repository_owner }}/qodana-reports"'",
+            "dispatch_workflow": "'"dispatch-qodana.yml"'",
+            "dispatch_ref": "'"master"'",
+            "dispatch_inputs": "'"$secondary_inputs"'"
           }' | jq -c .)
 
-          echo $client_payload
-          echo $client_payload | jq .
-          echo "client_payload=$client_payload" >> $GITHUB_OUTPUT
+          echo $primary_inputs
+          echo $primary_inputs | jq .
+          echo "primary_inputs=$primary_inputs" >> $GITHUB_OUTPUT
 
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2.1.1
+      - name: Workflow Dispatch
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        continue-on-error: true  # this might error if the workflow is not found, but we don't want to fail the workflow
         with:
-          token: ${{ secrets.GH_BOT_TOKEN }}
-          repository: ${{ github.repository_owner }}/qodana-reports
-          event-type: qodana-publish
-          client-payload: ${{ steps.client_payload.outputs.client_payload }}
+          ref: ${{ github.base_ref || github.ref_name }}  # base ref for PR and branch name for push
+          workflow: dispatcher.yml
+          inputs: ${{ steps.inputs.outputs.primary_inputs }}
+          token: ${{ github.token }}

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -1,0 +1,69 @@
+---
+# This action is centrally managed in https://github.com/<organization>/.github/
+# Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in
+# the above-mentioned repo.
+
+# This action receives a dispatch event and passes it through to another repo. This is a workaround to avoid issues
+# where fork PRs do not have access to secrets.
+
+name: Dispatcher
+
+on:
+  workflow_dispatch:
+    inputs:
+      dispatch_repository:
+        description: 'Repository to dispatch to'
+        required: true
+      dispatch_workflow:
+        description: 'Workflow to dispatch to'
+        required: true
+      dispatch_ref:
+        description: 'Ref/branch to dispatch to'
+        required: true
+      dispatch_inputs:
+        description: 'Inputs to send'
+        required: true
+
+jobs:
+  dispatcher:
+    name: Repository Dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unescape JSON control characters
+        id: inputs
+        run: |
+          # get the inputs
+          dispatch_inputs=${{ github.event.inputs.dispatch_inputs }}
+          echo "$dispatch_inputs"
+
+          # temporarily replace newlines with a placeholder
+          dispatch_inputs=$(echo ${dispatch_inputs} | sed 's/\\\\n/_!new_line!_/g')
+
+          # remove newline characters
+          dispatch_inputs=$(echo ${dispatch_inputs} | sed 's/\\n//g')
+
+          # replace placeholder with newline
+          dispatch_inputs=$(echo ${dispatch_inputs} | sed 's/_!new_line!_/\\n/g')
+
+          # replace escaped quotes with unescaped quotes
+          dispatch_inputs=$(echo ${dispatch_inputs} | sed 's/\\"//g')
+
+          # debug echo
+          echo "$dispatch_inputs"
+
+          # parse as JSON
+          dispatch_inputs=$(echo "$dispatch_inputs" | jq -c .)
+
+          # debug echo
+          echo "$dispatch_inputs"
+
+          echo "dispatch_inputs=$dispatch_inputs" >> $GITHUB_OUTPUT
+
+      - name: Workflow Dispatch
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+          repo: ${{ github.event.inputs.dispatch_repository }}
+          ref: ${{ github.event.inputs.dispatch_ref || 'master' }}  # default to master if not specified
+          workflow: ${{ github.event.inputs.dispatch_workflow }}
+          inputs: ${{ steps.inputs.outputs.dispatch_inputs }}
+          token: ${{ secrets.GH_BOT_TOKEN || github.token }}  # fallback to default token if not specified


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use workflow dispatch for qodana workflows. This should solve an issue where PRs from forks could not fully run qodana ci.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
