### PR TITLE
Enable DPI Scaling on Windows Installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,6 +789,7 @@ if(WIN32) # see options at: https://cmake.org/cmake/help/latest/cpack_gen/nsis.h
             "https://sunshinestream.readthedocs.io" "Sunshine documentation"
             "https://app.lizardbyte.dev" "LizardByte Web Site"
             "https://app.lizardbyte.dev/support" "LizardByte Support")
+    set(CPACK_NSIS_MANIFEST_DPI_AWARE true)
 
     # Setting components groups and dependencies
     # sunshine binary


### PR DESCRIPTION
## Description
Enables the DPI scaling on the Windows Installer, so that text does not appear blurry or have jagged edges for users who install Sunshine on high resolution screens.




## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
