### PR TITLE
Fix system tray bugs when running as a service

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -79,4 +79,10 @@ namespace mail {
 #undef MAIL
 
 }  // namespace mail
+
+namespace lifetime {
+  void
+  exit_sunshine(int exit_code, bool async);
+}  // namespace lifetime
+
 #endif  // SUNSHINE_MAIN_H

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -727,9 +727,10 @@ namespace platf {
 
   bool
   restart() {
-    // Raise SIGINT to trigger the graceful exit logic. The service will
-    // restart us in a few seconds.
-    std::raise(SIGINT);
+    // Gracefully exit. The service will restart us in a few seconds.
+    // We use an async exit call here because we can't block the
+    // HTTP thread or we'll hang shutdown.
+    lifetime::exit_sunshine(0, true);
     return true;
   }
 

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -131,7 +131,15 @@ namespace system_tray {
   tray_quit_cb(struct tray_menu *item) {
     BOOST_LOG(info) << "Quiting from system tray"sv;
 
-    std::raise(SIGINT);
+  #ifdef _WIN32
+    // If we're running in a service, return a special status to
+    // tell it to terminate too, otherwise it will just respawn us.
+    if (GetConsoleWindow() == NULL) {
+      lifetime::exit_sunshine(ERROR_SHUTDOWN_IN_PROGRESS, false);
+    }
+  #endif
+
+    lifetime::exit_sunshine(0, false);
   }
 
   // Tray menu

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -301,9 +301,16 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
         }
         break;
 
-      case WAIT_OBJECT_0 + 1:
+      case WAIT_OBJECT_0 + 1: {
         // Sunshine terminated itself.
+
+        DWORD exit_code;
+        if (GetExitCodeProcess(process_info.hProcess, &exit_code) && exit_code == ERROR_SHUTDOWN_IN_PROGRESS) {
+          // Sunshine is asking for us to shut down, so gracefully stop ourselves.
+          SetEvent(stop_event);
+        }
         break;
+      }
     }
 
     CloseHandle(process_info.hThread);


### PR DESCRIPTION
## Description
This fixes a couple systray bugs when running Sunshine as a service.

- The first commit fixes Explorer's termination detection to ensure the tray icon will disappear when Sunshine terminates unexpectedly. Explorer will try to open a thread handle and delete the tray icon when it is signalled. That fails when running as System because there's no `LogonSessionId` principal in the DACL that would ordinarily grant `SYNCHRONIZE` access to other processes in the same session. To avoid this, we add an ACE to our systray thread that allows `SYNCHRONIZE` access for everyone.
- The second commit makes the Quit option in the systray menu stop the service to avoid automatically respawning Sunshine after quitting.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #1170
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
