### PR TITLE
Create config directories recursively

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1138,7 +1138,7 @@ namespace config {
 
     // create appdata folder if it does not exist
     if (!boost::filesystem::exists(platf::appdata().string())) {
-      boost::filesystem::create_directory(platf::appdata().string());
+      boost::filesystem::create_directories(platf::appdata().string());
     }
 
     // create config file if it does not exist

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -488,7 +488,7 @@ namespace confighttp {
 
     const std::string coverdir = platf::appdata().string() + "/covers/";
     if (!boost::filesystem::exists(coverdir)) {
-      boost::filesystem::create_directory(coverdir);
+      boost::filesystem::create_directories(coverdir);
     }
 
     std::basic_string path = coverdir + http::url_escape(key) + ".png";


### PR DESCRIPTION
## Description
Running on macOS without `~/.config` folder got me this

```
user@macos build % ./sunshine
libc++abi: terminating with uncaught exception of type boost::filesystem::filesystem_error: boost::filesystem::create_directory: No such file or directory [system:2]: "/Users/user/.config/sunshine"
zsh: abort      ./sunshine
```

Should be very straightforward fix, switch to recursive variant of boost function
https://www.boost.org/doc/libs/1_66_0/libs/filesystem/doc/reference.html#create_directories

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
