### PR TITLE
Use Share button on DS4 controllers (ViGEm DS4_BUTTON_SHARE) as BACK action

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -494,6 +494,7 @@ namespace platf {
   if(flags & LEFT_BUTTON)  buttons |= DS4_BUTTON_SHOULDER_LEFT;
   if(flags & RIGHT_BUTTON) buttons |= DS4_BUTTON_SHOULDER_RIGHT;
   if(flags & START)        buttons |= DS4_BUTTON_OPTIONS;
+  if(flags & BACK)         buttons |= DS4_BUTTON_SHARE;
   if(flags & A)            buttons |= DS4_BUTTON_CROSS;
   if(flags & B)            buttons |= DS4_BUTTON_CIRCLE;
   if(flags & X)            buttons |= DS4_BUTTON_SQUARE;
@@ -510,7 +511,6 @@ namespace platf {
   ds4_special_buttons(const gamepad_state_t &gamepad_state) {
     int buttons {};
 
-    if (gamepad_state.buttonFlags & BACK) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
     if (gamepad_state.buttonFlags & HOME) buttons |= DS4_SPECIAL_BUTTON_PS;
 
     return (DS4_SPECIAL_BUTTONS) buttons;


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

It is currently not possible to register a "BACK" action (Select / Share button press) when Sunshine is configured to emulate a DS4 controller on Windows.
This seems to be due to the BACK action being triggered by the touchpad button press instead.
When testing I was not able to register a BACK action using the touchpad, since as soon as the touchpad is pressed it is treated as a mouse input instead.

This PR is a simple fix for the "BACK" functionality on DS4 controller emulation when using a DS4 or DualSense controller, which maps it to the Share button, and unmaps the non-functional touchpad press.

(It is up to interpretation whether this is a breaking change, as it unmaps the touchpad press despite the touchpad press seemingly being incorrectly registered.)

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

- Fixes #799
- Most likely related to #965
- Possibly related to #1064

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
