### PR TITLE
Fixes for keyboard issues with mobile Moonlight clients

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -436,7 +436,7 @@ namespace platf {
   void
   hscroll(input_t &input, int distance);
   void
-  keyboard(input_t &input, uint16_t modcode, bool release);
+  keyboard(input_t &input, uint16_t modcode, bool release, uint8_t flags);
   void
   gamepad(input_t &input, int nr, const gamepad_state_t &gamepad_state);
   void

--- a/src/platform/linux/input.cpp
+++ b/src/platform/linux/input.cpp
@@ -1337,14 +1337,15 @@ namespace platf {
  * @param input The input_t instance to use.
  * @param modcode The moonlight key code.
  * @param release Whether the event was a press (false) or a release (true)
+ * @param flags SS_KBE_FLAG_* values
  *
  * EXAMPLES:
  * ```cpp
- * x_keyboard(input, 0x5A, false); // Press Z
+ * x_keyboard(input, 0x5A, false, 0); // Press Z
  * ```
  */
   static void
-  x_keyboard(input_t &input, uint16_t modcode, bool release) {
+  x_keyboard(input_t &input, uint16_t modcode, bool release, uint8_t flags) {
 #ifdef SUNSHINE_BUILD_X11
     auto keycode = keysym(modcode);
     if (keycode.keysym == UNKNOWN) {
@@ -1371,17 +1372,18 @@ namespace platf {
  * @param input The input_t instance to use.
  * @param modcode The moonlight key code.
  * @param release Whether the event was a press (false) or a release (true)
+ * @param flags SS_KBE_FLAG_* values
  *
  * EXAMPLES:
  * ```cpp
- * keyboard(input, 0x5A, false); // Press Z
+ * keyboard(input, 0x5A, false, 0); // Press Z
  * ```
  */
   void
-  keyboard(input_t &input, uint16_t modcode, bool release) {
+  keyboard(input_t &input, uint16_t modcode, bool release, uint8_t flags) {
     auto keyboard = ((input_raw_t *) input.get())->keyboard_input.get();
     if (!keyboard) {
-      x_keyboard(input, modcode, release);
+      x_keyboard(input, modcode, release, flags);
       return;
     }
 

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -230,7 +230,7 @@ const KeyCodeMap kKeyCodesMap[] = {
   }
 
   void
-  keyboard(input_t &input, uint16_t modcode, bool release) {
+  keyboard(input_t &input, uint16_t modcode, bool release, uint8_t flags) {
     auto key = keysym(modcode);
 
     BOOST_LOG(debug) << "got keycode: 0x"sv << std::hex << modcode << ", translated to: 0x" << std::hex << key << ", release:" << release;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -338,15 +338,16 @@ namespace platf {
   }
 
   void
-  keyboard(input_t &input, uint16_t modcode, bool release) {
+  keyboard(input_t &input, uint16_t modcode, bool release, uint8_t flags) {
     auto raw = (input_raw_t *) input.get();
 
     INPUT i {};
     i.type = INPUT_KEYBOARD;
     auto &ki = i.ki;
 
-    // For some reason, MapVirtualKey(VK_LWIN, MAPVK_VK_TO_VSC) doesn't seem to work :/
-    if (modcode != VK_LWIN && modcode != VK_RWIN && modcode != VK_PAUSE && raw->keyboard_layout != NULL) {
+    // If the client did not normalize this VK code to a US English layout, we can't accurately convert it to a scancode.
+    if (!(flags & SS_KBE_FLAG_NON_NORMALIZED) && modcode != VK_LWIN && modcode != VK_RWIN && modcode != VK_PAUSE && raw->keyboard_layout != NULL) {
+      // For some reason, MapVirtualKey(VK_LWIN, MAPVK_VK_TO_VSC) doesn't seem to work :/
       ki.wScan = MapVirtualKeyEx(modcode, MAPVK_VK_TO_VSC, raw->keyboard_layout);
     }
 
@@ -355,7 +356,7 @@ namespace platf {
       ki.dwFlags = KEYEVENTF_SCANCODE;
     }
     else {
-      // If there is no scancode mapping, send it as a regular VK event.
+      // If there is no scancode mapping or it's non-normalized, send it as a regular VK event.
       ki.wVk = modcode;
     }
 


### PR DESCRIPTION
## Description
This PR fixes 2 keyboard bugs that impact the mobile Moonlight clients.

- Android and iOS key input, especially from the software keyboard, cannot always be normalized to the US English layout that we use for scancode conversion. In that case, the latest iOS and Android clients will pass `SS_KBE_FLAG_NON_NORMALIZED` to tell the host that these are from an unknown layout. When we receive a non-normalized key event, we will not perform scan code conversion and instead just send the VK value unchanged. This fixes input from non-US keyboard layouts on iOS and Android.
- The Android software keyboard has peculiar behavior for modifiers. It will send a key up+down combo for the Shift key when Shift is toggled on/off, but then uses the modifier flags on each subsequent event to indicate whether Shift is active or not. Sunshine was ignoring the modifier flags, so capital letters or symbols that required Shift wouldn't work with the Android software keyboard.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
