### PR TITLE
Fix console session changes via fast user switching

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -594,6 +594,11 @@ main(int argc, char *argv[]) {
     BOOST_LOG(error) << "Platform failed to initialize"sv;
   }
 
+  auto proc_deinit_guard = proc::init();
+  if (!proc_deinit_guard) {
+    BOOST_LOG(error) << "Proc failed to initialize"sv;
+  }
+
   reed_solomon_init();
   auto input_deinit_guard = input::init();
   if (video::probe_encoders()) {

--- a/src/process.h
+++ b/src/process.h
@@ -14,6 +14,7 @@
 #include <boost/process.hpp>
 
 #include "config.h"
+#include "platform/common.h"
 #include "utility.h"
 
 namespace proc {
@@ -115,6 +116,9 @@ namespace proc {
   refresh(const std::string &file_name);
   std::optional<proc::proc_t>
   parse(const std::string &file_name);
+
+  std::unique_ptr<platf::deinit_t>
+  init();
 
   extern proc_t proc;
 }  // namespace proc

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -16,6 +16,7 @@
 SERVICE_STATUS_HANDLE service_status_handle;
 SERVICE_STATUS service_status;
 HANDLE stop_event;
+HANDLE session_change_event;
 
 #define SERVICE_NAME "SunshineSvc"
 
@@ -23,6 +24,14 @@ DWORD WINAPI
 HandlerEx(DWORD dwControl, DWORD dwEventType, LPVOID lpEventData, LPVOID lpContext) {
   switch (dwControl) {
     case SERVICE_CONTROL_INTERROGATE:
+      return NO_ERROR;
+
+    case SERVICE_CONTROL_SESSIONCHANGE:
+      // If a new session connects to the console, restart Sunshine
+      // to allow it to spawn inside the new console session.
+      if (dwEventType == WTS_CONSOLE_CONNECT) {
+        SetEvent(session_change_event);
+      }
       return NO_ERROR;
 
     case SERVICE_CONTROL_PRESHUTDOWN:
@@ -39,7 +48,7 @@ HandlerEx(DWORD dwControl, DWORD dwEventType, LPVOID lpEventData, LPVOID lpConte
       return NO_ERROR;
 
     default:
-      return NO_ERROR;
+      return ERROR_CALL_NOT_IMPLEMENTED;
   }
 }
 
@@ -87,13 +96,7 @@ AllocateProcThreadAttributeList(DWORD attribute_count) {
 }
 
 HANDLE
-DuplicateTokenForConsoleSession() {
-  auto console_session_id = WTSGetActiveConsoleSessionId();
-  if (console_session_id == 0xFFFFFFFF) {
-    // No console session yet
-    return NULL;
-  }
-
+DuplicateTokenForSession(DWORD console_session_id) {
   HANDLE current_token;
   if (!OpenProcessToken(GetCurrentProcess(), TOKEN_DUPLICATE, &current_token)) {
     return NULL;
@@ -201,8 +204,19 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
   service_status.dwCurrentState = SERVICE_START_PENDING;
   SetServiceStatus(service_status_handle, &service_status);
 
+  // Create a manual-reset stop event
   stop_event = CreateEventA(NULL, TRUE, FALSE, NULL);
   if (stop_event == NULL) {
+    // Tell SCM we failed to start
+    service_status.dwWin32ExitCode = GetLastError();
+    service_status.dwCurrentState = SERVICE_STOPPED;
+    SetServiceStatus(service_status_handle, &service_status);
+    return;
+  }
+
+  // Create an auto-reset session change event
+  session_change_event = CreateEventA(NULL, FALSE, FALSE, NULL);
+  if (session_change_event == NULL) {
     // Tell SCM we failed to start
     service_status.dwWin32ExitCode = GetLastError();
     service_status.dwCurrentState = SERVICE_STOPPED;
@@ -248,13 +262,19 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
     NULL);
 
   // Tell SCM we're running (and stoppable now)
-  service_status.dwControlsAccepted = SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_PRESHUTDOWN;
+  service_status.dwControlsAccepted = SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_PRESHUTDOWN | SERVICE_ACCEPT_SESSIONCHANGE;
   service_status.dwCurrentState = SERVICE_RUNNING;
   SetServiceStatus(service_status_handle, &service_status);
 
   // Loop every 3 seconds until the stop event is set or Sunshine.exe is running
   while (WaitForSingleObject(stop_event, 3000) != WAIT_OBJECT_0) {
-    auto console_token = DuplicateTokenForConsoleSession();
+    auto console_session_id = WTSGetActiveConsoleSessionId();
+    if (console_session_id == 0xFFFFFFFF) {
+      // No console session yet
+      continue;
+    }
+
+    auto console_token = DuplicateTokenForSession(console_session_id);
     if (console_token == NULL) {
       continue;
     }
@@ -292,30 +312,42 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       continue;
     }
 
-    // Wait for either the stop event to be set or Sunshine.exe to terminate
-    const HANDLE wait_objects[] = { stop_event, process_info.hProcess };
-    switch (WaitForMultipleObjects(_countof(wait_objects), wait_objects, FALSE, INFINITE)) {
-      case WAIT_OBJECT_0:
-        // The service is shutting down, so try to gracefully terminate Sunshine.exe.
-        // If it doesn't terminate in 20 seconds, we will forcefully terminate it.
-        if (!RunTerminationHelper(console_token, process_info.dwProcessId) ||
-            WaitForSingleObject(process_info.hProcess, 20000) != WAIT_OBJECT_0) {
-          // If it won't terminate gracefully, kill it now
-          TerminateProcess(process_info.hProcess, ERROR_PROCESS_ABORTED);
-        }
-        break;
+    bool still_running;
+    do {
+      // Wait for the stop event to be set, Sunshine.exe to terminate, or the console session to change
+      const HANDLE wait_objects[] = { stop_event, process_info.hProcess, session_change_event };
+      switch (WaitForMultipleObjects(_countof(wait_objects), wait_objects, FALSE, INFINITE)) {
+        case WAIT_OBJECT_0 + 2:
+          if (WTSGetActiveConsoleSessionId() == console_session_id) {
+            // The active console session didn't actually change. Let Sunshine keep running.
+            still_running = true;
+            continue;
+          }
+          // Fall-through to terminate Sunshine.exe and start it again.
+        case WAIT_OBJECT_0:
+          // The service is shutting down, so try to gracefully terminate Sunshine.exe.
+          // If it doesn't terminate in 20 seconds, we will forcefully terminate it.
+          if (!RunTerminationHelper(console_token, process_info.dwProcessId) ||
+              WaitForSingleObject(process_info.hProcess, 20000) != WAIT_OBJECT_0) {
+            // If it won't terminate gracefully, kill it now
+            TerminateProcess(process_info.hProcess, ERROR_PROCESS_ABORTED);
+          }
+          still_running = false;
+          break;
 
-      case WAIT_OBJECT_0 + 1: {
-        // Sunshine terminated itself.
+        case WAIT_OBJECT_0 + 1: {
+          // Sunshine terminated itself.
 
-        DWORD exit_code;
-        if (GetExitCodeProcess(process_info.hProcess, &exit_code) && exit_code == ERROR_SHUTDOWN_IN_PROGRESS) {
-          // Sunshine is asking for us to shut down, so gracefully stop ourselves.
-          SetEvent(stop_event);
+          DWORD exit_code;
+          if (GetExitCodeProcess(process_info.hProcess, &exit_code) && exit_code == ERROR_SHUTDOWN_IN_PROGRESS) {
+            // Sunshine is asking for us to shut down, so gracefully stop ourselves.
+            SetEvent(stop_event);
+          }
+          still_running = false;
+          break;
         }
-        break;
       }
-    }
+    } while (still_running);
 
     CloseHandle(process_info.hThread);
     CloseHandle(process_info.hProcess);


### PR DESCRIPTION
## Description
SunshineSvc was not properly handling fast user switching, so the Sunshine process would continue running in the original session after the new session became the active console session. Since Sunshine was disconnected from the console, it could no longer capture the desktop or send input.

With this fix, SunshineSvc now requests session change notifications from SCM and will signal the main service thread to restart Sunshine if the active console session changes. Any connected clients will be disconnected when the first Sunshine process terminates, but this is the best we can do without major refactoring that's probably not worth the effort right now.

This also allows a client to reconnect to a host after Microsoft Remote Desktop has been used.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
