### PR TITLE
Fix regression introduced during standalone nvenc merge

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -249,7 +249,7 @@ namespace nvenc {
       if (config.enable_min_qp) {
         enc_config.rcParams.enableMinQP = 1;
         enc_config.rcParams.minQP.qpInterP = value;
-        enc_config.rcParams.minQP.qpInterP = value;
+        enc_config.rcParams.minQP.qpIntra = value;
       }
     };
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -194,6 +194,9 @@ namespace platf::dxgi {
     int
     init(const ::video::config_t &config, const std::string &display_name);
 
+    std::unique_ptr<avcodec_encode_device_t>
+    make_avcodec_encode_device(pix_fmt_e pix_fmt) override;
+
     cursor_t cursor;
     D3D11_MAPPED_SUBRESOURCE img_info;
     texture2d_t texture;

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -389,4 +389,10 @@ namespace platf::dxgi {
 
     return 0;
   }
+
+  std::unique_ptr<avcodec_encode_device_t>
+  display_ram_t::make_avcodec_encode_device(pix_fmt_e pix_fmt) {
+    return std::make_unique<avcodec_encode_device_t>();
+  }
+
 }  // namespace platf::dxgi


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

Software encoding stopped working on Windows, this fixes it.

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
