### PR TITLE
Fix color conversion for Advanced Color SDR displays

### DIFF
--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -362,7 +362,7 @@ namespace platf::dxgi {
 
   std::vector<DXGI_FORMAT>
   display_ram_t::get_supported_capture_formats() {
-    return { DXGI_FORMAT_B8G8R8A8_UNORM };
+    return { DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_B8G8R8X8_UNORM };
   }
 
   int

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1229,6 +1229,7 @@ namespace platf::dxgi {
       // while the client stream is HDR-capable. These UNORM formats can
       // use our normal pixel shaders that expect sRGB input.
       DXGI_FORMAT_B8G8R8A8_UNORM,
+      DXGI_FORMAT_B8G8R8X8_UNORM,
       DXGI_FORMAT_R8G8B8A8_UNORM,
     };
   }

--- a/src_assets/windows/assets/shaders/directx/ConvertUVPS_Linear.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ConvertUVPS_Linear.hlsl
@@ -1,0 +1,36 @@
+Texture2D image : register(t0);
+
+SamplerState def_sampler : register(s0);
+
+struct FragTexWide {
+	float3 uuv : TEXCOORD0;
+};
+
+cbuffer ColorMatrix : register(b0) {
+	float4 color_vec_y;
+	float4 color_vec_u;
+	float4 color_vec_v;
+	float2 range_y;
+	float2 range_uv;
+};
+
+// This is a fast sRGB approximation from Microsoft's ColorSpaceUtility.hlsli
+float3 ApplySRGBCurve(float3 x)
+{
+	return x < 0.0031308 ? 12.92 * x : 1.13005 * sqrt(x - 0.00228) - 0.13448 * x + 0.005719;
+}
+
+float2 main_ps(FragTexWide input) : SV_Target
+{
+	float3 rgb_left = ApplySRGBCurve(saturate(image.Sample(def_sampler, input.uuv.xz)).rgb);
+	float3 rgb_right = ApplySRGBCurve(saturate(image.Sample(def_sampler, input.uuv.yz)).rgb);
+	float3 rgb = (rgb_left + rgb_right) * 0.5;
+	
+	float u = dot(color_vec_u.xyz, rgb) + color_vec_u.w;
+	float v = dot(color_vec_v.xyz, rgb) + color_vec_v.w;
+
+	u = u * range_uv.x + range_uv.y;
+	v = v * range_uv.x + range_uv.y;
+
+	return float2(u, v);
+}

--- a/src_assets/windows/assets/shaders/directx/ConvertYPS_Linear.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ConvertYPS_Linear.hlsl
@@ -1,0 +1,31 @@
+Texture2D image : register(t0);
+
+SamplerState def_sampler : register(s0);
+
+cbuffer ColorMatrix : register(b0) {
+	float4 color_vec_y;
+	float4 color_vec_u;
+	float4 color_vec_v;
+	float2 range_y;
+	float2 range_uv;
+};
+
+struct PS_INPUT
+{
+	float4 pos : SV_POSITION;
+	float2 tex : TEXCOORD;
+};
+
+// This is a fast sRGB approximation from Microsoft's ColorSpaceUtility.hlsli
+float3 ApplySRGBCurve(float3 x)
+{
+	return x < 0.0031308 ? 12.92 * x : 1.13005 * sqrt(x - 0.00228) - 0.13448 * x + 0.005719;
+}
+
+float main_ps(PS_INPUT frag_in) : SV_Target
+{
+	float3 rgb = ApplySRGBCurve(saturate(image.Sample(def_sampler, frag_in.tex, 0)).rgb);
+	float y = dot(color_vec_y.xyz, rgb) + color_vec_y.w;
+
+	return y * range_y.x + range_y.y;
+}


### PR DESCRIPTION
## Description
Since the introduction of HDR, we were not properly handling the case where the client had requested HDR but the server had an Advanced Color SDR display. In that particular case, we would get frames in linear gamma but treat them as if they were sRGB. I believe this was actually noticed in #1032, but I didn't make the connection to this bug at the time.

When #1137 started allowing FP16 formats for SDR clients too, it became much more noticable since it impacted all streams from hosts with Advanced Color SDR displays.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
