### PR TITLE
Fix systray icon sometimes not appearing after login

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -212,6 +212,12 @@ namespace system_tray {
         return 1;
       }
     }
+
+    // Wait for the shell to be initialized before registering the tray icon.
+    // This ensures the tray icon works reliably after a logoff/logon cycle.
+    while (GetShellWindow() == nullptr) {
+      Sleep(1000);
+    }
   #endif
 
     if (tray_init(&tray) < 0) {


### PR DESCRIPTION
## Description
The systray icon doesn't always appear on my systems after a reboot. I wasn't able to consistently reproduce it to debug until I tried a signout/signin cycle which appears to always reproduce the bug for me.

I think this is happening because we're racing with the shell starting up. Adding a wait for the shell window to exist reliably fixes it for me.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
