### PR TITLE
Remove useless Flush() call

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -333,10 +333,6 @@ namespace platf::dxgi {
       device_ctx->PSSetShaderResources(0, 1, &img_ctx.encoder_input_res);
       device_ctx->Draw(3, 0);
 
-      // Artifacts start appearing on the rendered image if Sunshine doesn't flush
-      // before rendering on the UV part of the image.
-      device_ctx->Flush();
-
       device_ctx->OMSetRenderTargets(1, &nv12_UV_rt, nullptr);
       device_ctx->VSSetShader(convert_UV_vs.get(), nullptr, 0);
       device_ctx->PSSetShader(convert_UV_ps.get(), nullptr, 0);


### PR DESCRIPTION
## Description
This `Flush()` call was introduced by Loki back in 7aff15f7430310a58a9272c03f5e2fd28ec7281a when adding the extra draw calls for the aspect-ratio padding. Since we no longer use that approach for aspect-ratio padding, we can nuke the flush too. Unnecessary flushes can have a perf cost (though the cost of this one seems very minimal in my testing).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
