### PR TITLE
WIP: Input only sessions

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -267,6 +267,7 @@ namespace nvhttp {
 
     launch_session.host_audio = host_audio;
     launch_session.gcm_key = util::from_hex<crypto::aes_t>(get_arg(args, "rikey"), true);
+    launch_session.input_only = util::from_view(get_arg(args, "sunshineInputOnly"));
     uint32_t prepend_iv = util::endian::big<uint32_t>(util::from_view(get_arg(args, "rikeyid")));
     auto prepend_iv_p = (uint8_t *) &prepend_iv;
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -684,6 +684,8 @@ namespace rtsp_stream {
       return;
     }
 
+    config.inputOnly = launch_session->input_only;
+
     // When using stereo audio, the audio quality is (strangely) indicated by whether the Host field
     // in the RTSP message matches a local interface's IP address. Fortunately, Moonlight always sends
     // 0.0.0.0 when it wants low quality, so it is easy to check without enumerating interfaces.

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -17,6 +17,7 @@ namespace rtsp_stream {
     crypto::aes_t iv;
 
     bool host_audio;
+    bool input_only;
   };
 
   void

--- a/src/stream.h
+++ b/src/stream.h
@@ -28,6 +28,7 @@ namespace stream {
     int videoQosType;
 
     std::optional<int> gcmap;
+    bool inputOnly;
   };
 
   namespace session {


### PR DESCRIPTION
## Description
This is a Draft PR for making Sunshine capable of input-only sessions.
Some clients, due to the platform limitations, are not able to have all the available input methods (for example the Xbox client does not allow mouse, touch and DS4 inputs due to limitations of the UWP API on Xbox)
With this PR, Sunshine can make sessions without the video and audio thread initialized, to make more lightweight sessions. 

This is a first draft the server part of the change. While I have a working client and moonlight-common-c modifications, I would prefer to discuss this on the server side with you before going forward to the other parts of the stack.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
