### PR TITLE
Nightly Notification Bug Fixes

### DIFF
--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -89,7 +89,7 @@
       try {
         this.version = (await fetch("/api/config").then((r) => r.json())).version;
         this.githubVersion = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/releases/latest").then((r) => r.json()));
-        if (this.version.split(".").length > 1) {
+        if (!this.buildVersionIsStable()) {
           this.nightlyData = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/actions/workflows/CI.yml/runs?branch=nightly&status=success&per_page=1").then((r) => r.json())).workflow_runs[0];
         }
       } catch(e){
@@ -128,7 +128,7 @@
     },
     methods: {
       buildVersionIsStable() {
-        return !this.version || !this.nightlyData || this.version.split(".").length === 3;
+        return this.version.split(".").length === 3 || !this.version || !this.nightlyData;
       }
     }
   });

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -117,7 +117,7 @@
         return v !== this.version.split(".")[0];
       },
       nightlyBuildAvailable() {
-        if (this.buildVersionIsStable()) { return false };
+        if (this.buildVersionIsStable()) return false;
         // If built with dirty git tree, return false
         if (this.version.indexOf("dirty") !== -1) return false;
         // Get the commit hash

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -12,12 +12,12 @@
       <div v-if="loading">
         Loading Latest Release...
       </div>
-      <div v-else-if="!hasNewNightly && !hasNewStable">
+      <div v-else-if="!nightlyBuildAvailable && !stableBuildAvailable">
         <div class="alert alert-success">
           You're running the latest version of Sunshine
         </div>
       </div>
-      <div v-if="hasNewNightly">
+      <div v-if="nightlyBuildAvailable">
         <div class="alert alert-warning">
           <div class="d-flex justify-content-between">
             <div class="my-2">A new <b>Nightly</b> Version is Available!</div>
@@ -27,7 +27,7 @@
           <pre>{{nightlyData.display_title}}</pre>
         </div>
       </div>
-      <div v-if="hasNewStable">
+      <div v-if="stableBuildAvailable">
         <div class="alert alert-warning">
           <div class="d-flex justify-content-between">
             <div class="my-2">A new <b>Stable</b> Version is Available!</div>
@@ -97,8 +97,7 @@
       this.loading = false;
     },
     computed: {
-      // Check for new stable version
-      hasNewStable() {
+      stableBuildAvailable() {
         // If we can't get versions, return false
         if (!this.githubVersion || !this.version) return false;
         // If built with dirty git tree, return false
@@ -109,7 +108,7 @@
         if (v.indexOf("v") === 0) v = v.substring(1);
 
         // if nightly, we do an additional check to make sure its an actual upgrade.
-        if (this.version.split('.').length > 3) {
+        if (!this.buildVersionIsStable()) {
           const stableVersion = this.version.split('.').slice(0, 3).join('.');
           return this.githubVersion.tag_name.substring(1) > stableVersion;
         }
@@ -117,16 +116,19 @@
         // return true if the version is different, otherwise false
         return v !== this.version.split(".")[0];
       },
-      hasNewNightly() {
-        // If we're not on a nightly build, just return false
-        // If length of version split is 3, we're on a stable build
-        if (!this.version || !this.nightlyData || this.version.split(".").length === 3) return false;
+      nightlyBuildAvailable() {
+        if (this.buildVersionIsStable()) { return false };
         // If built with dirty git tree, return false
         if (this.version.indexOf("dirty") !== -1) return false;
         // Get the commit hash
         let commit = this.version.split(".").pop();
         // return true if the commit hash is different, otherwise false
         return this.nightlyData.head_sha.indexOf(commit) !== 0;
+      }
+    },
+    methods: {
+      buildVersionIsStable() {
+        return !this.version || !this.nightlyData || this.version.split(".").length === 3;
       }
     }
   });

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -107,10 +107,16 @@
         let v = this.githubVersion.name;
         // If the version starts with a v, remove it
         if (v.indexOf("v") === 0) v = v.substring(1);
+
+        // if nightly, we do an additional check to make sure its an actual upgrade.
+        if (this.version.split('.').length > 3) {
+          const stableVersion = this.version.split('.').slice(0, 3).join('.');
+          return this.githubVersion.tag_name.substring(1) > stableVersion;
+        }
+
         // return true if the version is different, otherwise false
         return v !== this.version.split(".")[0];
       },
-      // Check for new nightly version
       hasNewNightly() {
         // If we're not on a nightly build, just return false
         // If length of version split is 3, we're on a stable build
@@ -118,7 +124,7 @@
         // If built with dirty git tree, return false
         if (this.version.indexOf("dirty") !== -1) return false;
         // Get the commit hash
-        let commit = this.version.split(".")[-1];
+        let commit = this.version.split(".").pop();
         // return true if the commit hash is different, otherwise false
         return this.nightlyData.head_sha.indexOf(commit) !== 0;
       }

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -89,7 +89,7 @@
       try {
         this.version = (await fetch("/api/config").then((r) => r.json())).version;
         this.githubVersion = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/releases/latest").then((r) => r.json()));
-        if (this.version.split("-g").length > 1) {
+        if (this.version.split(".").length > 1) {
           this.nightlyData = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/actions/workflows/CI.yml/runs?branch=nightly&status=success&per_page=1").then((r) => r.json())).workflow_runs[0];
         }
       } catch(e){

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -89,7 +89,7 @@
       try {
         this.version = (await fetch("/api/config").then((r) => r.json())).version;
         this.githubVersion = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/releases/latest").then((r) => r.json()));
-        if (!this.buildVersionIsStable()) {
+        if (this.buildVersionIsNightly()) {
           this.nightlyData = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/actions/workflows/CI.yml/runs?branch=nightly&status=success&per_page=1").then((r) => r.json())).workflow_runs[0];
         }
       } catch(e){
@@ -108,7 +108,7 @@
         if (v.indexOf("v") === 0) v = v.substring(1);
 
         // if nightly, we do an additional check to make sure its an actual upgrade.
-        if (!this.buildVersionIsStable()) {
+        if (this.buildVersionIsNightly()) {
           const stableVersion = this.version.split('.').slice(0, 3).join('.');
           return this.githubVersion.tag_name.substring(1) > stableVersion;
         }
@@ -117,18 +117,23 @@
         return v !== this.version.split(".")[0];
       },
       nightlyBuildAvailable() {
-        if (this.buildVersionIsStable()) return false;
+        // Verify nightly data is available and the build version is not stable
+        // This is important to ensure the UI does not try to load undefined values.
+        if (!this.nightlyData || this.buildVersionIsStable()) return false;
         // If built with dirty git tree, return false
-        if (this.version.indexOf("dirty") !== -1) return false;
+        if (this.version?.indexOf("dirty") !== -1) return false;
         // Get the commit hash
-        let commit = this.version.split(".").pop();
+        let commit = this.version?.split(".").pop();
         // return true if the commit hash is different, otherwise false
         return this.nightlyData.head_sha.indexOf(commit) !== 0;
       }
     },
     methods: {
       buildVersionIsStable() {
-        return this.version.split(".").length === 3 || !this.version || !this.nightlyData;
+        return this.version?.split(".").length === 3;
+      },
+      buildVersionIsNightly() {
+        return this.version?.split(".").length === 4
       }
     }
   });


### PR DESCRIPTION
## Description
This pull request fixes a bug in the code that prevents the version update from working properly for nightly builds. The changes made in this pull request ensure that the expected behavior is met, which is to suggest a new nightly release when available, and only suggest a stable release if it has a higher version number than the nightly release.


Changes Made:

Updated the hasNewStable method to check nightly builds by comparing the latest nightly version tag with the stable version, and only returning true if the latest stable version is higher than their current nightly version. If the user does not have a nightly version of Sunshine, the existing functionality of the method remains the same.

Fixed a bug in the hasNewNightly method by using pop() instead of indexing by -1. JavaScript does not use negative indexes, so that would have returned back undefined instead of their original intended design decision, which was to retrieve the last index of the version split.

### Issues Fixed or Closed
- Fixes #1072 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
