### PR TITLE
Extend packet header with frame processing latency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,8 @@ set(SUNSHINE_TARGET_FILES
         src/thread_safe.h
         src/sync.h
         src/round_robin.h
+        src/stat_trackers.h
+        src/stat_trackers.cpp
         ${PLATFORM_TARGET_FILES})
 
 set_source_files_properties(src/upnp.cpp PROPERTIES COMPILE_FLAGS -Wno-pedantic)

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -186,6 +186,8 @@ namespace platf {
     std::int32_t pixel_pitch {};
     std::int32_t row_pitch {};
 
+    std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
+
     virtual ~img_t() = default;
   };
 

--- a/src/platform/linux/cuda.cu
+++ b/src/platform/linux/cuda.cu
@@ -1,5 +1,6 @@
 // #include <algorithm>
 #include <helper_math.h>
+#include <chrono>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -31,8 +32,10 @@ using namespace std::literals;
 
 //////////////////// Special desclarations
 /**
- * NVCC segfaults when including <chrono>
- * Therefore, some declarations need to be added explicitely
+ * NVCC tends to have problems with standard headers.
+ * Don't include common.h, instead use bare minimum
+ * of standard headers and duplicate declarations of necessary classes.
+ * Not pretty and extremely error-prone, fix at earliest convenience.
  */
 namespace platf {
 struct img_t: std::enable_shared_from_this<img_t> {
@@ -42,6 +45,8 @@ public:
   std::int32_t height {};
   std::int32_t pixel_pitch {};
   std::int32_t row_pitch {};
+
+  std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
 
   virtual ~img_t() = default;
 };

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1020,4 +1020,25 @@ namespace platf {
 
     return std::make_unique<qos_t>(flow_id);
   }
+  int64_t
+  qpc_counter() {
+    LARGE_INTEGER performace_counter;
+    if (QueryPerformanceCounter(&performace_counter)) return performace_counter.QuadPart;
+    return 0;
+  }
+
+  std::chrono::nanoseconds
+  qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2) {
+    auto get_frequency = []() {
+      LARGE_INTEGER frequency;
+      frequency.QuadPart = 0;
+      QueryPerformanceFrequency(&frequency);
+      return frequency.QuadPart;
+    };
+    static const double frequency = get_frequency();
+    if (frequency) {
+      return std::chrono::nanoseconds((int64_t) ((performance_counter1 - performance_counter2) * frequency / std::nano::den));
+    }
+    return {};
+  }
 }  // namespace platf

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -1,5 +1,7 @@
 #ifndef SUNSHINE_WINDOWS_MISC_H
 #define SUNSHINE_WINDOWS_MISC_H
+
+#include <chrono>
 #include <string_view>
 #include <windows.h>
 #include <winnt.h>
@@ -9,6 +11,12 @@ namespace platf {
   print_status(const std::string_view &prefix, HRESULT status);
   HDESK
   syncThreadDesktop();
+
+  int64_t
+  qpc_counter();
+
+  std::chrono::nanoseconds
+  qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2);
 }  // namespace platf
 
 #endif

--- a/src/stat_trackers.cpp
+++ b/src/stat_trackers.cpp
@@ -1,0 +1,10 @@
+#include "stat_trackers.h"
+
+namespace stat_trackers {
+
+  boost::format
+  one_digit_after_decimal() {
+    return boost::format("%1$.1f");
+  }
+
+}  // namespace stat_trackers

--- a/src/stat_trackers.h
+++ b/src/stat_trackers.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <limits>
+
+#include <boost/format.hpp>
+
+namespace stat_trackers {
+
+  boost::format
+  one_digit_after_decimal();
+
+  template <typename T>
+  class min_max_avg_tracker {
+  public:
+    using callback_function = std::function<void(T stat_min, T stat_max, double stat_avg)>;
+
+    void
+    collect_and_callback_on_interval(T stat, const callback_function &callback, std::chrono::seconds interval_in_seconds) {
+      if (std::chrono::steady_clock::now() > data.last_callback_time + interval_in_seconds) {
+        callback(data.stat_min, data.stat_max, data.stat_total / data.calls);
+        data = {};
+      }
+      data.stat_min = std::min(data.stat_min, stat);
+      data.stat_max = std::max(data.stat_max, stat);
+      data.stat_total += stat;
+      data.calls += 1;
+    }
+
+  private:
+    struct {
+      std::chrono::steady_clock::steady_clock::time_point last_callback_time = std::chrono::steady_clock::now();
+      T stat_min = std::numeric_limits<T>::max();
+      T stat_max = 0;
+      double stat_total = 0;
+      uint32_t calls = 0;
+    } data;
+  };
+
+}  // namespace stat_trackers

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <openssl/err.h>
 
+#include <boost/endian/arithmetic.hpp>
+
 extern "C" {
 #include <moonlight-common-c/src/RtpAudioQueue.h>
 #include <moonlight-common-c/src/Video.h>
@@ -74,7 +76,11 @@ namespace stream {
     }
 
     std::uint8_t headerType;  // Always 0x01 for short headers
-    std::uint8_t unknown[2];
+
+    // Sunshine extension
+    // Frame processing latency, in 1/10 ms units
+    //     zero when the frame is repeated or there is no backend implementation
+    boost::endian::little_uint16_at frame_processing_latency;
 
     // Currently known values:
     // 1 = Normal P-frame
@@ -1012,6 +1018,19 @@ namespace stream {
       video_short_frame_header_t frame_header = {};
       frame_header.headerType = 0x01;  // Short header type
       frame_header.frameType = (av_packet->flags & AV_PKT_FLAG_KEY) ? 2 : 1;
+
+      if (packet->frame_timestamp) {
+        auto duration_to_latency = [](const std::chrono::steady_clock::duration &duration) {
+          const auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
+          return (uint16_t) std::clamp<decltype(duration_us)>((duration_us + 50) / 100, 0, std::numeric_limits<uint16_t>::max());
+        };
+
+        uint16_t latency = duration_to_latency(std::chrono::steady_clock::now() - *packet->frame_timestamp);
+        frame_header.frame_processing_latency = latency;
+      }
+      else {
+        frame_header.frame_processing_latency = 0;
+      }
 
       std::copy_n((uint8_t *) &frame_header, sizeof(frame_header), std::back_inserter(payload_new));
       std::copy(std::begin(payload), std::end(payload), std::back_inserter(payload_new));

--- a/src/video.h
+++ b/src/video.h
@@ -48,6 +48,8 @@ namespace video {
     AVPacket *av_packet;
     std::vector<replace_t> *replacements;
     void *channel_data;
+
+    std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
   };
 
   using packet_t = std::unique_ptr<packet_raw_t>;


### PR DESCRIPTION
## Description
Utilize 2 unused bytes of packet short header for transferring frame latency to moonlight.

Can't really granulate this latency (into processing and encoding for example) because of asynchronous nature of gpu commands, at least to my knowledge and while keeping the code clean. And I don't expect anyone particularly caring for it.

moonlight-common-c pull request: https://github.com/moonlight-stream/moonlight-common-c/pull/77
moonlight-qt pull request: https://github.com/moonlight-stream/moonlight-qt/pull/995

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
