### PR TITLE
Build fixes for new MinGW headers

### DIFF
--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -2,6 +2,7 @@
  * @file src/platform/windows/audio.cpp
  * @brief todo
  */
+#define INITGUID
 #include <audioclient.h>
 #include <mmdeviceapi.h>
 #include <roapi.h>
@@ -11,10 +12,6 @@
 #include <synchapi.h>
 
 #include <newdev.h>
-
-#define INITGUID
-#include <propkeydef.h>
-#undef INITGUID
 
 #include "src/config.h"
 #include "src/main.h"
@@ -28,11 +25,6 @@
 DEFINE_PROPERTYKEY(PKEY_Device_DeviceDesc, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 2);  // DEVPROP_TYPE_STRING
 DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 14);  // DEVPROP_TYPE_STRING
 DEFINE_PROPERTYKEY(PKEY_DeviceInterface_FriendlyName, 0x026e516e, 0xb814, 0x414b, 0x83, 0xcd, 0x85, 0x6d, 0x6f, 0xef, 0x48, 0x22, 2);
-
-const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
-const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
-const IID IID_IAudioClient = __uuidof(IAudioClient);
-const IID IID_IAudioCaptureClient = __uuidof(IAudioCaptureClient);
 
 #if defined(__x86_64) || defined(_M_AMD64)
   #define STEAM_DRIVER_SUBDIR L"x64"

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -40,9 +40,6 @@
   #define UDP_SEND_MSG_SIZE 2
 #endif
 
-// MinGW headers are missing qWAVE stuff
-typedef UINT32 QOS_FLOWID, *PQOS_FLOWID;
-#define QOS_NON_ADAPTIVE_FLOW 0x00000002
 #include <qos2.h>
 
 #ifndef WLAN_API_MAKE_VERSION

--- a/tools/audio.cpp
+++ b/tools/audio.cpp
@@ -2,6 +2,7 @@
  * @file tools/audio.cpp
  * @brief todo
  */
+#define INITGUID
 #include <audioclient.h>
 #include <mmdeviceapi.h>
 #include <roapi.h>
@@ -10,10 +11,6 @@
 #include <locale>
 
 #include <synchapi.h>
-
-#define INITGUID
-#include <propkeydef.h>
-#undef INITGUID
 
 #include <iostream>
 
@@ -24,10 +21,6 @@ DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0
 DEFINE_PROPERTYKEY(PKEY_DeviceInterface_FriendlyName, 0x026e516e, 0xb814, 0x414b, 0x83, 0xcd, 0x85, 0x6d, 0x6f, 0xef, 0x48, 0x22, 2);
 
 using namespace std::literals;
-const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
-const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
-const IID IID_IAudioClient = __uuidof(IAudioClient);
-const IID IID_IAudioCaptureClient = __uuidof(IAudioCaptureClient);
 
 int device_state_filter = DEVICE_STATE_ACTIVE;
 


### PR DESCRIPTION
## Description
Several fixes for compatibility with new MinGW headers. As with previous similar changes, we will now require these newer headers to build.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
