### PR TITLE
Expose subset of client connection variables to commands

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -758,7 +758,8 @@ namespace nvhttp {
     }
 
     if (appid > 0) {
-      auto err = proc::proc.execute(appid);
+      auto mode = get_arg(args, "mode");
+      auto err = proc::proc.execute(appid, mode);
       if (err) {
         tree.put("root.<xmlattr>.status_code", err);
         tree.put("root.<xmlattr>.status_message", "Failed to start the specified application");

--- a/src/process.h
+++ b/src/process.h
@@ -65,7 +65,7 @@ namespace proc {
         _apps(std::move(apps)) {}
 
     int
-    execute(int app_id);
+    execute(int app_id, std::string mode);
 
     /**
      * @return _app_id if a process is running, otherwise returns 0
@@ -98,9 +98,16 @@ namespace proc {
     boost::process::child _process;
     boost::process::group _process_handle;
 
+    std::string _mode_width;
+    std::string _mode_height;
+    std::string _mode_refresh;
+
     file_t _pipe;
     std::vector<cmd_t>::const_iterator _app_prep_it;
     std::vector<cmd_t>::const_iterator _app_prep_begin;
+
+    void
+    replace_cmd_variables(std::string &cmd);
   };
 
   /**


### PR DESCRIPTION
## Description
Expose client video settings to command execution. Useful for auto auto resolution change using tools such as qres or nircmd.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
