### PR TITLE
Fix X11 fallback during init

### DIFF
--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -578,9 +578,8 @@ namespace platf {
           // Hide it by default
           display_cursor = false;
         }
+        sources[source::KMS] = true;
       }
-
-      sources[source::KMS] = true;
     }
 #endif
 #ifdef SUNSHINE_BUILD_X11


### PR DESCRIPTION
## Description
This was accidentally broken in c6548f4.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
n/a


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
