### PR TITLE
Elevated Do/Undo Command Fixes

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -368,6 +368,12 @@ namespace platf {
   display_names(mem_type_e hwdevice_type);
 
   boost::process::child
+  safely_run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group, bool detached);
+
+  boost::process::child
+  run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
+  
+  boost::process::child
   run_unprivileged(const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
 
   enum class thread_priority_e : int {
@@ -389,6 +395,9 @@ namespace platf {
   restart_supported();
   bool
   restart();
+
+  bool
+  unsafe_elevation_enabled();
 
   struct batched_send_info_t {
     const char *buffer;

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -372,7 +372,7 @@ namespace platf {
 
   boost::process::child
   run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
-  
+
   boost::process::child
   run_unprivileged(const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -159,6 +159,17 @@ namespace platf {
   }
 
   bp::child
+  run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+    // Not supported on this platform, simply forward it to run_unprivileged
+    run_unprivileged(cmd, working_dir, env, file, ec, group);
+  }
+
+  safely_run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group, bool detached) {
+    // Not supported on this platform, simply forward it to run_unprivileged
+    run_unprivileged(cmd, working_dir, env, file, ec, group);
+  }
+
+  bp::child
   run_unprivileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     BOOST_LOG(warning) << "run_unprivileged() is not yet implemented for this platform. The new process will run with Sunshine's permissions."sv;
     if (!group) {
@@ -203,6 +214,12 @@ namespace platf {
   bool
   restart() {
     // Restart not supported yet
+    return false;
+  }
+
+  bool
+  unsafe_elevation_enabled() {
+    // This is not supported.
     return false;
   }
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -161,12 +161,13 @@ namespace platf {
   bp::child
   run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     // Not supported on this platform, simply forward it to run_unprivileged
-    run_unprivileged(cmd, working_dir, env, file, ec, group);
+    return run_unprivileged(cmd, working_dir, env, file, ec, group);
   }
 
+  bp::child
   safely_run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group, bool detached) {
     // Not supported on this platform, simply forward it to run_unprivileged
-    run_unprivileged(cmd, working_dir, env, file, ec, group);
+    return run_unprivileged(cmd, working_dir, env, file, ec, group);
   }
 
   bp::child

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -158,6 +158,17 @@ namespace platf {
   }
 
   bp::child
+  run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+    // Not supported on this platform, simply forward it to run_unprivileged
+    return run_unprivileged(cmd, working_dir, env, file, ec, group);
+  }
+
+  bp::child
+  safely_run_privileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group, bool detached) {
+    // Not supported on this platform, simply forward it to run_unprivileged
+    return run_unprivileged(cmd, working_dir, env, file, ec, group);
+  }
+
   run_unprivileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     BOOST_LOG(warning) << "run_unprivileged() is not yet implemented for this platform. The new process will run with Sunshine's permissions."sv;
     if (!group) {
@@ -202,6 +213,12 @@ namespace platf {
   bool
   restart() {
     // Restart not supported yet
+    return false;
+  }
+
+  bool
+  unsafe_elevation_enabled() {
+    // This is not supported.
     return false;
   }
 

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -169,6 +169,7 @@ namespace platf {
     return run_unprivileged(cmd, working_dir, env, file, ec, group);
   }
 
+  bp::child
   run_unprivileged(const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     BOOST_LOG(warning) << "run_unprivileged() is not yet implemented for this platform. The new process will run with Sunshine's permissions."sv;
     if (!group) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -82,7 +82,6 @@ namespace proc {
     return cmd_path.parent_path();
   }
 
-#ifdef __WIN32
   boost::process::child
   run_elevated_cmd(const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &_env, proc::file_t &_pipe, std::error_code &ec) {
     auto unsafe_elevation_enabled = platf::unsafe_elevation_enabled();
@@ -101,7 +100,6 @@ namespace proc {
 
     return child;
   }
-#endif
 
   int
   proc_t::execute(int app_id) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -94,8 +94,8 @@ namespace proc {
       // Execute the elevation request, detached so it doesn't keep the session locked.
       child = platf::safely_run_privileged(cmd, working_dir, _env, _pipe.get(), ec, nullptr, true);
       // Inform user of workaround, making it clear that it is not recommended
-      BOOST_LOG(info) << "To remove prompt for admin rights, you can create a registry key called UnsafeElevation (DWORD) with a value of 1 under HKLM/LizardByte/Sunshine."
-                      << "Doing this will make your computer more vulnerable to malware, as it would allow elevation of privelege exploits.";
+      BOOST_LOG(info) << "To remove the prompt for admin rights, you can create a registry key called \"UnsafeElevation\" (DWORD) with a value of 1 under HKLM\\LizardByte\\Sunshine."
+                      << "Enabling \"UnsafeElevation\" will make your computer more vulnerable to malware, as it would allow elevation of privilege exploits.";
     }
 
     return child;


### PR DESCRIPTION
## Description
Adds support for executing do/undo commands (safely) with elevation prompts. 

If users prefer to make their system vulnerable by disabling the prompts, they can add a registry key called UnsafeElevation under HKLM/LizardByte/Sunshine with a value of 1.

When doing that, it will launch the commands under system and inform the user (via logs) that they are vulnerable to exploits.




### Issues Fixed or Closed
#1117 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
