### PR TITLE
Allow use of multiple ENet channels

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -106,7 +106,7 @@ namespace net {
     enet_address_set_host(&addr, "0.0.0.0");
     enet_address_set_port(&addr, port);
 
-    return host_t { enet_host_create(AF_INET, &addr, peers, 1, 0, 0) };
+    return host_t { enet_host_create(AF_INET, &addr, peers, 0, 0, 0) };
   }
 
   void


### PR DESCRIPTION
## Description
ENet channels provide a solution to the head-of-line blocking issue common to reliable protocols after a packet loss. I'm adding multi-channel support to moonlight-common-c to be able to send mouse/keyboard/gamepad on separate channels, but we need to accept more than one channel for it to work.

This is a trivial change to pass 0 instead of 1 as the `channelLimit` parameter.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
