### PR TITLE
Add support for RGBA capture for Windows software encoding

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -180,6 +180,7 @@ namespace platf {
     img_t &
     operator=(const img_t &) = delete;
 
+    // Keep this in sync with platform/linux/cuda.cu
     std::uint8_t *data {};
     std::int32_t width {};
     std::int32_t height {};

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -185,6 +185,7 @@ namespace platf {
     std::int32_t height {};
     std::int32_t pixel_pitch {};
     std::int32_t row_pitch {};
+    bool is_bgr = true;
 
     virtual ~img_t() = default;
   };

--- a/src/platform/linux/cuda.cu
+++ b/src/platform/linux/cuda.cu
@@ -37,11 +37,13 @@ using namespace std::literals;
 namespace platf {
 struct img_t: std::enable_shared_from_this<img_t> {
 public:
+  // Keep this in sync with platform/common.h
   std::uint8_t *data {};
   std::int32_t width {};
   std::int32_t height {};
   std::int32_t pixel_pitch {};
   std::int32_t row_pitch {};
+  bool is_bgr = true;
 
   virtual ~img_t() = default;
 };

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -113,9 +113,14 @@ namespace video {
         data[1] = sw_frame->data[1] + offsetUV * 2;
         data[2] = nullptr;
       }
-      else {
+      else if (img.is_bgr) {  // BGR0
         data[1] = sw_frame->data[1] + offsetUV;
         data[2] = sw_frame->data[2] + offsetUV;
+        data[3] = nullptr;
+      }
+      else {  // RGB0
+        data[1] = sw_frame->data[2] + offsetUV;
+        data[2] = sw_frame->data[1] + offsetUV;
         data[3] = nullptr;
       }
 


### PR DESCRIPTION
## Description
This PR adds support for RGBA capture for software encoding on Windows. Previously, DWM had to convert RGBA desktop surfaces to BGRA for our capture code, which causes additional load on the system and reduces performance.

I pulled in the changes from @psyke83 's old PR #522 for handling RGB surfaces in video.cpp with modifications to work with the current code.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
