### PR TITLE
ci(docker): bump cmake from 3.26 to 3.27 for Fedora

### DIFF
--- a/docker/fedora-37.dockerfile
+++ b/docker/fedora-37.dockerfile
@@ -31,7 +31,7 @@ dnf -y update
 dnf -y group install "Development Tools"
 dnf -y install \
   boost-devel-1.78.* \
-  cmake-3.26.* \
+  cmake-3.27.* \
   gcc-12.2.* \
   gcc-c++-12.2.* \
   git \

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -31,9 +31,9 @@ dnf -y update
 dnf -y group install "Development Tools"
 dnf -y install \
   boost-devel-1.78.0* \
-  cmake-3.26.* \
-  gcc-13.0.* \
-  gcc-c++-13.0.* \
+  cmake-3.27.* \
+  gcc-13.2.* \
+  gcc-c++-13.2.* \
   git \
   libappindicator-gtk3-devel \
   libcap-devel \


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Bump cmake from 3.26 to 3.27 for Fedora builds.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
