### PR TITLE
Fix Fedora 37 build

### DIFF
--- a/docker/fedora-37.dockerfile
+++ b/docker/fedora-37.dockerfile
@@ -50,7 +50,7 @@ dnf -y install \
   libXinerama-devel-1.1.4* \
   libXrandr-devel-1.5.2* \
   libXtst-devel-1.2.3* \
-  mesa-libGL-devel-23.0.2* \
+  mesa-libGL-devel-23.0.3* \
   nodejs-npm-9.5.0* \
   numactl-devel-2.0.14* \
   openssl-devel-3.0.8* \


### PR DESCRIPTION
## Description
Stop-gap fix to address the build break on Fedora 37 caused by their update to Mesa 23.0.3. We probably shouldn't be pinning the patch version (or maybe even the version at all), but this will get us moving again until we figure out the right approach for that logic.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
