### PR TITLE
Improve speed of encoder probing

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -622,13 +622,13 @@ namespace nvhttp {
     tree.put("root.HttpsPort", map_port(PORT_HTTPS));
     tree.put("root.ExternalPort", map_port(PORT_HTTP));
     tree.put("root.mac", platf::get_mac_address(local_endpoint.address().to_string()));
-    tree.put("root.MaxLumaPixelsHEVC", config::video.hevc_mode > 1 ? "1869449984" : "0");
+    tree.put("root.MaxLumaPixelsHEVC", video::active_hevc_mode > 1 ? "1869449984" : "0");
     tree.put("root.LocalIP", local_endpoint.address().to_string());
 
-    if (config::video.hevc_mode == 3) {
+    if (video::active_hevc_mode == 3) {
       tree.put("root.ServerCodecModeSupport", "3843");
     }
-    else if (config::video.hevc_mode == 2) {
+    else if (video::active_hevc_mode == 2) {
       tree.put("root.ServerCodecModeSupport", "259");
     }
     else {
@@ -713,7 +713,7 @@ namespace nvhttp {
     for (auto &proc : proc::proc.get_apps()) {
       pt::ptree app;
 
-      app.put("IsHdrSupported"s, config::video.hevc_mode == 3 ? 1 : 0);
+      app.put("IsHdrSupported"s, video::active_hevc_mode == 3 ? 1 : 0);
       app.put("AppTitle"s, proc.name);
       app.put("ID", proc.id);
 

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -25,6 +25,7 @@ vaSyncBuffer(
 #include "src/main.h"
 #include "src/platform/common.h"
 #include "src/utility.h"
+#include "src/video.h"
 
 using namespace std::literals;
 
@@ -626,11 +627,11 @@ namespace va {
       return false;
     }
 
-    if (config::video.hevc_mode > 1 && !query(display.get(), profile_e::HEVCMain)) {
+    if (video::active_hevc_mode > 1 && !query(display.get(), profile_e::HEVCMain)) {
       return false;
     }
 
-    if (config::video.hevc_mode > 2 && !query(display.get(), profile_e::HEVCMain10)) {
+    if (video::active_hevc_mode > 2 && !query(display.get(), profile_e::HEVCMain10)) {
       return false;
     }
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -19,6 +19,7 @@ extern "C" {
 #include "rtsp.h"
 #include "stream.h"
 #include "sync.h"
+#include "video.h"
 
 #include <unordered_map>
 
@@ -489,7 +490,7 @@ namespace rtsp_stream {
     option.content = const_cast<char *>(seqn_str.c_str());
 
     std::stringstream ss;
-    if (config::video.hevc_mode != 1) {
+    if (video::active_hevc_mode != 1) {
       ss << "sprop-parameter-sets=AAAAAU"sv << std::endl;
     }
 
@@ -690,7 +691,7 @@ namespace rtsp_stream {
       }
     }
 
-    if (config.monitor.videoFormat != 0 && config::video.hevc_mode == 1) {
+    if (config.monitor.videoFormat != 0 && video::active_hevc_mode == 1) {
       BOOST_LOG(warning) << "HEVC is disabled, yet the client requested HEVC"sv;
 
       respond(sock, &option, 400, "BAD REQUEST", req->sequenceNumber, {});

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1106,12 +1106,14 @@ namespace video {
 
     ctx->keyint_min = std::numeric_limits<int>::max();
 
-    if (config.numRefFrames == 0) {
-      ctx->refs = video_format[encoder_t::REF_FRAMES_AUTOSELECT] ? 0 : 16;
-    }
-    else {
-      // Some client decoders have limits on the number of reference frames
-      ctx->refs = video_format[encoder_t::REF_FRAMES_RESTRICT] ? config.numRefFrames : 0;
+    // Some client decoders have limits on the number of reference frames
+    if (config.numRefFrames) {
+      if (video_format[encoder_t::REF_FRAMES_RESTRICT]) {
+        ctx->refs = config.numRefFrames;
+      }
+      else {
+        BOOST_LOG(warning) << "Client requested reference frame limit, but encoder doesn't support it!"sv;
+      }
     }
 
     ctx->flags |= (AV_CODEC_FLAG_CLOSED_GOP | AV_CODEC_FLAG_LOW_DELAY);

--- a/src/video.h
+++ b/src/video.h
@@ -90,6 +90,8 @@ namespace video {
 
   extern color_t colors[6];
 
+  extern int active_hevc_mode;
+
   void
   capture(
     safe::mail_t mail,


### PR DESCRIPTION
## Description
The first commit changes the logic of setting the number of reference frames such that it will always succeed with any FFmpeg encoder. This eliminates the need for probing `REF_FRAMES_AUTOSELECT` in all cases, allowing us to short-circuit that in the next commit. AMD's encoder in particular uses `-1` as the default value for `ctx->refs`, so we were likely forcing 16 reference frames there before on clients that didn't explicitly request 1 reference frame (wasting memory).

The second commit adjusts `validate_encoder()` to eliminate the need for several encoder probes. Probing for `SLICE` is removed in favor of using the existing `SINGLE_SLICE_ONLY` encoder flag, because it appears to not be required for any encoders other than VAAPI. The common case probe count is down from 8 codec opens to 3.

The third commit introduces a faster path for `validate_encoder()` to reject encoders that we don't expect to succeed (based on the fact that we passed them up on the previous probe).

The fourth commit fixes a bug when HEVC mode is set to auto (default), where the first discovered value was locked-in and will not change even if a subsequent encoder is enumerated that does support HEVC after the initial encoder does not.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Resolves #1174 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
