### PR TITLE
(Windows) Use framelimiter only when needed

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -111,21 +111,17 @@ namespace platf::dxgi {
     duplication_frametime_t(std::size_t buffer_size);
 
     void
-    start_measuring();
+    save_frame_update_timepoint(const LONGLONG timepoint);
 
-    //! \returns the end timepoint for convenience
-    std::chrono::steady_clock::time_point
-    stop_measuring();
-
-    std::chrono::nanoseconds
+    LONGLONG
     get_rolling_average() const;
 
     void
     clear();
 
   private:
-    std::chrono::steady_clock::time_point start_timepoint;
-    std::vector<std::chrono::nanoseconds> frametimes;
+    LONGLONG last_timepoint;
+    std::vector<LONGLONG> frametimes;
     std::size_t max_buffer_size;
     std::size_t buffer_index;
   };
@@ -133,9 +129,10 @@ namespace platf::dxgi {
   class duplication_t {
   public:
     dup_t dup;
-    std::chrono::steady_clock::time_point last_valid_capture_timepoint;
-    std::chrono::nanoseconds desired_frametime;
+    LONGLONG last_valid_capture_timepoint;
+    LONGLONG desired_frametime;
     duplication_frametime_t frametimes { 60 /* hardcoded buffer size, should be more than enough for rolling average*/ };
+    bool mouse_update_was_processed {};
     bool has_frame {};
     bool use_dwmflush {};
 

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <codecvt>
 #include <initguid.h>
+#include <numeric>
 
 #include <boost/process.hpp>
 
@@ -25,8 +26,50 @@ namespace platf {
 namespace platf::dxgi {
   namespace bp = boost::process;
 
+  duplication_frametime_t::duplication_frametime_t(std::size_t buffer_size):
+      max_buffer_size { buffer_size }, buffer_index { 0 } {
+    BOOST_ASSERT(max_buffer_size > 0);
+    frametimes.reserve(max_buffer_size);
+  }
+
+  void
+  duplication_frametime_t::start_measuring() {
+    start_timepoint = std::chrono::steady_clock::now();
+  }
+
+  std::chrono::steady_clock::time_point
+  duplication_frametime_t::stop_measuring() {
+    const auto end_timepoint = std::chrono::steady_clock::now();
+    const auto frametime = end_timepoint - start_timepoint;
+
+    // If the the buffer size has already reached the max possible, we need to start managing circular buffer manually
+    if (frametimes.size() == max_buffer_size) {
+      frametimes[buffer_index++] = frametime;
+      if (buffer_index >= max_buffer_size) {
+        buffer_index = 0;
+      }
+    }
+    else {
+      frametimes.push_back(frametime);
+    }
+
+    return end_timepoint;
+  }
+
+  std::chrono::nanoseconds
+  duplication_frametime_t::get_rolling_average() const {
+    const auto sum = std::accumulate(std::begin(frametimes), std::end(frametimes), std::chrono::nanoseconds(0));
+    return frametimes.size() == 0 ? std::chrono::nanoseconds(0) : std::chrono::nanoseconds(sum / frametimes.size());
+  }
+
+  void
+  duplication_frametime_t::clear() {
+    frametimes.clear();
+    buffer_index = 0;
+  }
+
   capture_e
-  duplication_t::next_frame(DXGI_OUTDUPL_FRAME_INFO &frame_info, std::chrono::milliseconds timeout, resource_t::pointer *res_p) {
+  duplication_t::next_frame_without_skipping(DXGI_OUTDUPL_FRAME_INFO &frame_info, std::chrono::milliseconds timeout, resource_t::pointer *res_p) {
     auto capture_status = release_frame();
     if (capture_status != capture_e::ok) {
       return capture_status;
@@ -52,6 +95,95 @@ namespace platf::dxgi {
         BOOST_LOG(error) << "Couldn't acquire next frame [0x"sv << util::hex(status).to_string_view();
         return capture_e::error;
     }
+  }
+
+  capture_e
+  duplication_t::next_frame(DXGI_OUTDUPL_FRAME_INFO &frame_info, std::chrono::milliseconds timeout, resource_t::pointer *res_p) {
+    // The idea of this framelimiter algorithm is to rely on the `IDXGIOutputDuplication::AcquireNextFrame` to actually wait for the
+    // next frame to be available and then, once it is acquired, discard it or use it.
+    //
+    // The main goal here is not to incur any additional sleep/wait as it messes with the framepacing when the
+    // streamed FPS == rendered FPS.
+    // Ideally this framelimiter kicks in only when the streamed FPS < rendered FPS.
+    //
+    // Why is the normal sleep/wait approach not good enough?
+    // Consider that we are streaming 60 FPS, this gives us 16.67ms of frametime. Ideally we could sleep for
+    // 16.67ms, wake up, grab a frame and repeat. The problem is that the frame can become available way earlier
+    // or later than 16.67ms. Here is an example of measured frametimes for 1 second (measurements were done in Sunshine itself):
+    //
+    // 20.91ms 12.301ms 16.682ms 19.66ms 13.574ms 18.489ms 14.844ms 16.758ms 18.042ms 15.422ms 16.617ms 17.49ms
+    // 15.956ms 16.663ms 16.271ms 16.751ms 16.92ms 16.993ms 16.783ms 15.792ms 16.245ms 17.81ms 16.701ms 16.723ms
+    // 16.572ms 16.34ms 16.669ms 16.645ms 16.683ms 16.152ms 16.632ms 17.023ms 16.623ms 17.045ms 16.421ms 16.591ms
+    // 16.825ms 16.368ms 16.416ms 17.463ms 16.249ms 17.191ms 17.003ms 15.979ms 16.299ms 17.004ms 16.798ms 16.173ms
+    // 16.642ms 17.057ms 16.609ms 17.021ms 16.396ms 16.602ms 16.964ms 16.998ms 16.62ms 16.002ms 16.698ms 16.993ms
+    //
+    // As you can see we have frametimes ranging anywhere from 12.301ms to 20.91ms. On those ocassions any aditional
+    // sleep/wait may give the feeling of stutter when panning the camera and etc.
+
+    // This is our target point. If we are close enough to this timepoint,
+    // the frame is good enough for us to use. More about skipping frames below.
+    const auto next_expected_capture_timepoint = last_valid_capture_timepoint + desired_frametime;
+
+    std::chrono::steady_clock::time_point capture_end;
+    while (true) {
+      frametimes.start_measuring();
+      const auto status = next_frame_without_skipping(frame_info, timeout, res_p);
+      capture_end = frametimes.stop_measuring();
+
+      if (status != capture_e::ok) {
+        frametimes.clear();
+        last_valid_capture_timepoint = {};
+        return status;
+      }
+
+      // First we need to check if we have a situation like this:
+      // |----------|-x--------|
+      //            T |
+      //              Actual frame
+      //
+      // In case we have already missed the target timepoint (T), we need to use the current frame as soon as possible.
+      // No need to think about anything else...
+      if (capture_end >= next_expected_capture_timepoint) {
+        break;
+      }
+
+      // This is where it gets tricky.
+      // Consider that we are streaming at 30 FPS while the frames (source) are being provided at 60 FPS
+      // (here `T` - is timepoint where we expect a frame and `x` is when we actually get it):
+      // Source: |----------|----------|--x-------|----------|----------|-------x--|
+      // Stream: |--------------------------------|--------------------------------|
+      //                              T_0 |      T_1                   T_2      | T_3
+      //                                   \                                   /
+      //                                    ->         Actual Frame          <-
+      //
+      // We need a way to figure out if the frame is good enough or not. In case
+      // of T_0 vs T_1, the frame belongs to T_0 (not good enough and we can skip it),
+      // but in the case of T_2 vs T_3, the frame might belong to T_2, if it's very late.
+      // On the other hand, the frame can also belong to T_3 if it came early. In both
+      // cases it is considered good enough to use.
+      //
+      // Here we can subdivide the source's frametime to evalutate if it's good enough to be used:
+      // Source:         |-----------|-----------|--x--------|-----------|-----------|--------x--|
+      // Source/2:       |-----|-----|-----|-----|--x--|-----|-----|-----|-----|-----|-----|--x--|
+      // Stream:         |-----------------------------------|-----------------------------------|
+      // GoodEnoughZone:                               |+++++|                             |+++++|
+      //
+      // What we need additionally is the uniform frametime window the source source is trying to render at,
+      // which we can calculate using the rolling average for more stability
+      // (we want to avoid jumpy frametimes like 12.301ms or 20.91ms).
+      //
+      // Finally, since we are dividing the average frametime, some frames might end up on the fence, so we want
+      // to push it to "good enough" side since we really want to preserve frames if possible.
+      // For that, adding 1ms should be enough.
+      const auto average_frametime = frametimes.get_rolling_average() / 2;
+      static const auto division_offset = 1ms;
+      if (capture_end + division_offset + average_frametime >= next_expected_capture_timepoint) {
+        break;
+      }
+    }
+
+    last_valid_capture_timepoint = capture_end;
+    return capture_e::ok;
   }
 
   capture_e
@@ -93,46 +225,12 @@ namespace platf::dxgi {
 
   capture_e
   display_base_t::capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) {
-    auto next_frame = std::chrono::steady_clock::now();
-
-    // Use CREATE_WAITABLE_TIMER_HIGH_RESOLUTION if supported (Windows 10 1809+)
-    HANDLE timer = CreateWaitableTimerEx(nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
-    if (!timer) {
-      timer = CreateWaitableTimerEx(nullptr, nullptr, 0, TIMER_ALL_ACCESS);
-      if (!timer) {
-        auto winerr = GetLastError();
-        BOOST_LOG(error) << "Failed to create timer: "sv << winerr;
-        return capture_e::error;
-      }
-    }
-
-    auto close_timer = util::fail_guard([timer]() {
-      CloseHandle(timer);
-    });
-
     while (true) {
       // This will return false if the HDR state changes or for any number of other
       // display or GPU changes. We should reinit to examine the updated state of
       // the display subsystem. It is recommended to call this once per frame.
       if (!factory->IsCurrent()) {
         return platf::capture_e::reinit;
-      }
-
-      // If the wait time is between 1 us and 1 second, wait the specified time
-      // and offset the next frame time from the exact current frame time target.
-      auto wait_time_us = std::chrono::duration_cast<std::chrono::microseconds>(next_frame - std::chrono::steady_clock::now()).count();
-      if (wait_time_us > 0 && wait_time_us < 1000000) {
-        LARGE_INTEGER due_time { .QuadPart = -10LL * wait_time_us };
-        SetWaitableTimer(timer, &due_time, 0, nullptr, nullptr, false);
-        WaitForSingleObject(timer, INFINITE);
-        next_frame += delay;
-      }
-      else {
-        // If the wait time is negative (meaning the frame is past due) or the
-        // computed wait time is beyond a second (meaning possible clock issues),
-        // just capture the frame now and resynchronize the frame interval with
-        // the current time.
-        next_frame = std::chrono::steady_clock::now() + delay;
       }
 
       std::shared_ptr<img_t> img_out;
@@ -317,8 +415,6 @@ namespace platf::dxgi {
     // Ensure we can duplicate the current display
     syncThreadDesktop();
 
-    delay = std::chrono::nanoseconds { 1s } / config.framerate;
-
     // Get rectangle of full desktop for absolute mouse coordinates
     env_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
     env_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
@@ -455,6 +551,7 @@ namespace platf::dxgi {
     }
 
     dup.use_dwmflush = config::video.dwmflush && !(config.framerate > refresh_rate) ? true : false;
+    dup.desired_frametime = std::chrono::nanoseconds { 1s } / config.framerate;
 
     // Bump up thread priority
     {

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -176,9 +176,8 @@ namespace platf::dxgi {
 
     DXGI_OUTDUPL_FRAME_INFO frame_info;
 
-    resource_t::pointer res_p {};
-    auto capture_status = dup.next_frame(frame_info, timeout, &res_p);
-    resource_t res { res_p };
+    resource_t res;
+    auto capture_status = dup.next_frame(frame_info, timeout, res);
 
     if (capture_status != capture_e::ok) {
       return capture_status;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -813,9 +813,8 @@ namespace platf::dxgi {
 
     DXGI_OUTDUPL_FRAME_INFO frame_info;
 
-    resource_t::pointer res_p {};
-    auto capture_status = dup.next_frame(frame_info, timeout, &res_p);
-    resource_t res { res_p };
+    resource_t res;
+    auto capture_status = dup.next_frame(frame_info, timeout, res);
 
     if (capture_status != capture_e::ok) {
       return capture_status;


### PR DESCRIPTION
## Description
This change makes use of the `IDXGIOutputDuplication::AcquireNextFrame` to wait for next frames instead of using additional sleep-based framelimiter.

Additionally, a new framelimiter has been introduced to work with the `IDXGIOutputDuplication::AcquireNextFrame` to skip the frames when we actually need to (when streaming at lower FPS than what is being rendered).

### More details

I have been chasing random "jumpy camera movement" for months. The problem is how random it all is.
You can have a very smooth framerate:
![image](https://user-images.githubusercontent.com/22381748/231079625-8a9037c3-bb37-425b-8382-b156ddf6f994.png)

and then out of nowhere it just starts jerking (going into the game menu makes it go away, until it comes back):
![image](https://user-images.githubusercontent.com/22381748/231079788-206678d2-4b19-4012-b568-45d1cd6c37db.png)

It's not always noticeable, until the camera starts jumping. By jumping I mean stuttering, but in a very uniform manner, as if the FPS has dropped to 20 FPS or something.

I have managed to procure a 3 minute test run in Cyberpunk 2077, at the end of which the jerkiness occurs. I then have managed to track it down to the additional sleep/wait that is being done before the `AcquireNextFrame` is called. Once removed, the `AcquireNextFrame` does the waiting. Since then, I have yet to experience that uni-formally jumpy camera action.

So, I have removed the wait/sleep code block and introduced another framelimiter that kicks in if stream FPS < render FPS.

Overall the frametime seems to have improved a little in heavy-load games. Take Hogwarts Legacy for example (here I am standing in the same place and spinning around).

BEFORE:
![image](https://user-images.githubusercontent.com/22381748/231081702-6e7b17b0-a673-47bf-920e-7a2ce0041057.png)
![image](https://user-images.githubusercontent.com/22381748/231081772-747eeb2e-46df-41c0-ac06-53ba57155e30.png)

AFTER:
![image](https://user-images.githubusercontent.com/22381748/231081852-ec55f121-56a1-4fce-b2fa-f3da25754ad6.png)
![image](https://user-images.githubusercontent.com/22381748/231081927-b87b6804-3937-402d-a83f-1fa7ba985144.png)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
