### PR TITLE
Fix deadlock during exit/restart if mDNS registration fails

### DIFF
--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -141,14 +141,12 @@ namespace safe {
   public:
     using status_t = util::optional_t<T>;
 
-    alarm_raw_t():
-        _status { util::false_v<status_t> } {}
-
     void
     ring(const status_t &status) {
       std::lock_guard lg(_lock);
 
       _status = status;
+      _rang = true;
       _cv.notify_one();
     }
 
@@ -157,6 +155,7 @@ namespace safe {
       std::lock_guard lg(_lock);
 
       _status = std::move(status);
+      _rang = true;
       _cv.notify_one();
     }
 
@@ -165,7 +164,7 @@ namespace safe {
     wait_for(const std::chrono::duration<Rep, Period> &rel_time) {
       std::unique_lock ul(_lock);
 
-      return _cv.wait_for(ul, rel_time, [this]() { return (bool) status(); });
+      return _cv.wait_for(ul, rel_time, [this]() { return _rang; });
     }
 
     template <class Rep, class Period, class Pred>
@@ -173,7 +172,7 @@ namespace safe {
     wait_for(const std::chrono::duration<Rep, Period> &rel_time, Pred &&pred) {
       std::unique_lock ul(_lock);
 
-      return _cv.wait_for(ul, rel_time, [this, &pred]() { return (bool) status() || pred(); });
+      return _cv.wait_for(ul, rel_time, [this, &pred]() { return _rang || pred(); });
     }
 
     template <class Rep, class Period>
@@ -181,7 +180,7 @@ namespace safe {
     wait_until(const std::chrono::duration<Rep, Period> &rel_time) {
       std::unique_lock ul(_lock);
 
-      return _cv.wait_until(ul, rel_time, [this]() { return (bool) status(); });
+      return _cv.wait_until(ul, rel_time, [this]() { return _rang; });
     }
 
     template <class Rep, class Period, class Pred>
@@ -189,20 +188,20 @@ namespace safe {
     wait_until(const std::chrono::duration<Rep, Period> &rel_time, Pred &&pred) {
       std::unique_lock ul(_lock);
 
-      return _cv.wait_until(ul, rel_time, [this, &pred]() { return (bool) status() || pred(); });
+      return _cv.wait_until(ul, rel_time, [this, &pred]() { return _rang || pred(); });
     }
 
     auto
     wait() {
       std::unique_lock ul(_lock);
-      _cv.wait(ul, [this]() { return (bool) status(); });
+      _cv.wait(ul, [this]() { return _rang; });
     }
 
     template <class Pred>
     auto
     wait(Pred &&pred) {
       std::unique_lock ul(_lock);
-      _cv.wait(ul, [this, &pred]() { return (bool) status() || pred(); });
+      _cv.wait(ul, [this, &pred]() { return _rang || pred(); });
     }
 
     const status_t &
@@ -218,13 +217,15 @@ namespace safe {
     void
     reset() {
       _status = status_t {};
+      _rang = false;
     }
 
   private:
     std::mutex _lock;
     std::condition_variable _cv;
 
-    status_t _status;
+    status_t _status { util::false_v<status_t> };
+    bool _rang { false };
   };
 
   template <class T>


### PR DESCRIPTION
## Description
`alarm_t` is used by the mDNS registration code on Windows to pass back a pointer to the registered instance to the main thread. The code there assumes that the callback will `ring()` with `nullptr` if registration fails. However, `alarm_raw_t::wait()`'s condition predicate requires the value to satisfy `(bool) val == true` to return. Because `(bool) nullptr == false`, `wait()` never returns after our `ring()` and we deadlock the registering thread.

This is relatively harmless until the destructor for the mDNS `std::future` is called upon returning from `main()`. That will end up deadlocking the main thread and preventing Sunshine from terminating. Because this happens so late in the lifetime of the process, the fallback termination code is already cleaned up too. We will just sit in this deadlocked state forever until our process is manually killed.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
