### PR TITLE
Polish up the elevated command rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,9 +739,6 @@ if(WIN32) # see options at: https://cmake.org/cmake/help/latest/cpack_gen/nsis.h
         IfSilent +2 0
         ExecShell 'open' 'https://sunshinestream.readthedocs.io/'
         nsExec::ExecToLog 'icacls \\\"$INSTDIR\\\" /reset /T'
-        nsExec::ExecToLog 'icacls \\\"$INSTDIR\\\\config\\\\credentials\\\" /inheritance:r'
-        nsExec::ExecToLog 'icacls \\\"$INSTDIR\\\\config\\\\credentials\\\" \
-                                  /grant:r Administrators:\\\(OI\\\)\\\(CI\\\)\\\(F\\\)'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\migrate-config.bat\\\"'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\add-firewall-rule.bat\\\"'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\install-service.bat\\\"'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -738,7 +738,7 @@ if(WIN32) # see options at: https://cmake.org/cmake/help/latest/cpack_gen/nsis.h
             "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
         IfSilent +2 0
         ExecShell 'open' 'https://sunshinestream.readthedocs.io/'
-        nsExec::ExecToLog 'icacls \\\"$INSTDIR\\\" /reset /T'
+        nsExec::ExecToLog 'icacls \\\"$INSTDIR\\\" /reset'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\migrate-config.bat\\\"'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\add-firewall-rule.bat\\\"'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\install-service.bat\\\"'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,6 +764,20 @@ if(WIN32) # see options at: https://cmake.org/cmake/help/latest/cpack_gen/nsis.h
         NoDelete:
         ")
 
+    # Adding an option for the start menu
+    set(CPACK_NSIS_MODIFY_PATH "OFF")
+    set(CPACK_NSIS_EXECUTABLES_DIRECTORY ".")
+    # This will be shown on the installed apps Windows settings
+    set(CPACK_NSIS_INSTALLED_ICON_NAME "${CMAKE_PROJECT_NAME}.exe")
+    set(CPACK_NSIS_CREATE_ICONS_EXTRA
+        "${CPACK_NSIS_CREATE_ICONS_EXTRA}
+        CreateShortCut '\$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\${CMAKE_PROJECT_NAME}.lnk' \
+            '\$INSTDIR\\\\${CMAKE_PROJECT_NAME}.exe' '--shortcut'
+        ")
+    set(CPACK_NSIS_DELETE_ICONS_EXTRA
+        "${CPACK_NSIS_DELETE_ICONS_EXTRA}
+        Delete '\$SMPROGRAMS\\\\$MUI_TEMP\\\\${CMAKE_PROJECT_NAME}.lnk'
+        ")
 
     # Checking for previous installed versions
     set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL "ON")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,10 @@
 extern "C" {
 #include <libavutil/log.h>
 #include <rs.h>
+
+#ifdef _WIN32
+  #include <iphlpapi.h>
+#endif
 }
 
 safe::mail_t mail::man;
@@ -140,6 +144,209 @@ namespace lifetime {
     return argv;
   }
 }  // namespace lifetime
+
+#ifdef _WIN32
+namespace service_ctrl {
+  class service_controller {
+  public:
+    /**
+     * @brief Constructor for service_controller class
+     * @param service_desired_access SERVICE_* desired access flags
+     */
+    service_controller(DWORD service_desired_access) {
+      scm_handle = OpenSCManagerA(nullptr, nullptr, SC_MANAGER_CONNECT);
+      if (!scm_handle) {
+        auto winerr = GetLastError();
+        BOOST_LOG(error) << "OpenSCManager() failed: "sv << winerr;
+        return;
+      }
+
+      service_handle = OpenServiceA(scm_handle, "SunshineSvc", service_desired_access);
+      if (!service_handle) {
+        auto winerr = GetLastError();
+        BOOST_LOG(error) << "OpenService() failed: "sv << winerr;
+        return;
+      }
+    }
+
+    ~service_controller() {
+      if (service_handle) {
+        CloseServiceHandle(service_handle);
+      }
+
+      if (scm_handle) {
+        CloseServiceHandle(scm_handle);
+      }
+    }
+
+    /**
+     * @brief Asynchronously starts the Sunshine service
+     */
+    bool
+    start_service() {
+      if (!service_handle) {
+        return false;
+      }
+
+      if (!StartServiceA(service_handle, 0, nullptr)) {
+        auto winerr = GetLastError();
+        if (winerr != ERROR_SERVICE_ALREADY_RUNNING) {
+          BOOST_LOG(error) << "StartService() failed: "sv << winerr;
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    /**
+     * @brief Query the service status
+     * @param status The SERVICE_STATUS struct to populate
+     */
+    bool
+    query_service_status(SERVICE_STATUS &status) {
+      if (!service_handle) {
+        return false;
+      }
+
+      if (!QueryServiceStatus(service_handle, &status)) {
+        auto winerr = GetLastError();
+        BOOST_LOG(error) << "QueryServiceStatus() failed: "sv << winerr;
+        return false;
+      }
+
+      return true;
+    }
+
+  private:
+    SC_HANDLE scm_handle = NULL;
+    SC_HANDLE service_handle = NULL;
+  };
+
+  /**
+   * @brief Check if the service is running
+   *
+   * EXAMPLES:
+   * ```cpp
+   * is_service_running();
+   * ```
+   */
+  bool
+  is_service_running() {
+    service_controller sc { SERVICE_QUERY_STATUS };
+
+    SERVICE_STATUS status;
+    if (!sc.query_service_status(status)) {
+      return false;
+    }
+
+    return status.dwCurrentState == SERVICE_RUNNING;
+  }
+
+  /**
+   * @brief Start the service and wait for startup to complete
+   *
+   * EXAMPLES:
+   * ```cpp
+   * start_service();
+   * ```
+   */
+  bool
+  start_service() {
+    service_controller sc { SERVICE_QUERY_STATUS | SERVICE_START };
+
+    std::cout << "Starting Sunshine..."sv;
+
+    // This operation is asynchronous, so we must wait for it to complete
+    if (!sc.start_service()) {
+      return false;
+    }
+
+    SERVICE_STATUS status;
+    do {
+      Sleep(1000);
+      std::cout << '.';
+    } while (sc.query_service_status(status) && status.dwCurrentState == SERVICE_START_PENDING);
+
+    if (status.dwCurrentState != SERVICE_RUNNING) {
+      BOOST_LOG(error) << SERVICE_NAME " failed to start: "sv << status.dwWin32ExitCode;
+      return false;
+    }
+
+    std::cout << std::endl;
+    return true;
+  }
+
+  /**
+   * @brief Wait for the UI to be ready after Sunshine startup
+   *
+   * EXAMPLES:
+   * ```cpp
+   * wait_for_ui_ready();
+   * ```
+   */
+  bool
+  wait_for_ui_ready() {
+    std::cout << "Waiting for Web UI to be ready...";
+
+    // Wait up to 30 seconds for the web UI to start
+    for (int i = 0; i < 30; i++) {
+      PMIB_TCPTABLE tcp_table = nullptr;
+      ULONG table_size = 0;
+      ULONG err;
+
+      auto fg = util::fail_guard([&tcp_table]() {
+        free(tcp_table);
+      });
+
+      do {
+        // Query all open TCP sockets to look for our web UI port
+        err = GetTcpTable(tcp_table, &table_size, false);
+        if (err == ERROR_INSUFFICIENT_BUFFER) {
+          free(tcp_table);
+          tcp_table = (PMIB_TCPTABLE) malloc(table_size);
+        }
+      } while (err == ERROR_INSUFFICIENT_BUFFER);
+
+      if (err != NO_ERROR) {
+        BOOST_LOG(error) << "Failed to query TCP table: "sv << err;
+        return false;
+      }
+
+      uint16_t port_nbo = htons(map_port(confighttp::PORT_HTTPS));
+      for (DWORD i = 0; i < tcp_table->dwNumEntries; i++) {
+        auto &entry = tcp_table->table[i];
+
+        // Look for our port in the listening state
+        if (entry.dwLocalPort == port_nbo && entry.dwState == MIB_TCP_STATE_LISTEN) {
+          std::cout << std::endl;
+          return true;
+        }
+      }
+
+      Sleep(1000);
+      std::cout << '.';
+    }
+
+    std::cout << "timed out"sv << std::endl;
+    return false;
+  }
+}  // namespace service_ctrl
+#endif
+
+/**
+ * @brief Launch the Web UI
+ *
+ * EXAMPLES:
+ * ```cpp
+ * launch_ui();
+ * ```
+ */
+void
+launch_ui() {
+  std::string url = "https://localhost:" + std::to_string(map_port(confighttp::PORT_HTTPS));
+  platf::open_url(url);
+}
 
 /**
  * @brief Flush the log.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -600,7 +600,14 @@ main(int argc, char *argv[]) {
   }
 
   if (http::init()) {
-    BOOST_LOG(error) << "http failed to initialize"sv;
+    BOOST_LOG(fatal) << "HTTP interface failed to initialize"sv;
+
+#ifdef _WIN32
+    BOOST_LOG(fatal) << "To relaunch Sunshine successfully, use the shortcut in the Start Menu. Do not run Sunshine.exe manually."sv;
+    std::this_thread::sleep_for(10s);
+#endif
+
+    return -1;
   }
 
   std::unique_ptr<platf::deinit_t> mDNS;

--- a/src/main.h
+++ b/src/main.h
@@ -40,6 +40,8 @@ int
 write_file(const char *path, const std::string_view &contents);
 std::uint16_t
 map_port(int port);
+void
+launch_ui();
 
 // namespaces
 namespace mail {
@@ -72,5 +74,18 @@ namespace lifetime {
   char **
   get_argv();
 }  // namespace lifetime
+
+#ifdef _WIN32
+namespace service_ctrl {
+  bool
+  is_service_running();
+
+  bool
+  start_service();
+
+  bool
+  wait_for_ui_ready();
+}  // namespace service_ctrl
+#endif
 
 #endif  // SUNSHINE_MAIN_H

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -423,6 +423,13 @@ namespace platf {
   std::unique_ptr<deinit_t>
   enable_socket_qos(uintptr_t native_socket, boost::asio::ip::address &address, uint16_t port, qos_data_type_e data_type);
 
+  /**
+   * @brief Open a url in the default web browser.
+   * @param url The url to open.
+   */
+  void
+  open_url(const std::string &url);
+
   input_t
   input();
   void

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -384,7 +384,7 @@ namespace platf {
   display_names(mem_type_e hwdevice_type);
 
   boost::process::child
-  run_command(bool elevated, const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
+  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
 
   enum class thread_priority_e : int {
     low,

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -159,7 +159,7 @@ namespace platf {
   }
 
   bp::child
-  run_command(bool elevated, const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     if (!group) {
       if (!file) {
         return bp::child(cmd, env, bp::start_dir(working_dir), bp::std_out > bp::null, bp::std_err > bp::null, ec);
@@ -190,7 +190,7 @@ namespace platf {
 
     boost::process::environment _env = boost::this_process::environment();
     std::error_code ec;
-    auto child = run_command(false, cmd, working_dir, _env, nullptr, ec, nullptr);
+    auto child = run_command(false, false, cmd, working_dir, _env, nullptr, ec, nullptr);
     if (ec) {
       BOOST_LOG(warning) << "Couldn't open url ["sv << url << "]: System: "sv << ec.message();
     }

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -178,6 +178,28 @@ namespace platf {
     }
   }
 
+  /**
+   * @brief Open a url in the default web browser.
+   * @param url The url to open.
+   */
+  void
+  open_url(const std::string &url) {
+    // set working dir to user home directory
+    auto working_dir = boost::filesystem::path(std::getenv("HOME"));
+    std::string cmd = R"(xdg-open ")" + url + R"(")";
+
+    boost::process::environment _env = boost::this_process::environment();
+    std::error_code ec;
+    auto child = run_command(false, cmd, working_dir, _env, nullptr, ec, nullptr);
+    if (ec) {
+      BOOST_LOG(warning) << "Couldn't open url ["sv << url << "]: System: "sv << ec.message();
+    }
+    else {
+      BOOST_LOG(info) << "Opened url ["sv << url << "]"sv;
+      child.detach();
+    }
+  }
+
   void
   adjust_thread_priority(thread_priority_e priority) {
     // Unimplemented

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -178,6 +178,27 @@ namespace platf {
     }
   }
 
+  /**
+   * @brief Open a url in the default web browser.
+   * @param url The url to open.
+   */
+  void
+  open_url(const std::string &url) {
+    boost::filesystem::path working_dir;
+    std::string cmd = R"(open ")" + url + R"(")";
+
+    boost::process::environment _env = boost::this_process::environment();
+    std::error_code ec;
+    auto child = run_command(false, cmd, working_dir, _env, nullptr, ec, nullptr);
+    if (ec) {
+      BOOST_LOG(warning) << "Couldn't open url ["sv << url << "]: System: "sv << ec.message();
+    }
+    else {
+      BOOST_LOG(info) << "Opened url ["sv << url << "]"sv;
+      child.detach();
+    }
+  }
+
   void
   adjust_thread_priority(thread_priority_e priority) {
     // Unimplemented

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -159,7 +159,7 @@ namespace platf {
   }
 
   bp::child
-  run_command(bool elevated, const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     if (!group) {
       if (!file) {
         return bp::child(cmd, env, bp::start_dir(working_dir), bp::std_out > bp::null, bp::std_err > bp::null, ec);
@@ -189,7 +189,7 @@ namespace platf {
 
     boost::process::environment _env = boost::this_process::environment();
     std::error_code ec;
-    auto child = run_command(false, cmd, working_dir, _env, nullptr, ec, nullptr);
+    auto child = run_command(false, false, cmd, working_dir, _env, nullptr, ec, nullptr);
     if (ec) {
       BOOST_LOG(warning) << "Couldn't open url ["sv << url << "]: System: "sv << ec.message();
     }

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -651,6 +651,31 @@ namespace platf {
     return create_boost_child_from_results(ret, cmd, ec, process_info, group);
   }
 
+  /**
+   * @brief Open a url in the default web browser.
+   * @param url The url to open.
+   */
+  void
+  open_url(const std::string &url) {
+    // set working dir to Windows system directory
+    auto working_dir = boost::filesystem::path(std::getenv("SystemRoot"));
+
+    // this isn't ideal as it briefly shows a command window
+    // but start a command built into cmd, not an executable
+    std::string cmd = R"(cmd /C "start )" + url + R"(")";
+
+    boost::process::environment _env = boost::this_process::environment();
+    std::error_code ec;
+    auto child = run_command(false, cmd, working_dir, _env, nullptr, ec, nullptr);
+    if (ec) {
+      BOOST_LOG(warning) << "Couldn't open url ["sv << url << "]: System: "sv << ec.message();
+    }
+    else {
+      BOOST_LOG(info) << "Opened url ["sv << url << "]"sv;
+      child.detach();
+    }
+  }
+
   void
   adjust_thread_priority(thread_priority_e priority) {
     int win32_priority;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -136,7 +136,7 @@ namespace proc {
                                               find_working_directory(cmd.do_cmd, _env) :
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << "Executing Do Cmd: ["sv << cmd.do_cmd << ']';
-      auto child = platf::run_command(cmd.elevated, cmd.do_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
+      auto child = platf::run_command(cmd.elevated, true, cmd.do_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
 
       if (ec) {
         BOOST_LOG(error) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << ec.message();
@@ -157,7 +157,7 @@ namespace proc {
                                               find_working_directory(cmd, _env) :
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << "Spawning ["sv << cmd << "] in ["sv << working_dir << ']';
-      auto child = platf::run_command(_app.elevated, cmd, working_dir, _env, _pipe.get(), ec, nullptr);
+      auto child = platf::run_command(_app.elevated, true, cmd, working_dir, _env, _pipe.get(), ec, nullptr);
       if (ec) {
         BOOST_LOG(warning) << "Couldn't spawn ["sv << cmd << "]: System: "sv << ec.message();
       }
@@ -175,7 +175,7 @@ namespace proc {
                                               find_working_directory(_app.cmd, _env) :
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << "Executing: ["sv << _app.cmd << "] in ["sv << working_dir << ']';
-      _process = platf::run_command(_app.elevated, _app.cmd, working_dir, _env, _pipe.get(), ec, &_process_handle);
+      _process = platf::run_command(_app.elevated, true, _app.cmd, working_dir, _env, _pipe.get(), ec, &_process_handle);
       if (ec) {
         BOOST_LOG(warning) << "Couldn't run ["sv << _app.cmd << "]: System: "sv << ec.message();
         return -1;
@@ -223,7 +223,7 @@ namespace proc {
                                               find_working_directory(cmd.undo_cmd, _env) :
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << "Executing Undo Cmd: ["sv << cmd.undo_cmd << ']';
-      auto child = platf::run_command(cmd.elevated, cmd.undo_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
+      auto child = platf::run_command(cmd.elevated, true, cmd.undo_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
 
       if (ec) {
         BOOST_LOG(warning) << "System: "sv << ec.message();

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -37,54 +37,13 @@ using namespace std::literals;
 namespace system_tray {
 
   /**
- * @brief Open a url in the default web browser.
- * @param url The url to open.
- */
-  void
-  open_url(const std::string &url) {
-    boost::filesystem::path working_dir;
-
-    // if windows
-  #if defined(_WIN32)
-    // set working dir to Windows system directory
-    working_dir = boost::filesystem::path(std::getenv("SystemRoot"));
-
-    // this isn't ideal as it briefly shows a command window
-    // but start a command built into cmd, not an executable
-    std::string cmd = R"(cmd /C "start )" + url + R"(")";
-  #elif defined(__linux__) || defined(linux) || defined(__linux)
-    // set working dir to user home directory
-    working_dir = boost::filesystem::path(std::getenv("HOME"));
-    std::string cmd = R"(xdg-open ")" + url + R"(")";
-  #elif defined(__APPLE__) || defined(__MACH__)
-    std::string cmd = R"(open ")" + url + R"(")";
-  #endif
-
-    boost::process::environment _env = boost::this_process::environment();
-    std::error_code ec;
-    auto child = platf::run_command(false, cmd, working_dir, _env, nullptr, ec, nullptr);
-    if (ec) {
-      BOOST_LOG(warning) << "Couldn't open url ["sv << url << "]: System: "sv << ec.message();
-    }
-    else {
-      BOOST_LOG(info) << "Opened url ["sv << url << "]"sv;
-      child.detach();
-    }
-  }
-
-  /**
  * @brief Callback for opening the UI from the system tray.
  * @param item The tray menu item.
  */
   void
   tray_open_ui_cb(struct tray_menu *item) {
     BOOST_LOG(info) << "Opening UI from system tray"sv;
-
-    // create the url with the port
-    std::string url = "https://localhost:" + std::to_string(map_port(confighttp::PORT_HTTPS));
-
-    // open the url in the default web browser
-    open_url(url);
+    launch_ui();
   }
 
   /**
@@ -93,7 +52,7 @@ namespace system_tray {
  */
   void
   tray_donate_github_cb(struct tray_menu *item) {
-    open_url("https://github.com/sponsors/LizardByte");
+    platf::open_url("https://github.com/sponsors/LizardByte");
   }
 
   /**
@@ -102,7 +61,7 @@ namespace system_tray {
  */
   void
   tray_donate_mee6_cb(struct tray_menu *item) {
-    open_url("https://mee6.xyz/m/804382334370578482");
+    platf::open_url("https://mee6.xyz/m/804382334370578482");
   }
 
   /**
@@ -111,7 +70,7 @@ namespace system_tray {
  */
   void
   tray_donate_patreon_cb(struct tray_menu *item) {
-    open_url("https://www.patreon.com/LizardByte");
+    platf::open_url("https://www.patreon.com/LizardByte");
   }
 
   /**
@@ -120,7 +79,7 @@ namespace system_tray {
  */
   void
   tray_donate_paypal_cb(struct tray_menu *item) {
-    open_url("https://www.paypal.com/paypalme/ReenigneArcher");
+    platf::open_url("https://www.paypal.com/paypalme/ReenigneArcher");
   }
 
   /**

--- a/src_assets/windows/misc/migration/migrate-config.bat
+++ b/src_assets/windows/misc/migration/migrate-config.bat
@@ -6,21 +6,25 @@ for %%I in ("%~dp0\..") do set "OLD_DIR=%%~fI"
 rem Create the config directory if it didn't already exist
 set "NEW_DIR=%OLD_DIR%\config"
 if not exist "%NEW_DIR%\" mkdir "%NEW_DIR%"
+icacls "%NEW_DIR%" /reset
 
 rem Migrate all files that aren't already present in the config dir
 if exist "%OLD_DIR%\apps.json" (
     if not exist "%NEW_DIR%\apps.json" (
         move "%OLD_DIR%\apps.json" "%NEW_DIR%\apps.json"
+        icacls "%NEW_DIR%\apps.json" /reset
     )
 )
 if exist "%OLD_DIR%\sunshine.conf" (
     if not exist "%NEW_DIR%\sunshine.conf" (
         move "%OLD_DIR%\sunshine.conf" "%NEW_DIR%\sunshine.conf"
+        icacls "%NEW_DIR%\sunshine.conf" /reset
     )
 )
 if exist "%OLD_DIR%\sunshine_state.json" (
     if not exist "%NEW_DIR%\sunshine_state.json" (
         move "%OLD_DIR%\sunshine_state.json" "%NEW_DIR%\sunshine_state.json"
+        icacls "%NEW_DIR%\sunshine_state.json" /reset
     )
 )
 

--- a/src_assets/windows/misc/migration/migrate-config.bat
+++ b/src_assets/windows/misc/migration/migrate-config.bat
@@ -31,6 +31,13 @@ if exist "%OLD_DIR%\credentials\" (
     )
 )
 
+rem Create the credentials directory if it wasn't migrated or already existing
+if not exist "%NEW_DIR%\credentials\" mkdir "%NEW_DIR%\credentials"
+
+rem Disallow read access to the credentials directory for normal users
+icacls "%NEW_DIR%\credentials" /inheritance:r
+icacls "%NEW_DIR%\credentials" /grant:r Administrators:(OI)(CI)(F)
+
 rem Migrate the covers directory
 if exist "%OLD_DIR%\covers\" (
     if not exist "%NEW_DIR%\covers\" (


### PR DESCRIPTION
## Description
This PR contains a set of fixes and improvements for the elevated command redesign that @Nonary completed in #1123.

- The first commit ensures that we create the credentials directory before trying to set ACLs on it. Otherwise first installs would not have ACLs set correctly on this directory.
- The second commit reverts a change from #1123 that was resetting ACLs recursively on our directory. We don't want to do that because it would temporarily wipe out our stricter credential directory ACL, creating a window where an ordinary user could read it.
- The third commit reintroduces the start menu shortcut, but it launches Sunshine.exe with a special parameter that causes it to run in launcher mode. If the service is already running, it will just launch the web UI and exit.  If the service isn't running, it will prompt the user for elevation, start the service, then launch the web UI and exit.
- The fourth commit adds a new `interactive` parameter to `platf::run_command()` which allows us to avoid showing an extra console window when launching the browser via the system tray and shortcut.
- The fifth commit fixes a bug in #1123 that was not properly merging the user environment variables into the processes we were launching. I ended up running into this bug while working on the other changes, because Chrome will crash if the user profile variables aren't present.
- The sixth commit resets ACLs on the config directory and our config files when we migrate them from the old directory where ACLs were less strict.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
