### PR TITLE
Remove GetAsyncKeyState()

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -408,8 +408,6 @@ namespace platf {
 
   void
   button_mouse(input_t &input, int button, bool release) {
-    constexpr auto KEY_STATE_DOWN = (SHORT) 0x8000;
-
     INPUT i {};
 
     i.type = INPUT_MOUSE;
@@ -437,14 +435,6 @@ namespace platf {
       mi.dwFlags = release ? MOUSEEVENTF_XUP : MOUSEEVENTF_XDOWN;
       mi.mouseData = XBUTTON2;
       mouse_button = VK_XBUTTON2;
-    }
-
-    auto key_state = GetAsyncKeyState(mouse_button);
-    bool key_state_down = (key_state & KEY_STATE_DOWN) != 0;
-    if (key_state_down != release) {
-      BOOST_LOG(warning) << "Button state of mouse_button ["sv << button << "] does not match the desired state"sv;
-
-      return;
     }
 
     send_input(i);


### PR DESCRIPTION
## Description
It's unnecessary and races with OS-wide event processing.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #1433
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
