### PR TITLE
Fix resolutions reported by dxgi-info.exe on high DPI systems

### DIFF
--- a/tools/dxgi.cpp
+++ b/tools/dxgi.cpp
@@ -1,7 +1,8 @@
 /**
  * @file tools/dxgi.cpp
- * @brief todo
+ * @brief Displays information about connected displays and GPUs
  */
+#define WINVER 0x0A00
 #include <d3dcommon.h>
 #include <dxgi.h>
 
@@ -26,6 +27,9 @@ namespace dxgi {
 int
 main(int argc, char *argv[]) {
   HRESULT status;
+
+  // Set ourselves as per-monitor DPI aware for accurate resolution values on High DPI systems
+  SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
   dxgi::factory1_t::pointer factory_p {};
   status = CreateDXGIFactory1(IID_IDXGIFactory1, (void **) &factory_p);


### PR DESCRIPTION
## Description
Fix for a little bug in `dxgi-info.exe` reported on Discord. If we don't declare ourselves Per-Monitor DPI aware, `IDXGIOutput::GetDesc()` will report DPI-normalized values in `DesktopCoordinates` which causes us to display the wrong resolution for High DPI displays.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
