### PR TITLE
versioning: fix dirty commit notifications

### DIFF
--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -6,13 +6,13 @@
     <div class="card-body" v-if="version">
       <h2>Version {{version}}</h2>
       <br />
-      <div class="alert alert-success" v-if="version.indexOf('dirty') !== -1">
-        Thank you for helping to make Sunshine a better software! 🌇
-      </div>
       <div v-if="loading">
         Loading Latest Release...
       </div>
-      <div v-else-if="!nightlyBuildAvailable && !stableBuildAvailable">
+      <div class="alert alert-success" v-if="runningDirtyBuild">
+        Thank you for helping to make Sunshine a better software! 🌇
+      </div>
+      <div v-else-if="!nightlyBuildAvailable && !stableBuildAvailable && !runningDirtyBuild">
         <div class="alert alert-success">
           You're running the latest version of Sunshine
         </div>
@@ -97,18 +97,19 @@
       this.loading = false;
     },
     computed: {
+      runningDirtyBuild() {
+        return this.buildVersionIsDirty()
+      },
       stableBuildAvailable() {
         // If we can't get versions, return false
         if (!this.githubVersion || !this.version) return false;
-        // If built with dirty git tree, return false
-        if (this.version.indexOf("dirty") !== -1) return false;
         // Get the GitHub version tag
         let v = this.githubVersion.name;
         // If the version starts with a v, remove it
         if (v.indexOf("v") === 0) v = v.substring(1);
 
-        // if nightly, we do an additional check to make sure its an actual upgrade.
-        if (this.buildVersionIsNightly()) {
+        // if nightly or dirty, we do an additional check to make sure it's an actual upgrade.
+        if (this.buildVersionIsNightly() || this.buildVersionIsDirty()) {
           const stableVersion = this.version.split('.').slice(0, 3).join('.');
           return this.githubVersion.tag_name.substring(1) > stableVersion;
         }
@@ -121,7 +122,7 @@
         // This is important to ensure the UI does not try to load undefined values.
         if (!this.nightlyData || this.buildVersionIsStable()) return false;
         // If built with dirty git tree, return false
-        if (this.version?.indexOf("dirty") !== -1) return false;
+        if (this.buildVersionIsDirty()) return false;
         // Get the commit hash
         let commit = this.version?.split(".").pop();
         // return true if the commit hash is different, otherwise false
@@ -129,11 +130,15 @@
       }
     },
     methods: {
-      buildVersionIsStable() {
-        return this.version?.split(".").length === 3;
+      buildVersionIsDirty() {
+        return this.version?.split(".").length === 5 &&
+          this.version.indexOf("dirty") !== -1
       },
       buildVersionIsNightly() {
         return this.version?.split(".").length === 4
+      },
+      buildVersionIsStable() {
+        return this.version?.split(".").length === 3
       }
     }
   });


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes alerts when running a dirty (locally modified) version of Sunshine.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
