### PR TITLE
Fix Home/Guide button emulation and disable it by default

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -156,14 +156,12 @@ back_button_timeout
 ^^^^^^^^^^^^^^^^^^^
 
 **Description**
-   If, after the timeout, the back/select button is still pressed down, Home/Guide button press is emulated.
-
-   On Nvidia Shield, the home and power button are not passed to Moonlight.
+   If the Back/Select button is held down for the specified number of milliseconds, a Home/Guide button press is emulated.
 
    .. Tip:: If back_button_timeout < 0, then the Home/Guide button will not be emulated.
 
 **Default**
-   ``2000``
+   ``-1``
 
 **Example**
    .. code-block:: text

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -429,7 +429,7 @@ namespace config {
       { 0x11, 0xA2 },
       { 0x12, 0xA4 },
     },
-    2s,  // back_button_timeout
+    -1ms,  // back_button_timeout
     500ms,  // key_repeat_delay
     std::chrono::duration<double> { 1 / 24.9 },  // key_repeat_period
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -19,6 +19,9 @@ extern "C" {
 #include "thread_pool.h"
 #include "utility.h"
 
+#include <boost/chrono.hpp>
+#include <boost/thread/thread.hpp>
+
 using namespace std::literals;
 namespace input {
 
@@ -733,6 +736,9 @@ namespace input {
             // Press Home button
             state.buttonFlags |= platf::HOME;
             platf::gamepad(platf_input, gamepad.id, state);
+
+            // Sleep for a short time to allow the input to be detected
+            boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
 
             // Release Home button
             state.buttonFlags &= ~platf::HOME;

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -334,23 +334,21 @@
       </div>
     </div>
     <div v-if="currentTab === 'input'" class="config-page">
-      <!--Back Button Timeout-->
+      <!--Home/Guide Button Emulation Timeout-->
       <div class="mb-3">
         <label for="back_button_timeout" class="form-label"
-          >Back Button Timeout</label
+          >Home/Guide Button Emulation Timeout</label
         >
         <input
           type="text"
           class="form-control"
           id="back_button_timeout"
-          placeholder="2000"
+          placeholder="-1"
           v-model="config.back_button_timeout"
         />
         <div class="form-text">
-          The back/select button on the controller.<br />
-          On the Shield, the home and power button are not passed to  Moonlight.<br />
-          If, after the timeout, the back button is still pressed down, Home/Guide button press is emulated.<br />
-          If back_button_timeout &lt; 0, then the Home/Guide button will not be emulated<br />
+          If the Back/Select button is held down for the specified number of milliseconds, a Home/Guide button press is emulated.<br />
+          If set to a value &lt; 0 (default), holding the Back/Select button will not emulate the Home/Guide button.<br />
         </div>
       </div>
       <!--Enable Mouse Input-->


### PR DESCRIPTION
## Description
The Guide button emulation code instantaneously pressed and released the emulated button, which worked very inconsistently due to the input polling behavior of most apps. Delaying for a short time while the button is down (like Moonlight's button emulation code does) allows the emulated button press to work consistently.

I was surprised to see that Guide emulation is enabled by default. This causes issues with apps/games that use a long press of the Back button for in-game functionality. Since most common controllers have Guide/Home buttons these days and users expect their controller buttons to behave normally out of the box, I've changed Guide button emulation be off by default. I don't expect this to be a major impact, especially because the feature itself was mostly broken prior to this PR.

I rewrote the name and description of the Web UI option for this too, because "Back Button Timeout" wasn't really clearly stating what the feature was doing. The fact that it's the longest you a can press the back button is really a side-effect rather than a description of the user-facing feature that users will be looking for when they search the options.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/f3c7d3f9-c3aa-4f4c-b1f2-5602beefb488)

### Issues Fixed or Closed
Fixes #1048
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
