### PR TITLE
Nightly change log

### DIFF
--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -117,7 +117,7 @@
         return v !== this.version.split(".")[0];
       },
       nightlyBuildAvailable() {
-        if (this.buildVersionIsStable()) { return false };
+        if (this.buildVersionIsStable()) return false;
         // If built with dirty git tree, return false
         if (this.version.indexOf("dirty") !== -1) return false;
         // Get the commit hash

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -12,12 +12,12 @@
       <div v-if="loading">
         Loading Latest Release...
       </div>
-      <div v-else-if="!hasNewNightly && !hasNewStable">
+      <div v-else-if="!nightlyBuildAvailable && !stableBuildAvailable">
         <div class="alert alert-success">
           You're running the latest version of Sunshine
         </div>
       </div>
-      <div v-if="hasNewNightly">
+      <div v-if="nightlyBuildAvailable">
         <div class="alert alert-warning">
           <div class="d-flex justify-content-between">
             <div class="my-2">A new <b>Nightly</b> Version is Available!</div>
@@ -27,7 +27,7 @@
           <pre>{{nightlyData.display_title}}</pre>
         </div>
       </div>
-      <div v-if="hasNewStable">
+      <div v-if="stableBuildAvailable">
         <div class="alert alert-warning">
           <div class="d-flex justify-content-between">
             <div class="my-2">A new <b>Stable</b> Version is Available!</div>
@@ -97,8 +97,7 @@
       this.loading = false;
     },
     computed: {
-      // Check for new stable version
-      hasNewStable() {
+      stableBuildAvailable() {
         // If we can't get versions, return false
         if (!this.githubVersion || !this.version) return false;
         // If built with dirty git tree, return false
@@ -109,7 +108,7 @@
         if (v.indexOf("v") === 0) v = v.substring(1);
 
         // if nightly, we do an additional check to make sure its an actual upgrade.
-        if (this.version.split('.').length > 3) {
+        if (!this.buildVersionIsStable()) {
           const stableVersion = this.version.split('.').slice(0, 3).join('.');
           return this.githubVersion.tag_name.substring(1) > stableVersion;
         }
@@ -117,16 +116,19 @@
         // return true if the version is different, otherwise false
         return v !== this.version.split(".")[0];
       },
-      hasNewNightly() {
-        // If we're not on a nightly build, just return false
-        // If length of version split is 3, we're on a stable build
-        if (!this.version || !this.nightlyData || this.version.split(".").length === 3) return false;
+      nightlyBuildAvailable() {
+        if (this.buildVersionIsStable()) { return false };
         // If built with dirty git tree, return false
         if (this.version.indexOf("dirty") !== -1) return false;
         // Get the commit hash
         let commit = this.version.split(".").pop();
         // return true if the commit hash is different, otherwise false
         return this.nightlyData.head_sha.indexOf(commit) !== 0;
+      }
+    },
+    methods: {
+      buildVersionIsStable() {
+        return !this.version || !this.nightlyData || this.version.split(".").length === 3;
       }
     }
   });

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -24,7 +24,18 @@
             <a class="btn btn-success m-1" :href="nightlyData.html_url" target="_blank">Download</a>
           </div>
           <pre><b>{{nightlyData.head_sha}}</b></pre>
-          <pre>{{nightlyData.display_title}}</pre>
+
+          <h4>Change Log</h4>
+          <div v-if="nightlyCommitCount > nightlyCommitLimit">You are currently {{nightlyCommitCount}} revisions behind.</div>
+          <div class="alert alert-danger">WARNING: You are currently {{nightlyCommitLimit}} or more revisions behind.
+            <p>The change log only shows up to {{nightlyCommitLimit}} changes from your current version, and will not accurately
+              reflect the latest features available. Please update to ensure you recieve the latest features.</p>
+          </div>
+          <ul>
+            <li v-for="(message, index) in nightlyCommitMessages" :key="index">
+              {{ message }}
+            </li>
+          </ul>
         </div>
       </div>
       <div v-if="stableBuildAvailable">
@@ -83,6 +94,8 @@
         githubVersion: null,
         nightlyData: null,
         loading: true,
+        nightlyCommitMessages: [],
+        nightlyCommitLimit: 20,
       }
     },
     async created() {
@@ -91,8 +104,9 @@
         this.githubVersion = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/releases/latest").then((r) => r.json()));
         if (this.version.split(".").length > 1) {
           this.nightlyData = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/actions/workflows/CI.yml/runs?branch=nightly&status=success&per_page=1").then((r) => r.json())).workflow_runs[0];
+          this.nightlyCommitMessages = await this.retrieveNightlyChangelog();
         }
-      } catch(e){
+      } catch (e) {
       }
       this.loading = false;
     },
@@ -124,11 +138,63 @@
         let commit = this.version.split(".").pop();
         // return true if the commit hash is different, otherwise false
         return this.nightlyData.head_sha.indexOf(commit) !== 0;
+      },
+      nightlyCommitCount() {
+        return this.nightlyCommitMessages.length;
       }
     },
     methods: {
       buildVersionIsStable() {
         return !this.version || !this.nightlyData || this.version.split(".").length === 3;
+      },
+      async retrieveNightlyChangelog() {
+        // Fetches the most recent commits for the "nightly" branch of the "LizardByte/Sunshine" repository using the GitHub API
+        const commits = await fetch(`https://api.github.com/repos/LizardByte/Sunshine/commits?sha=nightly&per_page=${this.nightlyCommitLimit}`).then(r => r.json());
+
+        // Defines a function that takes a commit SHA as an argument and returns the corresponding commit object from the fetched data
+        function findCommitById(commitSha) {
+          return commits.find(commit => commit.sha === commitSha);
+        }
+
+        // Using the commit object, return all the following commits after the provided one up to the maximum specified count.
+        function getNextCommits(commit, count) {
+          const nextCommits = [];
+          let currentCommit = commit;
+
+          // Iterates over the next commits using a loop that runs "count" number of times
+          for (let i = 0; i < count; i++) {
+            // Finds the parent commit of the current commit using the "findCommitById" function
+            const parentCommit = findCommitById(currentCommit.parents[0].sha);
+
+            // If there are no more parent commits, breaks the loop
+            if (!parentCommit) {
+              break;
+            }
+
+            // Adds the parent commit to the "nextCommits" array and sets it as the current commit
+            nextCommits.push(parentCommit);
+            currentCommit = parentCommit;
+          }
+
+          // Returns the array of next commits
+          return nextCommits;
+        }
+
+        // Calls the "findCommitById" function to get the current commit object based on the "nightlyData.head_sha" property, which is used to determine the current commit of this build.
+        const currentCommit = findCommitById(this.nightlyData.head_sha);
+
+        // If the current commit exists, calls the "getNextCommits" function to get an array of the next variable amount of commits after the current one
+        // This can be adjusted by changing the nightly commit limit.
+        if (currentCommit) {
+          const nextCommits = getNextCommits(currentCommit, this.nightlyCommitLimit);
+          // Maps over the commit objects to extract the commit messages, which are stored in an array
+          const commitMessages = nextCommits.map(commit => commit.commit.message);
+          // Returns the array of commit messages
+          return commitMessages;
+        } else {
+          // If the current commit does not exist, returns an empty array instead
+          return [];
+        }
       }
     }
   });

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -107,10 +107,16 @@
         let v = this.githubVersion.name;
         // If the version starts with a v, remove it
         if (v.indexOf("v") === 0) v = v.substring(1);
+
+        // if nightly, we do an additional check to make sure its an actual upgrade.
+        if (this.version.split('.').length > 3) {
+          const stableVersion = this.version.split('.').slice(0, 3).join('.');
+          return this.githubVersion.tag_name.substring(1) > stableVersion;
+        }
+
         // return true if the version is different, otherwise false
         return v !== this.version.split(".")[0];
       },
-      // Check for new nightly version
       hasNewNightly() {
         // If we're not on a nightly build, just return false
         // If length of version split is 3, we're on a stable build
@@ -118,7 +124,7 @@
         // If built with dirty git tree, return false
         if (this.version.indexOf("dirty") !== -1) return false;
         // Get the commit hash
-        let commit = this.version.split(".")[-1];
+        let commit = this.version.split(".").pop();
         // return true if the commit hash is different, otherwise false
         return this.nightlyData.head_sha.indexOf(commit) !== 0;
       }

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -89,7 +89,7 @@
       try {
         this.version = (await fetch("/api/config").then((r) => r.json())).version;
         this.githubVersion = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/releases/latest").then((r) => r.json()));
-        if (this.version.split("-g").length > 1) {
+        if (this.version.split(".").length > 1) {
           this.nightlyData = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/actions/workflows/CI.yml/runs?branch=nightly&status=success&per_page=1").then((r) => r.json())).workflow_runs[0];
         }
       } catch(e){

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -26,14 +26,22 @@
           <pre><b>{{nightlyData.head_sha}}</b></pre>
 
           <h4>Change Log</h4>
-          <div v-if="nightlyCommitCount > nightlyCommitLimit">You are currently {{nightlyCommitCount}} revisions behind.</div>
-          <div class="alert alert-danger">WARNING: You are currently {{nightlyCommitLimit}} or more revisions behind.
-            <p>The change log only shows up to {{nightlyCommitLimit}} changes from your current version, and will not accurately
-              reflect the latest features available. Please update to ensure you recieve the latest features.</p>
+          <div v-if="nightlyCommitCount < nightlyCommitLimit">You are currently {{nightlyCommitCount}} revisions behind.
+          </div>
+          <div v-else class="alert alert-danger">WARNING: You are currently {{nightlyCommitLimit}} or more revisions
+            behind.
+            <p>The change log only shows up to {{nightlyCommitLimit}} changes from the most recent version, and will not
+              accurately reflect the latest features available.</p>
           </div>
           <ul>
             <li v-for="(message, index) in nightlyCommitMessages" :key="index">
-              {{ message }}
+              <!-- Save the result of getPrNumber to a variable, so we don't have to call it twice -->
+              <template v-if="(prNumber = getPrNumber(message))">
+                <a target="_blank" :href="`https://github.com/LizardByte/Sunshine/pulls/${prNumber}`">{{ message }}</a>
+              </template>
+              <template v-else>
+                {{ message }}
+              </template>
             </li>
           </ul>
         </div>
@@ -148,53 +156,39 @@
         return !this.version || !this.nightlyData || this.version.split(".").length === 3;
       },
       async retrieveNightlyChangelog() {
-        // Fetches the most recent commits for the "nightly" branch of the "LizardByte/Sunshine" repository using the GitHub API
-        const commits = await fetch(`https://api.github.com/repos/LizardByte/Sunshine/commits?sha=nightly&per_page=${this.nightlyCommitLimit}`).then(r => r.json());
-
-        // Defines a function that takes a commit SHA as an argument and returns the corresponding commit object from the fetched data
-        function findCommitById(commitSha) {
-          return commits.find(commit => commit.sha === commitSha);
-        }
-
-        // Using the commit object, return all the following commits after the provided one up to the maximum specified count.
-        function getNextCommits(commit, count) {
-          const nextCommits = [];
-          let currentCommit = commit;
-
-          // Iterates over the next commits using a loop that runs "count" number of times
-          for (let i = 0; i < count; i++) {
-            // Finds the parent commit of the current commit using the "findCommitById" function
-            const parentCommit = findCommitById(currentCommit.parents[0].sha);
-
-            // If there are no more parent commits, breaks the loop
-            if (!parentCommit) {
-              break;
-            }
-
-            // Adds the parent commit to the "nextCommits" array and sets it as the current commit
-            nextCommits.push(parentCommit);
-            currentCommit = parentCommit;
-          }
-
-          // Returns the array of next commits
-          return nextCommits;
-        }
-
-        // Calls the "findCommitById" function to get the current commit object based on the "nightlyData.head_sha" property, which is used to determine the current commit of this build.
-        const currentCommit = findCommitById(this.nightlyData.head_sha);
-
-        // If the current commit exists, calls the "getNextCommits" function to get an array of the next variable amount of commits after the current one
-        // This can be adjusted by changing the nightly commit limit.
-        if (currentCommit) {
-          const nextCommits = getNextCommits(currentCommit, this.nightlyCommitLimit);
-          // Maps over the commit objects to extract the commit messages, which are stored in an array
-          const commitMessages = nextCommits.map(commit => commit.commit.message);
-          // Returns the array of commit messages
-          return commitMessages;
-        } else {
-          // If the current commit does not exist, returns an empty array instead
+        // This shouldn't happen, but just in case we will return back empty commit log.
+        if(buildVersionIsStable()){
           return [];
         }
+
+        // Fetches the commits for the nightly build from the GitHub API
+        const commits = await fetch(`https://api.github.com/repos/LizardByte/Sunshine/commits?sha=nightly&per_page=${this.nightlyCommitLimit}`).then(r => r.json());
+
+        // Finds the currently installed commit by using the fourth split of the version number as its SHA
+        const currentlyInstalledCommit = commits.find(commit => commit.sha === this.version.split('.')[3]);
+
+        // If the currently installed commit is found, retrieve the commit messages for the commits since it was installed
+        if (currentlyInstalledCommit) {
+          const commitCount = commits.indexOf(currentlyInstalledCommit);
+          const nextCommits = commits.slice(0, commitCount);
+          return nextCommits.map(commit => commit.commit.message);
+        }
+        // If the currently installed commit is not found, return all commits as this means the user has a build older than the defined limit.
+        else {
+          return commits.map(commit => commit.commit.message);
+        }
+      },
+      getPrNumber(commitMessage) {
+        // Use a regular expression to search for a PR number in the commit message
+        const match = /#(\d+)/.exec(commitMessage);    // If a match is found, return the PR number as an integer
+        if (match) {
+          // The PR number is the first captured group in the match, which is the digits after the "#" character
+          const prNumber = parseInt(match[1]);
+          return prNumber;
+        }
+
+        // If no match was found, return 0
+        return 0;
       }
     }
   });


### PR DESCRIPTION
## Description
This PR updates notifications for nightly builds to display the change log for up to 20 commits from latest Nightly Version of Sunshine. In addition, the change long will now link to the pull request if applicable.


This has a dependency to #1073 

Changes Made:

Added a new section to display the change log for the latest Nightly Version of Sunshine.
Created retrieveNightlyChangelog method to fetch the commits for the nightly build from the GitHub API and retrieve the commit messages for the commits since it was installed.
Add getPrNumber method to search for a PR number in the commit message and return it as an integer.



## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ x] I want maintainers to keep my branch updated
