### PR TITLE
fix: consider link-local addresses as LAN

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -19,7 +19,8 @@ namespace net {
     ip_block("192.168.0.0/16"sv),
     ip_block("172.16.0.0/12"sv),
     ip_block("10.0.0.0/8"sv),
-    ip_block("100.64.0.0/10"sv)
+    ip_block("100.64.0.0/10"sv),
+    ip_block("169.254.0.0/16"sv)
   };
 
   std::uint32_t


### PR DESCRIPTION
## Description
When connecting two machines without the use of a router, the machines are assigned link-local IPs. Sunshine is not considering these to be LAN IPs, making the web dash inaccessible.  

See also: discussion on Discord [here](https://discord.com/channels/804382334370578482/1074377411069747250/1126550517879947315)


### Screenshot
N.A.


### Issues Fixed or Closed
N.A.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
