### PR TITLE
Continue in the face of failure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -346,18 +346,20 @@ main(int argc, char *argv[]) {
 
   proc::refresh(config::stream.file_apps);
 
-  auto deinit_guard = platf::init();
-  if (!deinit_guard) {
-    return 4;
+  // If any of the following fail, we log an error and continue event though sunshine will not function correctly.
+  // This allows access to the UI to fix configuration problems or view the logs.
+  if (!platf::init()) {
+    BOOST_LOG(error) << "Platform failed to initialize"sv;
   }
 
   reed_solomon_init();
   auto input_deinit_guard = input::init();
   if (video::init()) {
-    return 2;
+    BOOST_LOG(error) << "Video failed to initialize"sv;
   }
+
   if (http::init()) {
-    return 3;
+    BOOST_LOG(error) << "http failed to initialize"sv;
   }
 
   std::unique_ptr<platf::deinit_t> mDNS;


### PR DESCRIPTION
## Description
Instead of exiting when one of the major components fails to initialise, this change will log errors and continue. The advantage of this is that even though sunshine will not work, the web UI will still be available to view the logs and fix configuration.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
