### PR TITLE
Improve capture sleep scheduling on Windows

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -413,27 +413,6 @@ resolutions
         3840x1600,
       ]
 
-dwmflush
-^^^^^^^^
-
-**Description**
-   Invoke DwmFlush() to sync screen capture to the Windows presentation interval.
-
-   .. Caution:: Applies to Windows only. Alleviates visual stuttering during mouse movement.
-      If enabled, this feature will automatically deactivate if the client framerate exceeds
-      the host monitor's current refresh rate.
-
-   .. Note:: If you disable this option, you may see video stuttering during mouse movement in certain scenarios.
-      It is recommended to leave enabled when possible.
-
-**Default**
-   ``enabled``
-
-**Example**
-   .. code-block:: text
-
-      dwmflush = enabled
-
 Audio
 -----
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -438,7 +438,6 @@ namespace config {
     {},  // encoder
     {},  // adapter_name
     {},  // output_name
-    true  // dwmflush
   };
 
   audio_t audio {
@@ -1034,7 +1033,6 @@ namespace config {
     string_f(vars, "encoder", video.encoder);
     string_f(vars, "adapter_name", video.adapter_name);
     string_f(vars, "output_name", video.output_name);
-    bool_f(vars, "dwmflush", video.dwmflush);
 
     path_f(vars, "pkey", nvhttp.pkey);
     path_f(vars, "cert", nvhttp.cert);

--- a/src/config.h
+++ b/src/config.h
@@ -64,7 +64,6 @@ namespace config {
     std::string encoder;
     std::string adapter_name;
     std::string output_name;
-    bool dwmflush;
   };
 
   struct audio_t {

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -109,7 +109,6 @@ namespace platf::dxgi {
   public:
     dup_t dup;
     bool has_frame {};
-    bool use_dwmflush {};
     std::chrono::steady_clock::time_point last_protected_content_warning_time {};
 
     capture_e

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -132,14 +132,16 @@ namespace platf::dxgi {
     capture_e
     capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override;
 
-    std::chrono::nanoseconds delay;
-
     factory1_t factory;
     adapter_t adapter;
     output_t output;
     device_t device;
     device_ctx_t device_ctx;
     duplication_t dup;
+    DXGI_RATIONAL display_refresh_rate;
+    int display_refresh_rate_rounded;
+
+    int client_frame_rate;
 
     DXGI_FORMAT capture_format;
     D3D_FEATURE_LEVEL feature_level;

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -126,6 +126,9 @@ namespace platf::dxgi {
     int
     init(const ::video::config_t &config, const std::string &display_name);
 
+    void
+    high_precision_sleep(std::chrono::nanoseconds duration);
+
     capture_e
     capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override;
 
@@ -140,6 +143,8 @@ namespace platf::dxgi {
 
     DXGI_FORMAT capture_format;
     D3D_FEATURE_LEVEL feature_level;
+
+    util::safe_ptr_v2<std::remove_pointer_t<HANDLE>, BOOL, CloseHandle> timer;
 
     typedef enum _D3DKMT_SCHEDULINGPRIORITYCLASS {
       D3DKMT_SCHEDULINGPRIORITYCLASS_IDLE,

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -32,10 +32,6 @@ namespace platf::dxgi {
       return capture_status;
     }
 
-    if (use_dwmflush) {
-      DwmFlush();
-    }
-
     auto status = dup->AcquireNextFrame(timeout.count(), &frame_info, res_p);
 
     switch (status) {
@@ -469,21 +465,6 @@ namespace platf::dxgi {
       << "Capture size       : "sv << width << 'x' << height << std::endl
       << "Offset             : "sv << offset_x << 'x' << offset_y << std::endl
       << "Virtual Desktop    : "sv << env_width << 'x' << env_height;
-
-    // Enable DwmFlush() only if the current refresh rate can match the client framerate.
-    auto refresh_rate = config.framerate;
-    DWM_TIMING_INFO timing_info;
-    timing_info.cbSize = sizeof(timing_info);
-
-    status = DwmGetCompositionTimingInfo(NULL, &timing_info);
-    if (FAILED(status)) {
-      BOOST_LOG(warning) << "Failed to detect active refresh rate.";
-    }
-    else {
-      refresh_rate = std::round((double) timing_info.rateRefresh.uiNumerator / (double) timing_info.rateRefresh.uiDenominator);
-    }
-
-    dup.use_dwmflush = config::video.dwmflush && !(config.framerate > refresh_rate) ? true : false;
 
     // Bump up thread priority
     {

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -74,19 +74,20 @@ namespace platf::dxgi {
     }
 
     auto status = dup->ReleaseFrame();
+    has_frame = false;
     switch (status) {
       case S_OK:
-        has_frame = false;
         return capture_e::ok;
-      case DXGI_ERROR_WAIT_TIMEOUT:
-        return capture_e::timeout;
-      case WAIT_ABANDONED:
+
+      case DXGI_ERROR_INVALID_CALL:
+        BOOST_LOG(warning) << "Duplication frame already released";
+        return capture_e::ok;
+
       case DXGI_ERROR_ACCESS_LOST:
-      case DXGI_ERROR_ACCESS_DENIED:
-        has_frame = false;
         return capture_e::reinit;
+
       default:
-        BOOST_LOG(error) << "Couldn't release frame [0x"sv << util::hex(status).to_string_view();
+        BOOST_LOG(error) << "Error while releasing duplication frame [0x"sv << util::hex(status).to_string_view();
         return capture_e::error;
     }
   }
@@ -173,6 +174,11 @@ namespace platf::dxgi {
         default:
           BOOST_LOG(error) << "Unrecognized capture status ["sv << (int) status << ']';
           return status;
+      }
+
+      status = dup.release_frame();
+      if (status != platf::capture_e::ok) {
+        return status;
       }
     }
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -957,7 +957,7 @@ namespace platf::dxgi {
     }
 
     const bool mouse_update_flag = frame_info.LastMouseUpdateTime.QuadPart != 0 || frame_info.PointerShapeBufferSize > 0;
-    const bool frame_update_flag = frame_info.AccumulatedFrames != 0 || frame_info.LastPresentTime.QuadPart != 0;
+    const bool frame_update_flag = frame_info.LastPresentTime.QuadPart != 0;
     const bool update_flag = mouse_update_flag || frame_update_flag;
 
     if (!update_flag) {

--- a/src/stat_trackers.h
+++ b/src/stat_trackers.h
@@ -41,7 +41,7 @@ namespace stat_trackers {
     struct {
       std::chrono::steady_clock::steady_clock::time_point last_callback_time = std::chrono::steady_clock::now();
       T stat_min = std::numeric_limits<T>::max();
-      T stat_max = 0;
+      T stat_max = std::numeric_limits<T>::min();
       double stat_total = 0;
       uint32_t calls = 0;
     } data;

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -582,18 +582,6 @@
           tools\dxgi-info.exe<br />
         </div>
       </div>
-      <!--DwmFlush-->
-      <div class="mb-3" v-if="platform === 'windows'">
-        <label for="dwmflush" class="form-label">DwmFlush</label>
-        <select id="dwmflush" class="form-select" v-model="config.dwmflush">
-          <option value="disabled">Disabled</option>
-          <option value="enabled">Enabled</option>
-        </select>
-        <div class="form-text">
-          Improves capture latency/smoothness during mouse movement.<br />
-          Disable if you encounter any VSync-related issues.
-        </div>
-      </div>
       <div class="mb-3" v-if="platform === 'linux'">
         <label for="output_name" class="form-label">Monitor number</label>
         <input


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

This adds common synchronization point for consecutive frames, previously we calculated sleep duration on frame-to-frame basis, and this quickly accumulated errors because sleep function always overshoots (up to 1.5ms normally, 0.5ms in average).

Also removes the delay in releasing duplication surface, this dropped frames when the surface was not available during flip. And removes DwmFlush, because this hack is no longer necessary.

Related https://github.com/LizardByte/Sunshine/pull/1203, https://github.com/LizardByte/Sunshine/pull/1168

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
