### PR TITLE
Use UTF-8 conversion for log output and C standard library functions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -473,6 +473,9 @@ main(int argc, char *argv[]) {
   task_pool_util::TaskPool::task_id_t force_shutdown = nullptr;
 
 #ifdef _WIN32
+  // Switch default C standard library locale to UTF-8 on Windows 10 1803+
+  setlocale(LC_ALL, ".UTF-8");
+
   // Wait as long as possible to terminate Sunshine.exe during logoff/shutdown
   SetProcessShutdownParameters(0x100, SHUTDOWN_NORETRY);
 
@@ -515,6 +518,9 @@ main(int argc, char *argv[]) {
   });
   window_thread.detach();
 #endif
+
+  // Use UTF-8 conversion for the default C++ locale (used by boost::log)
+  std::locale::global(std::locale(std::locale(), new std::codecvt_utf8<wchar_t>));
 
   mail::man = std::make_shared<safe::mail_raw_t>();
 


### PR DESCRIPTION
## Description
This fixes the ability to print non-ASCII characters without crashing. Obviously crashing when trying to log non-ASCII characters is a pretty severe i18n problem for systems that aren't using English as the default/only language.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/36dd6b1a-9848-4174-b0c3-19c49bbc61ff)

### Issues Fixed or Closed
Fixes #1477
Fixes #475
Fixes #1446
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
