### PR TITLE
ci(docker): bump gcc-10 in ubuntu 20.04 image

### DIFF
--- a/docker/ubuntu-20.04.dockerfile
+++ b/docker/ubuntu-20.04.dockerfile
@@ -31,8 +31,8 @@ set -e
 apt-get update -y
 apt-get install -y --no-install-recommends \
   build-essential \
-  gcc-10=10.3.* \
-  g++-10=10.3.* \
+  gcc-10=10.5.* \
+  g++-10=10.5.* \
   git \
   libappindicator3-dev \
   libavdevice-dev \


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Within Ubuntu 20.04 Docker image, bump `gcc-10` from `10.3.*` to `10.5.*`


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
