### PR TITLE
ci(windows): prevent winget action from creating an update when runni…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -851,7 +851,10 @@ jobs:
   release-winget:
     name: Release to WinGet
     needs: [setup_release, build_win]
-    if: ${{ needs.setup_release.outputs.create_release == 'true' && github.ref == 'refs/heads/master' }}
+    if: |
+      (github.repository_owner == 'LizardByte' &&
+      needs.setup_release.outputs.create_release == 'true' &&
+      github.ref == 'refs/heads/master')
     runs-on: windows-latest  # the required action can only be run on Windows
     steps:
       - name: Release to WinGet


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR will prevent forks from accidentally creating a new release in winget, if they run our workflows in their fork, such as https://github.com/microsoft/winget-pkgs/pull/112895.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
