### PR TITLE
build(linux): honor install prefix for tray icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -944,7 +944,7 @@ elseif(UNIX)
 
         if(${SUNSHINE_TRAY} STREQUAL 1)
             install(FILES "${CMAKE_SOURCE_DIR}/sunshine.svg"
-                    DESTINATION "/usr/share/icons")
+                    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons")
 
             set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                     ${CPACK_DEBIAN_PACKAGE_DEPENDS}, \


### PR DESCRIPTION
## Description
Use install prefix for the tray icon location.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
