### PR TITLE
packaging: fix macos dmg

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -102,7 +102,6 @@ body:
         - Linux - solus (Third Party)
         - macOS - dmg
         - macOS - Portfile
-        - macOS - pkg
         - Windows - Chocolatey (Third Party)
         - Windows - installer
         - Windows - portable
@@ -111,6 +110,7 @@ body:
         - other (not listed)
         - other (self built)
         - other (fork of this repo)
+        - n/a
     validations:
       required: true
   - type: dropdown
@@ -123,6 +123,7 @@ body:
         - Intel
         - Nvidia
         - none (software encoding)
+        - n/a
     validations:
       required: true
   - type: input

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -514,13 +514,10 @@ jobs:
 
           # package
           cpack -G DragNDrop
-          mv ./cpack_artifacts/Sunshine.dmg ../artifacts/sunshine-macos-experimental-dragndrop.dmg
+          mv ./cpack_artifacts/Sunshine.dmg ../artifacts/sunshine.dmg
 
-          cpack -G Bundle
-          mv ./cpack_artifacts/Sunshine.dmg ../artifacts/sunshine-macos-experimental-bundle.dmg
-
-          cpack -G ZIP
-          mv ./cpack_artifacts/Sunshine.zip ../artifacts/sunshine-macos-experimental-archive.zip
+          # cpack -G Bundle
+          # mv ./cpack_artifacts/Sunshine.dmg ../artifacts/sunshine-bundle.dmg
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
@@ -528,29 +525,19 @@ jobs:
           name: sunshine-macos
           path: artifacts/
 
-      # this step can be removed after packages are fixed
-      - name: Delete experimental packages
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        working-directory: artifacts
-        run: |
-          rm -f ./sunshine-macos-experimental-dragndrop.dmg
-          rm -f ./sunshine-macos-experimental-bundle.dmg
-          rm -f ./sunshine-macos-experimental-archive.zip
-
-#      #  no artifacts to release currently
-#      - name: Create/Update GitHub Release
-#        if: ${{ needs.setup_release.outputs.create_release == 'true' }}
-#        uses: ncipollo/release-action@v1
-#        with:
-#          name: ${{ needs.setup_release.outputs.release_name }}
-#          tag: ${{ needs.setup_release.outputs.release_tag }}
-#          commit: ${{ needs.setup_release.outputs.release_commit }}
-#          artifacts: "*artifacts/*"
-#          token: ${{ secrets.GH_BOT_TOKEN }}
-#          allowUpdates: true
-#          body: ${{ needs.setup_release.outputs.release_body }}
-#          discussionCategory: announcements
-#          prerelease: ${{ needs.setup_release.outputs.pre_release }}
+      - name: Create/Update GitHub Release
+        if: ${{ needs.setup_release.outputs.create_release == 'true' }}
+        uses: ncipollo/release-action@v1
+        with:
+          name: ${{ needs.setup_release.outputs.release_name }}
+          tag: ${{ needs.setup_release.outputs.release_tag }}
+          commit: ${{ needs.setup_release.outputs.release_commit }}
+          artifacts: "*artifacts/*"
+          token: ${{ secrets.GH_BOT_TOKEN }}
+          allowUpdates: true
+          body: ${{ needs.setup_release.outputs.release_body }}
+          discussionCategory: announcements
+          prerelease: ${{ needs.setup_release.outputs.pre_release }}
 
   build_mac_port:
     name: Macports
@@ -727,25 +714,6 @@ jobs:
             echo "::endgroup::"
           done
           exit "$fail"
-
-      - name: Package
-        run: |
-          # create packages
-          sudo port pkg sunshine
-          sudo port dmg sunshine
-
-          work=$(port work sunshine)
-          echo "Sunshine port work directory: ${work}"
-
-          # move components out of port work directory
-          sudo mv ${work}/Sunshine*component.pkg /tmp/
-
-          # copy artifacts
-          sudo mv ${work}/Sunshine*.pkg ./artifacts/sunshine.pkg
-          sudo mv ${work}/Sunshine*.dmg ./artifacts/sunshine.dmg
-
-          # move components back
-          # sudo mv /tmp/Sunshine*component.pkg ${work}/
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/docs/source/about/installation.rst
+++ b/docs/source/about/installation.rst
@@ -190,11 +190,11 @@ macOS
 -----
 Sunshine on macOS is experimental. Gamepads do not work. Other features may not work as expected.
 
-pkg
+dmg
 ^^^
-.. Warning:: The `pkg` does not include runtime dependencies.
+.. Warning:: The `dmg` does not include runtime dependencies.
 
-#. Download the ``sunshine.pkg`` file and install it as normal.
+#. Download the ``sunshine.dmg`` file and install it.
 
 Uninstall:
    .. code-block:: bash


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
dmg for macOS (created by macports) was approaching 900mb... This PR moves to create a drag-n-drop package by cpack.

Note: The dmg is still not recommended for use. I think we need to statically link on macOS like we do for Windows.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
