### PR TITLE
Fix WebUI Stable Update notification

### DIFF
--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -9,10 +9,10 @@
       <div v-if="loading">
         Loading Latest Release...
       </div>
-      <div class="alert alert-success" v-if="runningDirtyBuild">
+      <div class="alert alert-success" v-if="buildVersionIsDirty">
         Thank you for helping to make Sunshine a better software! 🌇
       </div>
-      <div v-else-if="!nightlyBuildAvailable && !stableBuildAvailable && !runningDirtyBuild">
+      <div v-else-if="!nightlyBuildAvailable && !stableBuildAvailable && !buildVersionIsDirty">
         <div class="alert alert-success">
           You're running the latest version of Sunshine
         </div>
@@ -89,7 +89,7 @@
       try {
         this.version = (await fetch("/api/config").then((r) => r.json())).version;
         this.githubVersion = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/releases/latest").then((r) => r.json()));
-        if (this.buildVersionIsNightly()) {
+        if (this.buildVersionIsNightly) {
           this.nightlyData = (await fetch("https://api.github.com/repos/LizardByte/Sunshine/actions/workflows/CI.yml/runs?branch=nightly&status=success&per_page=1").then((r) => r.json())).workflow_runs[0];
         }
       } catch(e){
@@ -97,9 +97,6 @@
       this.loading = false;
     },
     computed: {
-      runningDirtyBuild() {
-        return this.buildVersionIsDirty()
-      },
       stableBuildAvailable() {
         // If we can't get versions, return false
         if (!this.githubVersion || !this.version) return false;
@@ -109,32 +106,30 @@
         if (v.indexOf("v") === 0) v = v.substring(1);
 
         // if nightly or dirty, we do an additional check to make sure it's an actual upgrade.
-        if (this.buildVersionIsNightly() || this.buildVersionIsDirty()) {
+        if (this.buildVersionIsNightly || this.buildVersionIsDirty) {
           const stableVersion = this.version.split('.').slice(0, 3).join('.');
           return this.githubVersion.tag_name.substring(1) > stableVersion;
         }
 
         // return true if the version is different, otherwise false
-        return v !== this.version.split(".")[0];
+        return v !== this.version;
       },
       nightlyBuildAvailable() {
         // Verify nightly data is available and the build version is not stable
         // This is important to ensure the UI does not try to load undefined values.
-        if (!this.nightlyData || this.buildVersionIsStable()) return false;
+        if (!this.nightlyData || this.buildVersionIsStable) return false;
         // If built with dirty git tree, return false
-        if (this.buildVersionIsDirty()) return false;
+        if (this.buildVersionIsDirty) return false;
         // Get the commit hash
         let commit = this.version?.split(".").pop();
         // return true if the commit hash is different, otherwise false
         return this.nightlyData.head_sha.indexOf(commit) !== 0;
-      }
-    },
-    methods: {
-      buildVersionIsDirty() {
+      },
+	  buildVersionIsDirty() {
         return this.version?.split(".").length === 5 &&
           this.version.indexOf("dirty") !== -1
       },
-      buildVersionIsNightly() {
+	  buildVersionIsNightly() {
         return this.version?.split(".").length === 4
       },
       buildVersionIsStable() {


### PR DESCRIPTION
## Description
Fixes the Web UI Update notification System. 
Stable releases are now checked correctly and does not show an update available. 
I've also changed some methods into Vue computed fields, which is a better approach
Fixes #1103 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
