### PR TITLE
Add RFC 6598 CGN CIDR block to LAN addresses list

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -16,7 +16,8 @@ namespace net {
   std::vector<std::tuple<std::uint32_t, std::uint32_t>> lan_ips {
     ip_block("192.168.0.0/16"sv),
     ip_block("172.16.0.0/12"sv),
-    ip_block("10.0.0.0/8"sv)
+    ip_block("10.0.0.0/8"sv),
+    ip_block("100.64.0.0/10"sv)
   };
 
   std::uint32_t


### PR DESCRIPTION
## Description
Tailscale uses the Carrier-Grade NAT range assigned by RFC 6598 for its VPN interface. Since these addresses are intended for internal use in Carrier-Grade NAT systems, they will not be exposed externally (i.e. without a NAT/firewalll) so it should be safe to treat these as LAN addresses.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #1159
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
