### PR TITLE
add X11 to PLATFORM_LIBARIES when found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,7 @@ else()
     if(X11_FOUND)
         add_compile_definitions(SUNSHINE_BUILD_X11)
         include_directories(${X11_INCLUDE_DIR})
+        list(APPEND PLATFORM_LIBRARIES ${X11_LIBRARIES})
         list(APPEND PLATFORM_TARGET_FILES src/platform/linux/x11grab.cpp)
     endif()
 


### PR DESCRIPTION
## Description
Prior to https://github.com/LizardByte/Sunshine/pull/997 it appears that full X11 libraries were only needed as part of `FFMPEG_PLATFORM_LIBRARIES` -- however, after this change, they are also needed outside the context of FFmpeg. This PR adds them to `PLATFORM_LIBRARIES` when found to satisfy this requirement.

Believe this is not an issue currently because the requirement is handled by `FFMPEG_PLATFORM_LIBRARIES` -- however it manifests as part of the [nixpkgs packaging of Sunshine](https://github.com/NixOS/nixpkgs/pull/224152) as we use FFmpeg from nixpkgs rather than the prebuilt version.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
