### PR TITLE
Archive Win32 binaries with debug info for crash analysis

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -781,7 +781,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release \
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DSUNSHINE_ASSETS_DIR=assets \
             -G "MinGW Makefiles" \
             ..
@@ -800,6 +800,15 @@ jobs:
           # move
           mv ./cpack_artifacts/Sunshine.exe ../artifacts/sunshine-windows-installer.exe
           mv ./cpack_artifacts/Sunshine.zip ../artifacts/sunshine-windows-portable.zip
+
+      - name: Package Windows Debug Info
+        working-directory: build
+        run: |
+          # save the original binaries with debug info
+          7z -r `
+            "-xr!CMakeFiles" `
+            "-xr!cpack_artifacts" `
+            a "../artifacts/sunshine-debuginfo-win32.zip" "*.exe"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description
It's very difficult to debug user-reported crashes on Windows, even with a crash dump, because we don't build our binaries with debug info. This PR changes the Windows build to build with debug info and archive the unstripped binaries in a separate zip file for crash analysis. CPack strips the binaries before packaging, so the actual release binaries are unaffected by this change.

With this change, we can download the associated `sunshine-debuginfo-win32.zip` for a given build and generate PDBs with [cv2pdb](https://github.com/rainers/cv2pdb) to debug crashes from any nightly or release build.

I gave the debug info zip file a name with a different format than other artifacts to hopefully reduce the chance someone downloads it by mistake.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
