### PR TITLE
Fix iteration of Undo Commands

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -206,9 +206,10 @@ namespace proc {
     _process = bp::child();
     _process_handle = bp::group();
     _app_id = -1;
+    _app_prep_it = std::begin(_app.prep_cmds);
 
-    for (; _app_prep_it != _app_prep_begin; --_app_prep_it) {
-      auto &cmd = (_app_prep_it - 1)->undo_cmd;
+    for (; _app_prep_it != std::end(_app.prep_cmds); ++_app_prep_it) {
+      auto &cmd = _app_prep_it->undo_cmd;
 
       if (cmd.empty()) {
         continue;


### PR DESCRIPTION
## Description
Currently, the undo commands iterate backwards while the do commands iterate forwards, causing a mismatch between the do and undo commands. This can be particularly problematic when performing a sequence of actions where the order is crucial. Notable examples would be activating a monitor and then changing the resolution, since it is backward that would mean the resolution changes before the monitor, for example.






## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ x] I want maintainers to keep my branch updated
