### PR TITLE
fix(ui): allow case-insensitive username

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -128,7 +128,7 @@ namespace confighttp {
     auto password = authData.substr(index + 1);
     auto hash = util::hex(crypto::hash(password + config::sunshine.salt)).to_string();
 
-    if (username != config::sunshine.username || hash != config::sunshine.password) {
+    if (!boost::iequals(username, config::sunshine.username) || hash != config::sunshine.password) {
       return false;
     }
 
@@ -631,7 +631,7 @@ namespace confighttp {
       }
       else {
         auto hash = util::hex(crypto::hash(password + config::sunshine.salt)).to_string();
-        if (config::sunshine.username.empty() || (username == config::sunshine.username && hash == config::sunshine.password)) {
+        if (config::sunshine.username.empty() || (boost::iequals(username, config::sunshine.username) && hash == config::sunshine.password)) {
           if (newPassword.empty() || newPassword != confirmPassword) {
             outputTree.put("status", false);
             outputTree.put("error", "Password Mismatch");


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR allows the UI username to be case-insensitive.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
