### PR TITLE
fix(web ui): add response headers

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -159,7 +159,9 @@ namespace confighttp {
 
     std::string header = read_file(WEB_DIR "header.html");
     std::string content = read_file(WEB_DIR "index.html");
-    response->write(header + content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    response->write(header + content, headers);
   }
 
   void
@@ -170,7 +172,9 @@ namespace confighttp {
 
     std::string header = read_file(WEB_DIR "header.html");
     std::string content = read_file(WEB_DIR "pin.html");
-    response->write(header + content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    response->write(header + content, headers);
   }
 
   void
@@ -179,11 +183,11 @@ namespace confighttp {
 
     print_req(request);
 
-    SimpleWeb::CaseInsensitiveMultimap headers;
-    headers.emplace("Access-Control-Allow-Origin", "https://images.igdb.com/");
-
     std::string header = read_file(WEB_DIR "header.html");
     std::string content = read_file(WEB_DIR "apps.html");
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    headers.emplace("Access-Control-Allow-Origin", "https://images.igdb.com/");
     response->write(header + content, headers);
   }
 
@@ -195,7 +199,9 @@ namespace confighttp {
 
     std::string header = read_file(WEB_DIR "header.html");
     std::string content = read_file(WEB_DIR "clients.html");
-    response->write(header + content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    response->write(header + content, headers);
   }
 
   void
@@ -206,7 +212,9 @@ namespace confighttp {
 
     std::string header = read_file(WEB_DIR "header.html");
     std::string content = read_file(WEB_DIR "config.html");
-    response->write(header + content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    response->write(header + content, headers);
   }
 
   void
@@ -217,7 +225,9 @@ namespace confighttp {
 
     std::string header = read_file(WEB_DIR "header.html");
     std::string content = read_file(WEB_DIR "password.html");
-    response->write(header + content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    response->write(header + content, headers);
   }
 
   void
@@ -229,7 +239,9 @@ namespace confighttp {
     }
     std::string header = read_file(WEB_DIR "header-no-nav.html");
     std::string content = read_file(WEB_DIR "welcome.html");
-    response->write(header + content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    response->write(header + content, headers);
   }
 
   void
@@ -240,7 +252,9 @@ namespace confighttp {
 
     std::string header = read_file(WEB_DIR "header.html");
     std::string content = read_file(WEB_DIR "troubleshooting.html");
-    response->write(header + content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    response->write(header + content, headers);
   }
 
   void
@@ -314,7 +328,9 @@ namespace confighttp {
     print_req(request);
 
     std::string content = read_file(config::stream.file_apps.c_str());
-    response->write(content);
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "application/json");
+    response->write(content, headers);
   }
 
   void


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add "Content-Type" response headers to web ui pages which prevented some browsers from rendering Sunshine pages correctly in some cases, such as if a user was running Sunshine behind a proxy.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Fixes #1186

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
