### PR TITLE
revert: execute do/undo commands non-elevated

### DIFF
--- a/src/process.h
+++ b/src/process.h
@@ -87,7 +87,6 @@ namespace proc {
 
     boost::process::environment _env;
     std::vector<ctx_t> _apps;
-    ctx_t _app;
 
     // If no command associated with _app_id, yet it's still running
     bool placebo {};
@@ -96,8 +95,8 @@ namespace proc {
     boost::process::group _process_handle;
 
     file_t _pipe;
-    std::vector<cmd_t>::const_iterator _app_prep_it;
-    std::vector<cmd_t>::const_iterator _app_prep_begin;
+    std::vector<cmd_t>::const_iterator _undo_it;
+    std::vector<cmd_t>::const_iterator _undo_begin;
   };
 
   /**


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Revert "Execute do/undo commands non-elevated" #1022.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
