### PR TITLE
DS4 touchpad button support

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -254,7 +254,7 @@ namespace input {
       << "--begin controller packet--"sv << std::endl
       << "controllerNumber ["sv << packet->controllerNumber << ']' << std::endl
       << "activeGamepadMask ["sv << util::hex(packet->activeGamepadMask).to_string_view() << ']' << std::endl
-      << "buttonFlags ["sv << util::hex(packet->buttonFlags).to_string_view() << ']' << std::endl
+      << "buttonFlags ["sv << util::hex((uint32_t) packet->buttonFlags | (packet->buttonFlags2 << 16)).to_string_view() << ']' << std::endl
       << "leftTrigger ["sv << util::hex(packet->leftTrigger).to_string_view() << ']' << std::endl
       << "rightTrigger ["sv << util::hex(packet->rightTrigger).to_string_view() << ']' << std::endl
       << "leftStickX ["sv << packet->leftStickX << ']' << std::endl
@@ -691,8 +691,9 @@ namespace input {
     }
 
     std::uint16_t bf = packet->buttonFlags;
+    std::uint32_t bf2 = packet->buttonFlags2;
     platf::gamepad_state_t gamepad_state {
-      bf,
+      bf | (bf2 << 16),
       packet->leftTrigger,
       packet->rightTrigger,
       packet->leftStickX,

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -47,7 +47,8 @@ namespace video {
 }  // namespace video
 
 namespace platf {
-  constexpr auto MAX_GAMEPADS = 32;
+  // Limited by bits in activeGamepadMask
+  constexpr auto MAX_GAMEPADS = 16;
 
   constexpr std::uint32_t DPAD_UP = 0x0001;
   constexpr std::uint32_t DPAD_DOWN = 0x0002;

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -49,21 +49,27 @@ namespace video {
 namespace platf {
   constexpr auto MAX_GAMEPADS = 32;
 
-  constexpr std::uint16_t DPAD_UP = 0x0001;
-  constexpr std::uint16_t DPAD_DOWN = 0x0002;
-  constexpr std::uint16_t DPAD_LEFT = 0x0004;
-  constexpr std::uint16_t DPAD_RIGHT = 0x0008;
-  constexpr std::uint16_t START = 0x0010;
-  constexpr std::uint16_t BACK = 0x0020;
-  constexpr std::uint16_t LEFT_STICK = 0x0040;
-  constexpr std::uint16_t RIGHT_STICK = 0x0080;
-  constexpr std::uint16_t LEFT_BUTTON = 0x0100;
-  constexpr std::uint16_t RIGHT_BUTTON = 0x0200;
-  constexpr std::uint16_t HOME = 0x0400;
-  constexpr std::uint16_t A = 0x1000;
-  constexpr std::uint16_t B = 0x2000;
-  constexpr std::uint16_t X = 0x4000;
-  constexpr std::uint16_t Y = 0x8000;
+  constexpr std::uint32_t DPAD_UP = 0x0001;
+  constexpr std::uint32_t DPAD_DOWN = 0x0002;
+  constexpr std::uint32_t DPAD_LEFT = 0x0004;
+  constexpr std::uint32_t DPAD_RIGHT = 0x0008;
+  constexpr std::uint32_t START = 0x0010;
+  constexpr std::uint32_t BACK = 0x0020;
+  constexpr std::uint32_t LEFT_STICK = 0x0040;
+  constexpr std::uint32_t RIGHT_STICK = 0x0080;
+  constexpr std::uint32_t LEFT_BUTTON = 0x0100;
+  constexpr std::uint32_t RIGHT_BUTTON = 0x0200;
+  constexpr std::uint32_t HOME = 0x0400;
+  constexpr std::uint32_t A = 0x1000;
+  constexpr std::uint32_t B = 0x2000;
+  constexpr std::uint32_t X = 0x4000;
+  constexpr std::uint32_t Y = 0x8000;
+  constexpr std::uint32_t PADDLE1 = 0x010000;
+  constexpr std::uint32_t PADDLE2 = 0x020000;
+  constexpr std::uint32_t PADDLE3 = 0x040000;
+  constexpr std::uint32_t PADDLE4 = 0x080000;
+  constexpr std::uint32_t TOUCHPAD_BUTTON = 0x100000;
+  constexpr std::uint32_t MISC_BUTTON = 0x200000;
 
   struct rumble_t {
     KITTY_DEFAULT_CONSTR(rumble_t)
@@ -154,7 +160,7 @@ namespace platf {
   };
 
   struct gamepad_state_t {
-    std::uint16_t buttonFlags;
+    std::uint32_t buttonFlags;
     std::uint8_t lt;
     std::uint8_t rt;
     std::int16_t lsX;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -520,6 +520,9 @@ namespace platf {
 
     if (gamepad_state.buttonFlags & HOME) buttons |= DS4_SPECIAL_BUTTON_PS;
 
+    // Allow either PS4/PS5 clickpad button or Xbox Series X share button to activate DS4 clickpad
+    if (gamepad_state.buttonFlags & (TOUCHPAD_BUTTON | MISC_BUTTON)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
+
     return (DS4_SPECIAL_BUTTONS) buttons;
   }
 


### PR DESCRIPTION
## Description
This PR pulls out the extended button support and gamepad count fix from #1396 since they are trivial changes and don't depend on any of the major new protocol work happening in that branch.

Clients supporting these new button flags aren't released yet, but support is present in the Qt and Android clients as of now. iOS will probably be done in the coming few days.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes https://github.com/LizardByte/Sunshine/issues/1362
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
