### PR TITLE
Fix compiler warnings due to deprecated elements in C++17

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -71,9 +71,9 @@ boost::filesystem::path find_working_directory(const std::string &cmd, bp::envir
 
   BOOST_LOG(debug) << "Parsed executable ["sv << parts.at(0) << "] from command ["sv << cmd << ']';
 
-  // If the cmd path is not a complete path, resolve it using our PATH variable
+  // If the cmd path is not an absolute path, resolve it using our PATH variable
   boost::filesystem::path cmd_path(parts.at(0));
-  if(!cmd_path.is_complete()) {
+  if(!cmd_path.is_absolute()) {
     cmd_path = boost::process::search_path(parts.at(0));
     if(cmd_path.empty()) {
       BOOST_LOG(error) << "Unable to find executable ["sv << parts.at(0) << "]. Is it in your PATH?"sv;

--- a/src/round_robin.h
+++ b/src/round_robin.h
@@ -5,14 +5,15 @@
 
 namespace round_robin_util {
 template<class V, class T>
-class it_wrap_t : public std::iterator<std::random_access_iterator_tag, V> {
+class it_wrap_t {
 public:
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = V;
+  using difference_type = V;
+  using pointer = V*;
+  using reference = V&;
+
   typedef T iterator;
-  typedef typename std::iterator<std::random_access_iterator_tag, V>::value_type class_t;
-
-  typedef class_t &reference;
-  typedef class_t *pointer;
-
   typedef std::ptrdiff_t diff_t;
 
   iterator operator+=(diff_t step) {

--- a/src/round_robin.h
+++ b/src/round_robin.h
@@ -8,10 +8,10 @@ template<class V, class T>
 class it_wrap_t {
 public:
   using iterator_category = std::random_access_iterator_tag;
-  using value_type = V;
-  using difference_type = V;
-  using pointer = V*;
-  using reference = V&;
+  using value_type        = V;
+  using difference_type   = V;
+  using pointer           = V *;
+  using reference         = V &;
 
   typedef T iterator;
   typedef std::ptrdiff_t diff_t;


### PR DESCRIPTION
## Description
The CMakeLists specifies the C++17 standard and some elements used by sunshine are deprecated. This change cleans up those warnings while preserving the same functionality.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
