### PR TITLE
Properly handle libcurl flags in CMakeLists.txt on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,10 @@ if(WIN32)
     enable_language(RC)
     set(CMAKE_RC_COMPILER windres)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CURL_STATIC_LDFLAGS} ${CURL_STATIC_CFLAGS}")
+
+    add_definitions(-DCURL_STATICLIB)
+    include_directories(${CURL_STATIC_INCLUDE_DIRS})
+    link_directories(${CURL_STATIC_LIBRARY_DIRS})
 
     add_compile_definitions(SUNSHINE_PLATFORM="windows")
     add_subdirectory(tools)  # This is temporary, only tools for Windows are needed, for now


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Stumbled upon this when setting up sunshine in vscode, where I was getting strange linker errors.

In `CMakeLists.txt` both `CURL_STATIC_LDFLAGS` and `CURL_STATIC_CFLAGS` are lists, when converted to string their items get semicolon-separated. `CMAKE_CXX_FLAGS` is a string, where flags are space-separated.

What basically happened, `CURL_STATIC_LDFLAGS` was always converted to single gibberish `-L` argument which just didn't trigger any errors. And `CURL_STATIC_CFLAGS` was properly converted *only* when the list had a single item (`pkg-config --static --cflags libcurl` returned only `-DCURL_STATICLIB`. When `pkg-config` gets called outside of msys environment, it prepends include directory with `-I` argument , and `CURL_STATIC_CFLAGS` breaks exactly like `CURL_STATIC_LDFLAGS`. To the end-user it looked like libcurl linking errors, because `-DCURL_STATICLIB` was not set.

This should fix building in vscode, and maybe some other scenarios. `CURL_STATIC_LDFLAGS` are not needed, because `CURL_STATIC_LIBRARIES` are already passed to `target_link_libraries()`, it's enough to set up include and library lookup directories for exotic libcurl installations.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
