### PR TITLE
Make Do/Undo Commands Optional

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -816,12 +816,12 @@ namespace config {
     boost::property_tree::read_json(jsonStream, jsonTree);
 
     for (auto &[_, prep_cmd] : jsonTree.get_child("prep_cmd"s)) {
-      auto do_cmd = prep_cmd.get<std::string>("do"s);
-      auto undo_cmd = prep_cmd.get<std::string>("undo"s);
+      auto do_cmd = prep_cmd.get_optional<std::string>("do"s);
+      auto undo_cmd = prep_cmd.get_optional<std::string>("undo"s);
 
       input.emplace_back(
-        std::move(do_cmd),
-        std::move(undo_cmd));
+        std::move(do_cmd.value_or("")),
+        std::move(undo_cmd.value_or("")));
     }
   }
 


### PR DESCRIPTION
## Description
Allows users to be able to completely omit a do or undo command and if they prefer to use an empty value instead, they can. There is no need for using cmd or any other workarounds.



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
