### PR TITLE
Fix several major memory leaks

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -938,7 +938,7 @@ namespace nvhttp {
 
     // Verify certificates after establishing connection
     https_server.verify = [&cert_chain, add_cert](SSL *ssl) {
-      auto x509 = SSL_get_peer_certificate(ssl);
+      crypto::x509_t x509 { SSL_get_peer_certificate(ssl) };
       if (!x509) {
         BOOST_LOG(info) << "unknown -- denied"sv;
         return 0;
@@ -949,7 +949,7 @@ namespace nvhttp {
       auto fg = util::fail_guard([&]() {
         char subject_name[256];
 
-        X509_NAME_oneline(X509_get_subject_name(x509), subject_name, sizeof(subject_name));
+        X509_NAME_oneline(X509_get_subject_name(x509.get()), subject_name, sizeof(subject_name));
 
         BOOST_LOG(debug) << subject_name << " -- "sv << (verified ? "verified"sv : "denied"sv);
       });
@@ -964,7 +964,7 @@ namespace nvhttp {
         cert_chain.add(std::move(cert));
       }
 
-      auto err_str = cert_chain.verify(x509);
+      auto err_str = cert_chain.verify(x509.get());
       if (err_str) {
         BOOST_LOG(warning) << "SSL Verification error :: "sv << err_str;
 

--- a/src/video.h
+++ b/src/video.h
@@ -33,7 +33,7 @@ namespace video {
     }
 
     ~packet_raw_t() {
-      av_packet_unref(this->av_packet);
+      av_packet_free(&this->av_packet);
     }
 
     struct replace_t {


### PR DESCRIPTION
## Description
This PR fixes all the leaks found by AddressSanitizer on my Linux machine. We were leaking continuously while streaming (not freeing `AVPacket` for each encoded frame) and also while not streaming if a Moonlight client was open and polling our server info over HTTPS (not freeing `X509` after cert verification). We also leaked a ton of VAAPI driver allocations each time the VAAPI encoder was reinitialized because `vaTerminate()` was never being called.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Resolves #1294
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
