### PR TITLE
Fix compilation on macOS

### DIFF
--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -3,6 +3,7 @@
 #ifndef SUNSHINE_THREAD_SAFE_H
 #define SUNSHINE_THREAD_SAFE_H
 
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <functional>


### PR DESCRIPTION
## Description
Compilation fails on `Clang 14.0.0 x86_64-apple-darwin21.6.0` from `Xcode 14.2` with the following message:
```
[build] /Users/user/Documents/Sunshine/src/thread_safe.h:450:52: error: implicit instantiation of undefined template 'std::array<unsigned char, 128>'
[build]     std::array<std::uint8_t, sizeof(element_type)> _object_buf;
```
Including the missing header fixes the problem.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
