### PR TITLE
Default audio device tracking fixes

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -471,7 +471,7 @@ namespace nvhttp {
       return;
     }
 
-    auto uniqID { std::move(get_arg(args, "uniqueid")) };
+    auto uniqID { get_arg(args, "uniqueid") };
     auto sess_it = map_id_sess.find(uniqID);
 
     args_t::const_iterator it;


### PR DESCRIPTION
## Description
This PR contains a couple fixes for audio device tracking issues on Windows (and a small fix for nvhttp.cpp to address a new warning in GCC 13.1).

- The first commit is the warning fix.

- The second commit adds an `IMMNotificationClient` that receives callbacks from the OS when the default audio device changes. Since we always want to capture from the default device, we reinitialize audio if the default device changes to ensure we pick up the new default device. This allows us to handle complex audio topology changes, like unplugging and replugging a monitor or TV with an integrated audio device while streaming.

- The third commit uses the notification added in the prior commit to enable us to set the default audio device back to the virtual sink if another application or device arrival changes it after streaming started.

- The fourth commit adds support for changing the local audio playback mode (audio sink vs virtual sink, depending on whether we want audio playing on the host PC or not) when resuming an existing stream. This is something supported by recent Moonlight clients, which send their `/launch` args to `/resume` too.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #976 
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
