### PR TITLE
fix(deps): replace libboost chrono and thread with standard chrono and thread

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -285,7 +285,6 @@ jobs:
               libboost-locale1.71-dev \
               libboost-log1.71-dev \
               libboost-regex1.71-dev \
-              libboost-thread1.71-dev \
               libboost-program-options1.71-dev
 
             # Install cmake
@@ -311,7 +310,6 @@ jobs:
               libboost-filesystem-dev \
               libboost-locale-dev \
               libboost-log-dev \
-              libboost-thread-dev \
               libboost-program-options-dev
           fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -906,7 +906,6 @@ elseif(UNIX)
                 libboost-locale${Boost_VERSION}, \
                 libboost-log${Boost_VERSION}, \
                 libboost-program-options${Boost_VERSION}, \
-                libboost-thread${Boost_VERSION}, \
                 libcap2, \
                 libcurl4, \
                 libdrm2, \
@@ -926,7 +925,6 @@ elseif(UNIX)
                 boost-locale >= ${Boost_VERSION}, \
                 boost-log >= ${Boost_VERSION}, \
                 boost-program-options >= ${Boost_VERSION}, \
-                boost-thread >= ${Boost_VERSION}, \
                 libcap >= 2.22, \
                 libcurl >= 7.0, \
                 libdrm >= 2.4.97, \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,6 +902,7 @@ elseif(UNIX)
         set(CPACK_DEB_COMPONENT_INSTALL ON)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                 ${CPACK_DEB_PLATFORM_PACKAGE_DEPENDS} \
+                libboost-chrono${Boost_VERSION}, \
                 libboost-filesystem${Boost_VERSION}, \
                 libboost-locale${Boost_VERSION}, \
                 libboost-log${Boost_VERSION}, \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,7 +902,6 @@ elseif(UNIX)
         set(CPACK_DEB_COMPONENT_INSTALL ON)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                 ${CPACK_DEB_PLATFORM_PACKAGE_DEPENDS} \
-                libboost-chrono${Boost_VERSION}, \
                 libboost-filesystem${Boost_VERSION}, \
                 libboost-locale${Boost_VERSION}, \
                 libboost-log${Boost_VERSION}, \

--- a/docker/debian-bullseye.dockerfile
+++ b/docker/debian-bullseye.dockerfile
@@ -38,7 +38,6 @@ apt-get install -y --no-install-recommends \
   libboost-locale-dev=1.74.* \
   libboost-log-dev=1.74.* \
   libboost-program-options-dev=1.74.* \
-  libboost-thread-dev=1.74.* \
   libcap-dev \
   libcurl4-openssl-dev \
   libdrm-dev \

--- a/docker/ubuntu-20.04.dockerfile
+++ b/docker/ubuntu-20.04.dockerfile
@@ -40,7 +40,6 @@ apt-get install -y --no-install-recommends \
   libboost-locale-dev=1.71.* \
   libboost-log-dev=1.71.* \
   libboost-program-options-dev=1.71.* \
-  libboost-thread-dev=1.71.* \
   libcap-dev \
   libcurl4-openssl-dev \
   libdrm-dev \

--- a/docker/ubuntu-22.04.dockerfile
+++ b/docker/ubuntu-22.04.dockerfile
@@ -39,7 +39,6 @@ apt-get install -y --no-install-recommends \
   libboost-locale-dev=1.74.* \
   libboost-log-dev=1.74.* \
   libboost-program-options-dev=1.74.* \
-  libboost-thread-dev=1.74.* \
   libcap-dev \
   libcurl4-openssl-dev \
   libdrm-dev \

--- a/docs/source/building/linux.rst
+++ b/docs/source/building/linux.rst
@@ -19,7 +19,6 @@ Install Requirements
           libboost-locale-dev \
           libboost-log-dev \
           libboost-program-options-dev \
-          libboost-thread-dev \
           libcap-dev \  # KMS
           libcurl4-openssl-dev \
           libdrm-dev \  # KMS
@@ -100,7 +99,6 @@ Install Requirements
           libboost-filesystem-dev \
           libboost-locale-dev \
           libboost-log-dev \
-          libboost-thread-dev \
           libboost-program-options-dev \
           libcap-dev \  # KMS
           libdrm-dev \  # KMS
@@ -149,7 +147,6 @@ Install Requirements
           libboost-filesystem-dev \
           libboost-locale-dev \
           libboost-log-dev \
-          libboost-thread-dev \
           libboost-program-options-dev \
           libcap-dev \  # KMS
           libdrm-dev \  # KMS

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -10,6 +10,7 @@ extern "C" {
 }
 
 #include <bitset>
+#include <chrono>
 #include <unordered_map>
 
 #include "config.h"
@@ -19,7 +20,6 @@ extern "C" {
 #include "thread_pool.h"
 #include "utility.h"
 
-#include <boost/chrono.hpp>
 #include <boost/thread/thread.hpp>
 
 using namespace std::literals;
@@ -738,7 +738,7 @@ namespace input {
             platf::gamepad(platf_input, gamepad.id, state);
 
             // Sleep for a short time to allow the input to be detected
-            boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
+            boost::this_thread::sleep_for(std::chrono::milliseconds(100));
 
             // Release Home button
             state.buttonFlags &= ~platf::HOME;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -11,6 +11,7 @@ extern "C" {
 
 #include <bitset>
 #include <chrono>
+#include <thread>
 #include <unordered_map>
 
 #include "config.h"
@@ -19,8 +20,6 @@ extern "C" {
 #include "platform/common.h"
 #include "thread_pool.h"
 #include "utility.h"
-
-#include <boost/thread/thread.hpp>
 
 using namespace std::literals;
 namespace input {
@@ -738,7 +737,7 @@ namespace input {
             platf::gamepad(platf_input, gamepad.id, state);
 
             // Sleep for a short time to allow the input to be detected
-            boost::this_thread::sleep_for(std::chrono::milliseconds(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
             // Release Home button
             state.buttonFlags &= ~platf::HOME;


### PR DESCRIPTION
## Description
Sunshine crashes on Ubuntu 22.04 due a missing lib boost dependency. This PR adds the missing dependency for the deb packages.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
