### PR TITLE
Remove Boost_NO_BOOST_CMAKE=ON to fix Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,6 @@ pkg_check_modules(CURL REQUIRED libcurl)
 
 if(WIN32)
     set(Boost_USE_STATIC_LIBS ON)  # cmake-lint: disable=C0103
-    # workaround to prevent link errors against icudata, icui18n
-    set(Boost_NO_BOOST_CMAKE ON)  # cmake-lint: disable=C0103
 endif()
 
 find_package(Boost COMPONENTS locale log filesystem program_options REQUIRED)


### PR DESCRIPTION
## Description
With the latest MinGW Boost package change (https://github.com/msys2/MINGW-packages/commit/eabbec9dfad12b4bc5b85f9481942a4200d066d0), it tries to link to the (missing) shared library for Boost::thread with `Boost_NO_BOOST_CMAKE=ON` set. The linking error this was designed to fix seems to be gone now anyway.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
