### PR TITLE
fix(audio)!: remove policy config for Windows Vista

### DIFF
--- a/src/platform/windows/PolicyConfig.h
+++ b/src/platform/windows/PolicyConfig.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <mmdeviceapi.h>
+
 #ifdef __MINGW32__
   #undef DEFINE_GUID
   #ifdef __cplusplus
@@ -99,81 +101,3 @@ public:
     PCWSTR,
     INT);
 };
-
-interface DECLSPEC_UUID("568b9108-44bf-40b4-9006-86afe5b5a620") IPolicyConfigVista;
-class DECLSPEC_UUID("294935CE-F637-4E7C-A41B-AB255460B862") CPolicyConfigVistaClient;
-// ----------------------------------------------------------------------------
-// class CPolicyConfigVistaClient
-// {294935CE-F637-4E7C-A41B-AB255460B862}
-//
-// interface IPolicyConfigVista
-// {568b9108-44bf-40b4-9006-86afe5b5a620}
-//
-// Query interface:
-// CComPtr<IPolicyConfigVista> PolicyConfig;
-// PolicyConfig.CoCreateInstance(__uuidof(CPolicyConfigVistaClient));
-//
-// @compatible: Windows Vista and Later
-// ----------------------------------------------------------------------------
-interface IPolicyConfigVista: public IUnknown {
-public:
-  virtual HRESULT
-  GetMixFormat(
-    PCWSTR,
-    WAVEFORMATEX **);  // not available on Windows 7, use method from IPolicyConfig
-
-  virtual HRESULT STDMETHODCALLTYPE
-  GetDeviceFormat(
-    PCWSTR,
-    INT,
-    WAVEFORMATEX **);
-
-  virtual HRESULT STDMETHODCALLTYPE
-  SetDeviceFormat(
-    PCWSTR,
-    WAVEFORMATEX *,
-    WAVEFORMATEX *);
-
-  virtual HRESULT STDMETHODCALLTYPE GetProcessingPeriod(
-    PCWSTR,
-    INT,
-    PINT64,
-    PINT64);  // not available on Windows 7, use method from IPolicyConfig
-
-  virtual HRESULT STDMETHODCALLTYPE SetProcessingPeriod(
-    PCWSTR,
-    PINT64);  // not available on Windows 7, use method from IPolicyConfig
-
-  virtual HRESULT STDMETHODCALLTYPE
-  GetShareMode(
-    PCWSTR,
-    struct DeviceShareMode *);  // not available on Windows 7, use method from IPolicyConfig
-
-  virtual HRESULT STDMETHODCALLTYPE
-  SetShareMode(
-    PCWSTR,
-    struct DeviceShareMode *);  // not available on Windows 7, use method from IPolicyConfig
-
-  virtual HRESULT STDMETHODCALLTYPE
-  GetPropertyValue(
-    PCWSTR,
-    const PROPERTYKEY &,
-    PROPVARIANT *);
-
-  virtual HRESULT STDMETHODCALLTYPE
-  SetPropertyValue(
-    PCWSTR,
-    const PROPERTYKEY &,
-    PROPVARIANT *);
-
-  virtual HRESULT STDMETHODCALLTYPE
-  SetDefaultEndpoint(
-    PCWSTR wszDeviceId,
-    ERole eRole);
-
-  virtual HRESULT STDMETHODCALLTYPE SetEndpointVisibility(
-    PCWSTR,
-    INT);  // not available on Windows 7, use method from IPolicyConfig
-};
-
-// ----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR removes the policy config for Windows Vista audio. Additionally, I have added `#include <mmdeviceapi.h>` which removes many false positive errors in CLion.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
