### PR TITLE
Add support for Applications (context menu) key on Windows hosts

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1228,6 +1228,10 @@ namespace input {
       }
 
       for (auto &kp : key_press) {
+        if (!kp.second) {
+          // already released
+          continue;
+        }
         platf::keyboard(platf_input, vk_from_kpid(kp.first) & 0x00FF, true, flags_from_kpid(kp.first));
         key_press[kp.first] = false;
       }

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -516,6 +516,7 @@ namespace platf {
       case VK_LEFT:
       case VK_RIGHT:
       case VK_DIVIDE:
+      case VK_APPS:
         ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
         break;
       default:


### PR DESCRIPTION
## Description
Add support for the [applications (aka context menu) key](https://en.wikipedia.org/wiki/Menu_key). The key opens the context menu and it's useful for using GUI applications with a keyboard. I'm will add corresponding support in moonlight-qt in https://github.com/moonlight-stream/moonlight-qt/pull/1035 .

I had to change input::reset() to not send key-up events for keys that are not pressed because a key-up on the applications key will open the context menu, which would cause the context menu to always open after the client disconnects if the key was pressed by the client.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
