### PR TITLE
Maximize resource eviction priority

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -118,6 +118,8 @@ namespace platf::dxgi {
     capture_e
     release_frame();
 
+    IDXGIResource *last_surface = nullptr;  // no refcounting, only for checking whether we got a different texture object
+
     ~duplication_t();
   };
 

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -254,6 +254,8 @@ namespace platf::dxgi {
             BOOST_LOG(error) << "Failed to create staging texture [0x"sv << util::hex(status).to_string_view() << ']';
             return capture_e::error;
           }
+
+          texture->SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
         }
 
         // It's possible for our display enumeration to race with mode changes and result in

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -533,6 +533,8 @@ namespace platf::dxgi {
       frame_texture->AddRef();
       hwframe_texture.reset(frame_texture);
 
+      hwframe_texture->SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
+
       float info_in[16 / sizeof(float)] { 1.0f / (float) out_width_f };  //aligned to 16-byte
       info_scene = make_buffer(device.get(), info_in);
 
@@ -764,6 +766,8 @@ namespace platf::dxgi {
         return -1;
       }
 
+      img_ctx.encoder_texture->SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
+
       // Get the keyed mutex to synchronize with the capture code
       status = img_ctx.encoder_texture->QueryInterface(__uuidof(IDXGIKeyedMutex), (void **) &img_ctx.encoder_mutex);
       if (FAILED(status)) {
@@ -860,6 +864,8 @@ namespace platf::dxgi {
       BOOST_LOG(error) << "Failed to create mouse texture [0x"sv << util::hex(status).to_string_view() << ']';
       return false;
     }
+
+    texture->SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
 
     // Free resources before allocating on the next line.
     cursor.input_res.reset();
@@ -1058,6 +1064,8 @@ namespace platf::dxgi {
         BOOST_LOG(error) << "Failed to create frame copy texture [0x"sv << util::hex(status).to_string_view() << ']';
         return false;
       }
+
+      surface->SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
 
       return true;
     };
@@ -1396,6 +1404,8 @@ namespace platf::dxgi {
       BOOST_LOG(error) << "Failed to create img buf texture [0x"sv << util::hex(status).to_string_view() << ']';
       return -1;
     }
+
+    img->capture_texture->SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
 
     status = device->CreateRenderTargetView(img->capture_texture.get(), nullptr, &img->capture_rt);
     if (FAILED(status)) {

--- a/src/stat_trackers.h
+++ b/src/stat_trackers.h
@@ -30,7 +30,7 @@ namespace stat_trackers {
 
   private:
     struct {
-      std::chrono::steady_clock::steady_clock::time_point last_callback_time = std::chrono::steady_clock::now();
+      std::chrono::steady_clock::time_point last_callback_time = std::chrono::steady_clock::now();
       T stat_min = std::numeric_limits<T>::max();
       T stat_max = 0;
       double stat_total = 0;


### PR DESCRIPTION
## Description
Follow-up to https://github.com/LizardByte/Sunshine/pull/1098, split up because that pull request is big enough already.
After we keep our image pool at minimal size, it makes sense to raise eviction priority of direct3d resources so they don't get dumped into system memory. Corresponding api function https://learn.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11resource-setevictionpriority. Not sure if we should go for "maximum", stop at more safe "high", or mix them.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
