### PR TITLE
Use X mouse even if /dev/uinput is present

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -124,6 +124,18 @@ global_prep_cmd
 Controls
 --------
 
+mouse
+^^^^^
+
+**Description**
+   In Linux use X mouse even if /dev/uinput is present
+
+**Example**
+   .. code-block:: text
+
+      mousex = enabled
+
+
 gamepad
 ^^^^^^^
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1037,6 +1037,7 @@ namespace config {
     string_restricted_f(vars, "gamepad"s, input.gamepad, platf::supported_gamepads());
 
     bool_f(vars, "mouse", input.mouse);
+    bool_f(vars, "mousex", input.mousex);
     bool_f(vars, "keyboard", input.keyboard);
     bool_f(vars, "controller", input.controller);
 

--- a/src/config.h
+++ b/src/config.h
@@ -108,6 +108,7 @@ namespace config {
 
     bool keyboard;
     bool mouse;
+    bool mousex;
     bool controller;
 
     bool always_send_scancodes;

--- a/src/platform/linux/input.cpp
+++ b/src/platform/linux/input.cpp
@@ -27,6 +27,7 @@
 
 #include "src/platform/common.h"
 
+#include "src/config.h"
 #include "misc.h"
 
 // Support older versions
@@ -1783,7 +1784,8 @@ namespace platf {
     gp.mouse_dev = mouse();
     gp.gamepad_dev = x360();
 
-    gp.create_mouse();
+    if (!config::input.mousex)
+        gp.create_mouse();
     gp.create_touchscreen();
     gp.create_keyboard();
 


### PR DESCRIPTION
I can never get mouse to work in my cloud rig

In Debian it worked but no gamepad

Switched to ubuntu now gamepad work and mouse fail

If there was a program to monitor ALL INPUT LIVE and poll for new devices. Maybe I could know why

But alas this is what I have to do. Now the Mose and gamepad works from moonlight android 