### PR TITLE
Fix system tray Open Sunshine

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -52,7 +52,7 @@ namespace system_tray {
   #else  // if unix
     // set working dir to user home directory
     working_dir = boost::filesystem::path(std::getenv("HOME"));
-    std::string cmd = R"(open ")" + url + R"(")";
+    std::string cmd = R"(xdg-open ")" + url + R"(")";
   #endif
 
     boost::process::environment _env = boost::this_process::environment();

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -49,7 +49,7 @@ namespace system_tray {
     // this isn't ideal as it briefly shows a command window
     // but start a command built into cmd, not an executable
     std::string cmd = R"(cmd /C "start )" + url + R"(")";
-  #else  // if unix
+  #elif defined(__linux__) || defined(linux) || defined(__linux)
     // set working dir to user home directory
     working_dir = boost::filesystem::path(std::getenv("HOME"));
     std::string cmd = R"(xdg-open ")" + url + R"(")";

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -53,6 +53,8 @@ namespace system_tray {
     // set working dir to user home directory
     working_dir = boost::filesystem::path(std::getenv("HOME"));
     std::string cmd = R"(xdg-open ")" + url + R"(")";
+  #elif defined(__APPLE__) || defined(__MACH__)
+    std::string cmd = R"(open ")" + url + R"(")";
   #endif
 
     boost::process::environment _env = boost::this_process::environment();


### PR DESCRIPTION
## Description
In Linux, the action to Open Sunshine in the system tray did not work. The action calls "open URL", but really it should be "xdg-open URL".

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
