### PR TITLE
commands: fix prep commands when empty

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -762,11 +762,17 @@ void list_string_f(std::unordered_map<std::string, std::string> &vars, const std
     input.emplace_back(begin, pos);
   }
 }
+
 void list_prep_cmd_f(std::unordered_map<std::string, std::string> &vars, const std::string &name, std::vector<prep_cmd_t> &input) {
   std::string string;
   string_f(vars, name, string);
 
   std::stringstream jsonStream;
+
+  // check if string is empty, i.e. when the value doesn't exist in the config file
+  if(string.empty()) {
+    return;
+  }
 
   // We need to add a wrapping object to make it valid JSON, otherwise ptree cannot parse it.
   jsonStream << "{\"prep_cmd\":" << string << "}";


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes an issue introduced by #977 when the `global_prep_cmd` config option was not set in the config file.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
