### PR TITLE
Audio Capture Improvements

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -447,6 +447,8 @@ audio_sink
 
             tools\audio-info.exe
 
+         .. Tip:: If you have multiple audio devices with identical names, use the Device ID instead.
+
    .. Tip:: If you want to mute the host speakers, use `virtual_sink`_ instead.
 
 **Default**
@@ -466,7 +468,7 @@ audio_sink
    **Windows**
       .. code-block:: text
 
-         audio_sink = {0.0.0.00000000}.{FD47D9CC-4218-4135-9CE2-0C195C87405B}
+         audio_sink = Speakers (High Definition Audio Device)
 
 virtual_sink
 ^^^^^^^^^^^^
@@ -488,7 +490,7 @@ virtual_sink
 **Example**
    .. code-block:: text
 
-      virtual_sink = {0.0.0.00000000}.{8edba70c-1125-467c-b89c-15da389bc1d4}
+      virtual_sink = Steam Streaming Speakers
 
 Network
 -------

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -222,14 +222,15 @@ namespace audio {
         case platf::capture_e::timeout:
           continue;
         case platf::capture_e::reinit:
+          BOOST_LOG(info) << "Reinitializing audio capture"sv;
           mic.reset();
-          mic = control->microphone(stream->mapping, stream->channelCount, stream->sampleRate, frame_size);
-          if (!mic) {
-            BOOST_LOG(error) << "Couldn't re-initialize audio input"sv;
-
-            return;
-          }
-          return;
+          do {
+            mic = control->microphone(stream->mapping, stream->channelCount, stream->sampleRate, frame_size);
+            if (!mic) {
+              BOOST_LOG(warning) << "Couldn't re-initialize audio input"sv;
+            }
+          } while (!mic && !shutdown_event->view(5s));
+          continue;
         default:
           return;
       }

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -666,7 +666,13 @@ namespace platf::audio {
       for (int x = 0; x < (int) ERole_enum_count; ++x) {
         auto status = policy->SetDefaultEndpoint(wstring_device_id->c_str(), (ERole) x);
         if (status) {
-          BOOST_LOG(warning) << "Couldn't set ["sv << sink << "] to role ["sv << x << ']';
+          // Depending on the format of the string, we could get either of these errors
+          if (status == HRESULT_FROM_WIN32(ERROR_NOT_FOUND) || status == E_INVALIDARG) {
+            BOOST_LOG(warning) << "Audio sink not found: "sv << sink;
+          }
+          else {
+            BOOST_LOG(warning) << "Couldn't set ["sv << sink << "] to role ["sv << x << "]: 0x"sv << util::hex(status).to_string_view();
+          }
 
           ++failure;
         }

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -100,6 +100,25 @@ namespace safe {
       return _status;
     }
 
+    // pop and view shoud not be used interchangeably
+    template <class Rep, class Period>
+    status_t
+    view(std::chrono::duration<Rep, Period> delay) {
+      std::unique_lock ul { _lock };
+
+      if (!_continue) {
+        return util::false_v<status_t>;
+      }
+
+      while (!_status) {
+        if (!_continue || _cv.wait_for(ul, delay) == std::cv_status::timeout) {
+          return util::false_v<status_t>;
+        }
+      }
+
+      return _status;
+    }
+
     bool
     peek() {
       return _continue && (bool) _status;

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -448,13 +448,14 @@
           type="text"
           class="form-control"
           id="audio_sink"
-          placeholder="{0.0.0.00000000}.{FD47D9CC-4218-4135-9CE2-0C195C87405B}"
+          placeholder="Speakers (High Definition Audio Device)"
           v-model="config.audio_sink"
         />
         <div class="form-text">
-          The name of the audio sink used for Audio Loopback<br />
+          The name of the audio sink used for audio capture. If not set, the default audio device will be used.<br />
           You can find the name of the audio sink using the following command:<br />
           <pre>tools\audio-info.exe</pre>
+          If you have multiple audio devices with identical names, use the Device ID instead.
         </div>
       </div>
       <div class="mb-3" v-if="platform === 'linux'">
@@ -506,12 +507,12 @@
           type="text"
           class="form-control"
           id="virtual_sink"
-          placeholder="{0.0.0.00000000}.{8edba70c-1125-467c-b89c-15da389bc1d4}"
+          placeholder="Steam Streaming Speakers"
           v-model="config.virtual_sink"
         />
         <div class="form-text">
-          The virtual sink, is the audio device that's virtual (Like Steam Streaming Speakers), it allows Sunshine to
-          stream audio, while muting the speakers.
+          The virtual sink is an audio device that's virtual (like Steam Streaming Speakers). It allows Sunshine to
+          stream audio, while muting the host PC speakers.
         </div>
       </div>
       <!--Adapter Name -->

--- a/tools/audio.cpp
+++ b/tools/audio.cpp
@@ -29,7 +29,6 @@ const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
 const IID IID_IAudioClient = __uuidof(IAudioClient);
 const IID IID_IAudioCaptureClient = __uuidof(IAudioCaptureClient);
 
-constexpr auto SAMPLE_RATE = 48000;
 int device_state_filter = DEVICE_STATE_ACTIVE;
 
 namespace audio {
@@ -156,28 +155,6 @@ namespace audio {
 
       return nullptr;
     }
-
-    wave_format->wBitsPerSample = 16;
-    wave_format->nSamplesPerSec = SAMPLE_RATE;
-    switch (wave_format->wFormatTag) {
-      case WAVE_FORMAT_PCM:
-        break;
-      case WAVE_FORMAT_IEEE_FLOAT:
-        break;
-      case WAVE_FORMAT_EXTENSIBLE: {
-        auto wave_ex = (PWAVEFORMATEXTENSIBLE) wave_format.get();
-        if (IsEqualGUID(KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, wave_ex->SubFormat)) {
-          wave_ex->SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
-          wave_ex->Samples.wValidBitsPerSample = 16;
-          break;
-        }
-
-        std::cout << "Unsupported Sub Format for WAVE_FORMAT_EXTENSIBLE: [0x"sv << util::hex(wave_ex->SubFormat).to_string_view() << ']' << std::endl;
-      }
-      default:
-        std::cout << "Unsupported Wave Format: [0x"sv << util::hex(wave_format->wFormatTag).to_string_view() << ']' << std::endl;
-        return nullptr;
-    };
 
     set_wave_format(wave_format, format);
 

--- a/tools/audio.cpp
+++ b/tools/audio.cpp
@@ -88,7 +88,21 @@ namespace audio {
     { "Stereo"sv,
       2,
       SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT },
-    { "Surround 5.1"sv,
+    { "Quadraphonic"sv,
+      4,
+      SPEAKER_FRONT_LEFT |
+        SPEAKER_FRONT_RIGHT |
+        SPEAKER_BACK_LEFT |
+        SPEAKER_BACK_RIGHT },
+    { "Surround 5.1 (Side)"sv,
+      6,
+      SPEAKER_FRONT_LEFT |
+        SPEAKER_FRONT_RIGHT |
+        SPEAKER_FRONT_CENTER |
+        SPEAKER_LOW_FREQUENCY |
+        SPEAKER_SIDE_LEFT |
+        SPEAKER_SIDE_RIGHT },
+    { "Surround 5.1 (Back)"sv,
       6,
       SPEAKER_FRONT_LEFT |
         SPEAKER_FRONT_RIGHT |


### PR DESCRIPTION
## Description
This PR contains several improvements to make Windows audio capture easier to configure and avoid breaking streaming entirely if the audio sink is invalid. It also improves the audio-info.exe tool to fix misleading output in several cases.

- The first commit adjusts the Audio Sink and Virtual Sink values to accept device names, device descriptions, and adapter names. This results in a more stable configuration (since names don't change across reconnection, but IDs do) and is also easier for users to set up without having to use audio-info.exe. The documentation and UI are also changed to reflect that sink names should be used on Windows.  The old format device IDs are still supported for backwards compatibility with existing configs.

- The second commit cleans up some misleading output from audio-info.exe that causes it to appear that certain channel configurations are not supported simply because the audio device is not currently using that format.

- The third commit adds 5.1 configurations with side speakers and quadraphonic configurations, so audio-info.exe displays those correctly instead of "Unknown".

- The fourth commit fixes inaccurate results caused by an incompatible sample rate when the audio device is using 192 KHz sample rate. In that scenario, audio-info.exe would incorrectly show all channel configurations as unsupported.

- The fifth commit adjusts the behavior when the audio sink is invalid, missing, or cannot be initialized. Rather than instantly terminating the stream right after it starts, which is incredibly confusing for users, it will print a log message and allow streaming to continue with no audio. The lack of audio will likely drive users to check the Audio/Video tab, which is what we want. This behavior, combined with the tendency for audio device IDs to not be stable, has been a major cause of user issues.

- The sixth commit fixes a bug in the audio reinit logic where `return` was accidentally used instead of `continue`. Instead of capturing from the newly reinitialized device, the audio thread would return instead. This fixes recovery of audio capture after a device disconnect, though we don't track changes to the default output yet. I also added a retry loop to reinit, because sometimes the audio device is temporarily lost only to come back shortly after (for example, a display while mode-setting).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
![image](https://user-images.githubusercontent.com/2695644/236107594-fdbacf53-18b5-4fd3-95c1-b4f20e6df29f.png)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
