### PR TITLE
Don't copy to intermediate surface when there is no mouse cursor

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -230,7 +230,9 @@ namespace platf::dxgi {
     gpu_cursor_t cursor_alpha;
     gpu_cursor_t cursor_xor;
 
-    texture2d_t last_frame_copy;
+    texture2d_t old_surface_delayed_destruction;
+    std::chrono::steady_clock::time_point old_surface_timestamp;
+    std::variant<std::monostate, texture2d_t, std::shared_ptr<platf::img_t>> last_frame_variant;
 
     std::atomic<uint32_t> next_image_id;
   };

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -101,8 +101,6 @@ namespace platf::dxgi {
   blob_t scene_NW_ps_hlsl;
 
   struct img_d3d_t: public platf::img_t {
-    std::shared_ptr<platf::display_t> display;
-
     // These objects are owned by the display_t's ID3D11Device
     texture2d_t capture_texture;
     render_target_t capture_rt;
@@ -1321,7 +1319,6 @@ namespace platf::dxgi {
     // Initialize format-independent fields
     img->width = width;
     img->height = height;
-    img->display = shared_from_this();
     img->id = next_image_id++;
 
     return img;


### PR DESCRIPTION
## Description
Optimize fullscreen game capture path with copy evasion and save one frame of vram. Currently in draft, it works well, but lacks documentation and instant `std::variant` should be replaced with delayed surface destruction.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
