### PR TITLE
Fix clamping mouse position to aspect ratio adjusted viewport

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -477,8 +477,8 @@ namespace input {
     auto offsetX = touch_port.client_offsetX;
     auto offsetY = touch_port.client_offsetY;
 
-    x = std::clamp(x, offsetX, size.first - offsetX);
-    y = std::clamp(y, offsetY, size.second - offsetY);
+    x = std::clamp(x, offsetX, (size.first * scalarX) - offsetX);
+    y = std::clamp(y, offsetY, (size.second * scalarY) - offsetY);
 
     return { (x - offsetX) * touch_port.scalar_inv, (y - offsetY) * touch_port.scalar_inv };
   }


### PR DESCRIPTION
## Description
These `std::clamp()` calls were no-ops until bd68aebe when I noticed the fact that the return value was ignored and fixed it. Unfortunately, the max values passed to `std::clamp()` were actually wrong so "fixing" the ignored return value actually broke the code.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #1512


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
