### PR TITLE
Don't zero-initialize non-dummy textures

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1106,15 +1106,20 @@ namespace platf::dxgi {
     t.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
     t.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
 
-    auto dummy_data = std::make_unique<std::uint8_t[]>(img->row_pitch * img->height);
-    std::fill_n(dummy_data.get(), img->row_pitch * img->height, 0);
-    D3D11_SUBRESOURCE_DATA initial_data {
-      dummy_data.get(),
-      (UINT) img->row_pitch,
-      0
-    };
-
-    auto status = device->CreateTexture2D(&t, &initial_data, &img->capture_texture);
+    HRESULT status;
+    if (dummy) {
+      auto dummy_data = std::make_unique<std::uint8_t[]>(img->row_pitch * img->height);
+      std::fill_n(dummy_data.get(), img->row_pitch * img->height, 0);
+      D3D11_SUBRESOURCE_DATA initial_data {
+        dummy_data.get(),
+        (UINT) img->row_pitch,
+        0
+      };
+      status = device->CreateTexture2D(&t, &initial_data, &img->capture_texture);
+    }
+    else {
+      status = device->CreateTexture2D(&t, nullptr, &img->capture_texture);
+    }
     if (FAILED(status)) {
       BOOST_LOG(error) << "Failed to create img buf texture [0x"sv << util::hex(status).to_string_view() << ']';
       return -1;


### PR DESCRIPTION
## Description
Follow-up to https://github.com/LizardByte/Sunshine/pull/1098, split up because that pull request is big enough already.
After we start dynamically adjusting capture buffer size, this operation is not free anymore.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
