### PR TITLE
Pass the SID instead of the group name to icacls

### DIFF
--- a/src_assets/windows/misc/migration/migrate-config.bat
+++ b/src_assets/windows/misc/migration/migrate-config.bat
@@ -39,8 +39,9 @@ rem Create the credentials directory if it wasn't migrated or already existing
 if not exist "%NEW_DIR%\credentials\" mkdir "%NEW_DIR%\credentials"
 
 rem Disallow read access to the credentials directory for normal users
+rem Note: We must use the SID directly because "Administrators" is localized
 icacls "%NEW_DIR%\credentials" /inheritance:r
-icacls "%NEW_DIR%\credentials" /grant:r Administrators:(OI)(CI)(F)
+icacls "%NEW_DIR%\credentials" /grant:r *S-1-5-32-544:(OI)(CI)(F)
 
 rem Migrate the covers directory
 if exist "%OLD_DIR%\covers\" (


### PR DESCRIPTION
## Description
Fixes issues accessing the `credentials` directory on non-English systems after the Elevated Commands Redesign. This also impacted the old code too, when we were granting access to the config directory for the `Users` group. 

I verified locally that manually removing the all ACEs from the `credentials` directory ACL and running the installer again will fix the issue for users already in the broken state.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated