### PR TITLE
windows: fix header conflict for msys2-w32api-headers 11.0.1+

### DIFF
--- a/src/platform/windows/publish.cpp
+++ b/src/platform/windows/publish.cpp
@@ -29,9 +29,8 @@ using namespace std::literals;
 #define SV(quote) __SV(quote)
 
 extern "C" {
-constexpr auto DNS_REQUEST_PENDING = 9506L;
-
 #ifndef __MINGW32__
+constexpr auto DNS_REQUEST_PENDING = 9506L;
 constexpr auto DNS_QUERY_REQUEST_VERSION1 = 0x1;
 constexpr auto DNS_QUERY_RESULTS_VERSION1 = 0x1;
 #endif


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes error in Windows build after updating all msys2 packages:
```
D:\Software\msys64\mingw64\bin\c++.exe -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_LOCALE_NO_LIB -DBOOST_LOG_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_THREAD_NO_LIB -DCURL_STATICLIB -DMINIUPNP_STATICLIB -DNDEBUG -DSUNSHINE_ASSETS_DIR=\"assets\" -DSUNSHINE_PLATFORM=\"windows\" -DSUNSHINE_TRAY=1 @CMakeFiles/sunshine.dir/includes_CXX.rsp -O3 -DNDEBUG -std=gnu++17 -Wall -Wno-sign-compare -MD -MT CMakeFiles/sunshine.dir/src/platform/windows/publish.cpp.obj -MF CMakeFiles\sunshine.dir\src\platform\windows\publish.cpp.obj.d -o CMakeFiles\sunshine.dir\src\platform\windows\publish.cpp.obj -c D:\Software\msys64\home\Conn\Sunshine\src\platform\windows\publish.cpp
In file included from D:/Software/msys64/mingw64/include/_mingw.h:10,
                 from D:/Software/msys64/mingw64/include/windows.h:9,
                 from D:/Software/msys64/mingw64/include/winsock2.h:23,
                 from D:\Software\msys64\home\Conn\Sunshine\src\platform\windows\publish.cpp:5:
D:\Software\msys64\home\Conn\Sunshine\src\platform\windows\publish.cpp:32:16: error: expected unqualified-id before numeric constant
   32 | constexpr auto DNS_REQUEST_PENDING = 9506L;
      |                ^~~~~~~~~~~~~~~~~~~
mingw32-make[2]: *** [CMakeFiles\sunshine.dir\build.make:366: CMakeFiles/sunshine.dir/src/platform/windows/publish.cpp.obj] Error 1
```
This definition is now included in the following header and package version:
`/usr/include/w32api/winerror.h is owned by msys2-w32api-headers 11.0.1.r0.gc3e587c06-1`


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
