### PR TITLE
ci(linux): free additional space on runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,6 +157,16 @@ jobs:
       matrix: ${{fromJson(needs.setup_flatpak_matrix.outputs.matrix)}}
 
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 10240
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'false'
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -177,13 +187,6 @@ jobs:
             org.freedesktop.Sdk/${{ matrix.arch }}/${PLATFORM_VERSION} \
             org.freedesktop.Sdk.Extension.node18/${{ matrix.arch }}/${PLATFORM_VERSION} \
             "
-
-      - name: Create Additional Disk Space
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo docker rmi $(docker images -a -q)
-          df -h
 
       - name: Cache Flatpak build
         uses: actions/cache@v3
@@ -273,6 +276,16 @@ jobs:
             dist: 20.04
 
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 20480
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'false'
+
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR frees additional space for Linux matrix in the CI, and changes the step in the Flatpak build to use the same action.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
