### PR TITLE
Don't skip disconnected X11 outputs

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -299,13 +299,18 @@ output_name
    .. Tip:: To find the name of the appropriate values follow these instructions.
 
       **Linux**
-         .. code-block:: bash
+         During Sunshine startup, you should see the list of detected monitors:
 
-            xrandr --listmonitors
+         .. code-block:: text
 
-         Example output: ``0: +HDMI-1 1920/518x1200/324+0+0  HDMI-1``
+            Info: Detecting connected monitors
+            Info: Detected monitor 0: DVI-D-0, connected: false
+            Info: Detected monitor 1: HDMI-0, connected: true
+            Info: Detected monitor 2: DP-0, connected: true
+            Info: Detected monitor 3: DP-1, connected: false
+            Info: Detected monitor 4: DVI-D-1, connected: false
 
-         You need to use the value before the colon in the output, e.g. ``0``.
+         You need to use the value before the colon in the output, e.g. ``1``.
 
       .. Todo:: macOS
 

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -776,6 +776,7 @@ namespace platf {
     for (int x = 0; x < output; ++x) {
       output_info_t out_info { x11::rr::GetOutputInfo(xdisplay.get(), screenr.get(), screenr->outputs[x]) };
       if (out_info) {
+        BOOST_LOG(info) << "Detected monitor "sv << monitor << ": "sv << out_info->name << ", connected: "sv << (out_info->connection == RR_Connected);
         ++monitor;
       }
     }

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -427,7 +427,7 @@ namespace platf {
         int monitor = 0;
         for (int x = 0; x < output; ++x) {
           output_info_t out_info { x11::rr::GetOutputInfo(xdisplay.get(), screenr.get(), screenr->outputs[x]) };
-          if (out_info && out_info->connection == RR_Connected) {
+          if (out_info) {
             if (monitor++ == streamedMonitor) {
               result = std::move(out_info);
               break;
@@ -761,7 +761,7 @@ namespace platf {
       return {};
     }
 
-    BOOST_LOG(info) << "Detecting connected monitors"sv;
+    BOOST_LOG(info) << "Detecting monitors"sv;
 
     x11::xdisplay_t xdisplay { x11::OpenDisplay(nullptr) };
     if (!xdisplay) {
@@ -775,7 +775,7 @@ namespace platf {
     int monitor = 0;
     for (int x = 0; x < output; ++x) {
       output_info_t out_info { x11::rr::GetOutputInfo(xdisplay.get(), screenr.get(), screenr->outputs[x]) };
-      if (out_info && out_info->connection == RR_Connected) {
+      if (out_info) {
         ++monitor;
       }
     }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -560,9 +560,17 @@
           v-model="config.output_name"
         />
         <div class="form-text">
-          xrandr --listmonitors<br />
-          Example output:
-          <pre>   0: +HDMI-1 1920/518x1200/324+0+0 HDMI-1</pre>
+          During Sunshine startup, you should see the list of detected monitors, e.g.:<br />
+          <br />
+          <pre style="white-space: pre-line;">
+            Info: Detecting connected monitors
+            Info: Detected monitor 0: DVI-D-0, connected: false
+            Info: Detected monitor 1: HDMI-0, connected: true
+            Info: Detected monitor 2: DP-0, connected: true
+            Info: Detected monitor 3: DP-1, connected: false
+            Info: Detected monitor 4: DVI-D-1, connected: false
+          </pre>
+          You need to use the value before the colon in the output, e.g. <b>1</b>.
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description
This change lets me use HDMI-0 (with HDMI dummy plugged in) as a Sunshine exclusive output when using the following do/undo commands:
* xrandr --output HDMI-0 --mode 1920x1080 --right-of DP-0
* xrandr --output HDMI-0 --off

### Screenshot
n/a

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
n/a

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
