### PR TITLE
AV1 encoding support

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -810,6 +810,37 @@ hevc_mode
 
       hevc_mode = 2
 
+av1_mode
+^^^^^^^^^
+
+**Description**
+   Allows the client to request AV1 Main 8-bit or 10-bit video streams.
+
+   .. Warning:: AV1 is more CPU-intensive to encode, so enabling this may reduce performance when using software
+      encoding.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   =====     ===========
+   Value     Description
+   =====     ===========
+   0         advertise support for AV1 based on encoder
+   1         do not advertise support for AV1
+   2         advertise support for AV1 Main 8-bit profile
+   3         advertise support for AV1 Main 8-bit and 10-bit (HDR) profiles
+   =====     ===========
+
+**Default**
+   ``0``
+
+**Example**
+   .. code-block:: text
+
+      av1_mode = 2
+
 capture
 ^^^^^^^
 

--- a/src/cbs.cpp
+++ b/src/cbs.cpp
@@ -96,7 +96,7 @@ namespace cbs {
 
     cbs::frag_t frag;
 
-    int err = ff_cbs_read_packet(ctx.get(), &frag, &*packet);
+    int err = ff_cbs_read_packet(ctx.get(), &frag, packet);
     if (err < 0) {
       char err_str[AV_ERROR_MAX_STRING_SIZE] { 0 };
       BOOST_LOG(error) << "Couldn't read packet: "sv << av_make_error_string(err_str, AV_ERROR_MAX_STRING_SIZE, err);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -130,12 +130,19 @@ namespace config {
   namespace amd {
 #ifdef __APPLE__
   // values accurate as of 27/12/2022, but aren't strictly necessary for MacOS build
+  #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_SPEED 100
+  #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_QUALITY 30
+  #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_BALANCED 70
   #define AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_SPEED 10
   #define AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_QUALITY 0
   #define AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_BALANCED 5
   #define AMF_VIDEO_ENCODER_QUALITY_PRESET_SPEED 1
   #define AMF_VIDEO_ENCODER_QUALITY_PRESET_QUALITY 2
   #define AMF_VIDEO_ENCODER_QUALITY_PRESET_BALANCED 0
+  #define AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CONSTANT_QP 0
+  #define AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CBR 3
+  #define AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR 2
+  #define AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR 1
   #define AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CONSTANT_QP 0
   #define AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR 3
   #define AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR 2
@@ -144,6 +151,10 @@ namespace config {
   #define AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR 1
   #define AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR 2
   #define AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR 3
+  #define AMF_VIDEO_ENCODER_AV1_USAGE_TRANSCODING 0
+  #define AMF_VIDEO_ENCODER_AV1_USAGE_LOW_LATENCY 1
+  #define AMF_VIDEO_ENCODER_AV1_USAGE_ULTRA_LOW_LATENCY 2
+  #define AMF_VIDEO_ENCODER_AV1_USAGE_WEBCAM 3
   #define AMF_VIDEO_ENCODER_HEVC_USAGE_TRANSCONDING 0
   #define AMF_VIDEO_ENCODER_HEVC_USAGE_ULTRA_LOW_LATENCY 1
   #define AMF_VIDEO_ENCODER_HEVC_USAGE_LOW_LATENCY 2
@@ -156,9 +167,16 @@ namespace config {
   #define AMF_VIDEO_ENCODER_CABAC 1
   #define AMF_VIDEO_ENCODER_CALV 2
 #else
+  #include <AMF/components/VideoEncoderAV1.h>
   #include <AMF/components/VideoEncoderHEVC.h>
   #include <AMF/components/VideoEncoderVCE.h>
 #endif
+
+    enum class quality_av1_e : int {
+      speed = AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_SPEED,
+      quality = AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_QUALITY,
+      balanced = AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_BALANCED
+    };
 
     enum class quality_hevc_e : int {
       speed = AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_SPEED,
@@ -170,6 +188,13 @@ namespace config {
       speed = AMF_VIDEO_ENCODER_QUALITY_PRESET_SPEED,
       quality = AMF_VIDEO_ENCODER_QUALITY_PRESET_QUALITY,
       balanced = AMF_VIDEO_ENCODER_QUALITY_PRESET_BALANCED
+    };
+
+    enum class rc_av1_e : int {
+      cqp = AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CONSTANT_QP,
+      vbr_latency = AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR,
+      vbr_peak = AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR,
+      cbr = AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CBR
     };
 
     enum class rc_hevc_e : int {
@@ -184,6 +209,13 @@ namespace config {
       vbr_latency = AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR,
       vbr_peak = AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR,
       cbr = AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR
+    };
+
+    enum class usage_av1_e : int {
+      transcoding = AMF_VIDEO_ENCODER_AV1_USAGE_TRANSCODING,
+      webcam = AMF_VIDEO_ENCODER_AV1_USAGE_WEBCAM,
+      lowlatency = AMF_VIDEO_ENCODER_AV1_USAGE_LOW_LATENCY,
+      ultralowlatency = AMF_VIDEO_ENCODER_AV1_USAGE_ULTRA_LOW_LATENCY
     };
 
     enum class usage_hevc_e : int {
@@ -206,10 +238,11 @@ namespace config {
       cavlc = AMF_VIDEO_ENCODER_CALV
     };
 
+    template <class T>
     std::optional<int>
-    quality_from_view(const std::string_view &quality_type, int codec) {
+    quality_from_view(const std::string_view &quality_type) {
 #define _CONVERT_(x) \
-  if (quality_type == #x##sv) return codec == 0 ? (int) quality_hevc_e::x : (int) quality_h264_e::x
+  if (quality_type == #x##sv) return (int) T::x
       _CONVERT_(quality);
       _CONVERT_(speed);
       _CONVERT_(balanced);
@@ -217,10 +250,11 @@ namespace config {
       return std::nullopt;
     }
 
+    template <class T>
     std::optional<int>
-    rc_from_view(const std::string_view &rc, int codec) {
+    rc_from_view(const std::string_view &rc) {
 #define _CONVERT_(x) \
-  if (rc == #x##sv) return codec == 0 ? (int) rc_hevc_e::x : (int) rc_h264_e::x
+  if (rc == #x##sv) return (int) T::x
       _CONVERT_(cqp);
       _CONVERT_(vbr_latency);
       _CONVERT_(vbr_peak);
@@ -229,10 +263,11 @@ namespace config {
       return std::nullopt;
     }
 
+    template <class T>
     std::optional<int>
-    usage_from_view(const std::string_view &rc, int codec) {
+    usage_from_view(const std::string_view &rc) {
 #define _CONVERT_(x) \
-  if (rc == #x##sv) return codec == 0 ? (int) usage_hevc_e::x : (int) usage_h264_e::x
+  if (rc == #x##sv) return (int) T::x
       _CONVERT_(transcoding);
       _CONVERT_(webcam);
       _CONVERT_(lowlatency);
@@ -333,15 +368,36 @@ namespace config {
 
   }  // namespace vt
 
+  namespace sw {
+    int
+    svtav1_preset_from_view(const std::string_view &preset) {
+#define _CONVERT_(x, y) \
+  if (preset == #x##sv) return y
+      _CONVERT_(veryslow, 1);
+      _CONVERT_(slower, 2);
+      _CONVERT_(slow, 4);
+      _CONVERT_(medium, 5);
+      _CONVERT_(fast, 7);
+      _CONVERT_(faster, 9);
+      _CONVERT_(veryfast, 10);
+      _CONVERT_(superfast, 11);
+      _CONVERT_(ultrafast, 12);
+#undef _CONVERT_
+      return 11;  // Default to superfast
+    }
+  }  // namespace sw
+
   video_t video {
     28,  // qp
 
     0,  // hevc_mode
+    0,  // av1_mode
 
     1,  // min_threads
     {
       "superfast"s,  // preset
       "zerolatency"s,  // tune
+      11,  // superfast
     },  // software
 
     {
@@ -359,10 +415,13 @@ namespace config {
     {
       (int) amd::quality_h264_e::balanced,  // quality (h264)
       (int) amd::quality_hevc_e::balanced,  // quality (hevc)
+      (int) amd::quality_av1_e::balanced,  // quality (av1)
       (int) amd::rc_h264_e::vbr_latency,  // rate control (h264)
       (int) amd::rc_hevc_e::vbr_latency,  // rate control (hevc)
+      (int) amd::rc_av1_e::vbr_latency,  // rate control (av1)
       (int) amd::usage_h264_e::ultralowlatency,  // usage (h264)
       (int) amd::usage_hevc_e::ultralowlatency,  // usage (hevc)
+      (int) amd::usage_av1_e::ultralowlatency,  // usage (av1)
       0,  // preanalysis
       1,  // vbaq
       (int) amd::coder_e::_auto,  // coder
@@ -924,7 +983,11 @@ namespace config {
     int_f(vars, "qp", video.qp);
     int_f(vars, "min_threads", video.min_threads);
     int_between_f(vars, "hevc_mode", video.hevc_mode, { 0, 3 });
+    int_between_f(vars, "av1_mode", video.av1_mode, { 0, 3 });
     string_f(vars, "sw_preset", video.sw.sw_preset);
+    if (!video.sw.sw_preset.empty()) {
+      video.sw.svtav1_preset = sw::svtav1_preset_from_view(video.sw.sw_preset);
+    }
     string_f(vars, "sw_tune", video.sw.sw_tune);
     int_f(vars, "nv_preset", video.nv.nv_preset, nv::preset_from_view);
     int_f(vars, "nv_tune", video.nv.nv_tune, nv::tune_from_view);
@@ -937,23 +1000,26 @@ namespace config {
     std::string quality;
     string_f(vars, "amd_quality", quality);
     if (!quality.empty()) {
-      video.amd.amd_quality_h264 = amd::quality_from_view(quality, 1);
-      video.amd.amd_quality_hevc = amd::quality_from_view(quality, 0);
+      video.amd.amd_quality_h264 = amd::quality_from_view<amd::quality_h264_e>(quality);
+      video.amd.amd_quality_hevc = amd::quality_from_view<amd::quality_hevc_e>(quality);
+      video.amd.amd_quality_av1 = amd::quality_from_view<amd::quality_av1_e>(quality);
     }
 
     std::string rc;
     string_f(vars, "amd_rc", rc);
     int_f(vars, "amd_coder", video.amd.amd_coder, amd::coder_from_view);
     if (!rc.empty()) {
-      video.amd.amd_rc_h264 = amd::rc_from_view(rc, 1);
-      video.amd.amd_rc_hevc = amd::rc_from_view(rc, 0);
+      video.amd.amd_rc_h264 = amd::rc_from_view<amd::rc_h264_e>(rc);
+      video.amd.amd_rc_hevc = amd::rc_from_view<amd::rc_hevc_e>(rc);
+      video.amd.amd_rc_av1 = amd::rc_from_view<amd::rc_av1_e>(rc);
     }
 
     std::string usage;
     string_f(vars, "amd_usage", usage);
     if (!usage.empty()) {
-      video.amd.amd_usage_h264 = amd::usage_from_view(rc, 1);
-      video.amd.amd_usage_hevc = amd::usage_from_view(rc, 0);
+      video.amd.amd_usage_h264 = amd::usage_from_view<amd::usage_h264_e>(rc);
+      video.amd.amd_usage_hevc = amd::usage_from_view<amd::usage_hevc_e>(rc);
+      video.amd.amd_usage_av1 = amd::usage_from_view<amd::usage_av1_e>(rc);
     }
 
     bool_f(vars, "amd_preanalysis", (bool &) video.amd.amd_preanalysis);

--- a/src/config.h
+++ b/src/config.h
@@ -17,11 +17,13 @@ namespace config {
     int qp;  // higher == more compression and less quality
 
     int hevc_mode;
+    int av1_mode;
 
     int min_threads;  // Minimum number of threads/slices for CPU encoding
     struct {
       std::string sw_preset;
       std::string sw_tune;
+      std::optional<int> svtav1_preset;
     } sw;
 
     struct {
@@ -39,10 +41,13 @@ namespace config {
     struct {
       std::optional<int> amd_quality_h264;
       std::optional<int> amd_quality_hevc;
+      std::optional<int> amd_quality_av1;
       std::optional<int> amd_rc_h264;
       std::optional<int> amd_rc_hevc;
+      std::optional<int> amd_rc_av1;
       std::optional<int> amd_usage_h264;
       std::optional<int> amd_usage_hevc;
+      std::optional<int> amd_usage_av1;
       std::optional<int> amd_preanalysis;
       std::optional<int> amd_vbaq;
       int amd_coder;

--- a/src/nvenc/nvenc_config.h
+++ b/src/nvenc/nvenc_config.h
@@ -35,6 +35,9 @@ namespace nvenc {
     // Min QP value for HEVC when enable_min_qp is selected
     unsigned min_qp_hevc = 23;
 
+    // Min QP value for AV1 when enable_min_qp is selected
+    unsigned min_qp_av1 = 23;
+
     // Use CAVLC entropy coding in H.264 instead of CABAC, not relevant and here for historical reasons
     bool h264_cavlc = false;
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -643,15 +643,20 @@ namespace nvhttp {
     tree.put("root.MaxLumaPixelsHEVC", video::active_hevc_mode > 1 ? "1869449984" : "0");
     tree.put("root.LocalIP", local_endpoint.address().to_string());
 
-    if (video::active_hevc_mode == 3) {
-      tree.put("root.ServerCodecModeSupport", "3843");
+    uint32_t codec_mode_flags = SCM_H264;
+    if (video::active_hevc_mode >= 2) {
+      codec_mode_flags |= SCM_HEVC;
     }
-    else if (video::active_hevc_mode == 2) {
-      tree.put("root.ServerCodecModeSupport", "259");
+    if (video::active_hevc_mode >= 3) {
+      codec_mode_flags |= SCM_HEVC_MAIN10;
     }
-    else {
-      tree.put("root.ServerCodecModeSupport", "3");
+    if (video::active_av1_mode >= 2) {
+      codec_mode_flags |= SCM_AV1_MAIN8;
     }
+    if (video::active_av1_mode >= 3) {
+      codec_mode_flags |= SCM_AV1_MAIN10;
+    }
+    tree.put("root.ServerCodecModeSupport", codec_mode_flags);
 
     pt::ptree display_nodes;
     for (auto &resolution : config::nvhttp.resolutions) {

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -504,6 +504,10 @@ namespace rtsp_stream {
       ss << "x-nv-video[0].refPicInvalidation=1"sv << std::endl;
     }
 
+    if (video::active_av1_mode != 1) {
+      ss << "a=rtpmap:98 AV1/90000"sv << std::endl;
+    }
+
     for (int x = 0; x < audio::MAX_STREAM_CONFIG; ++x) {
       auto &stream_config = audio::stream_configs[x];
       std::uint8_t mapping[platf::speaker::MAX_SPEAKERS];
@@ -701,8 +705,15 @@ namespace rtsp_stream {
       }
     }
 
-    if (config.monitor.videoFormat != 0 && video::active_hevc_mode == 1) {
+    if (config.monitor.videoFormat == 1 && video::active_hevc_mode == 1) {
       BOOST_LOG(warning) << "HEVC is disabled, yet the client requested HEVC"sv;
+
+      respond(sock, &option, 400, "BAD REQUEST", req->sequenceNumber, {});
+      return;
+    }
+
+    if (config.monitor.videoFormat == 2 && video::active_av1_mode == 1) {
+      BOOST_LOG(warning) << "AV1 is disabled, yet the client requested AV1"sv;
 
       respond(sock, &option, 400, "BAD REQUEST", req->sequenceNumber, {});
       return;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -760,7 +760,7 @@ namespace video {
     {
       // Common options
       {
-        { "filler_data"s, true },
+        { "filler_data"s, false },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
         { "quality"s, &config::video.amd.amd_quality_av1 },
         { "rc"s, &config::video.amd.amd_rc_av1 },
@@ -774,7 +774,7 @@ namespace video {
     {
       // Common options
       {
-        { "filler_data"s, true },
+        { "filler_data"s, false },
         { "gops_per_idr"s, 1 },
         { "header_insertion_mode"s, "idr"s },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
@@ -793,7 +793,7 @@ namespace video {
     {
       // Common options
       {
-        { "filler_data"s, true },
+        { "filler_data"s, false },
         { "log_to_dbg"s, "1"s },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
         { "qmax"s, 51 },

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -831,7 +831,15 @@ namespace video {
       {},  // SDR-specific options
       {},  // HDR-specific options
       std::make_optional<encoder_t::option_t>("qp"s, &config::video.qp),
+
+#ifdef ENABLE_BROKEN_AV1_ENCODER
+      // Due to bugs preventing on-demand IDR frames from working and very poor
+      // real-time encoding performance, we do not enable libsvtav1 by default.
+      // It is only suitable for testing AV1 until the IDR frame issue is fixed.
       "libsvtav1"s,
+#else
+      {},
+#endif
     },
     {
       // x265's Info SEI is so long that it causes the IDR picture data to be

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1282,6 +1282,10 @@ namespace video {
         return ret;
       }
 
+      if (frame->key_frame && !(av_packet->flags & AV_PKT_FLAG_KEY)) {
+        BOOST_LOG(error) << "Encoder did not produce IDR frame when requested!"sv;
+      }
+
       if (session.inject) {
         if (session.inject == 1) {
           auto h264 = cbs::make_sps_h264(ctx.get(), av_packet);

--- a/src/video.h
+++ b/src/video.h
@@ -137,7 +137,7 @@ namespace video {
        SDR encoding colorspace (encoderCscMode >> 1) : 0 - BT.601, 1 - BT.709, 2 - BT.2020 */
     int encoderCscMode;
 
-    int videoFormat;  // 0 - H.264, 1 - HEVC
+    int videoFormat;  // 0 - H.264, 1 - HEVC, 2 - AV1
 
     /* Encoding color depth (bit depth): 0 - 8-bit, 1 - 10-bit
        HDR encoding activates when color depth is higher than 8-bit and the display which is being captured is operating in HDR mode */
@@ -145,6 +145,7 @@ namespace video {
   };
 
   extern int active_hevc_mode;
+  extern int active_av1_mode;
   extern bool last_encoder_probe_supported_ref_frames_invalidation;
 
   void

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -691,6 +691,28 @@
           HEVC is more CPU-intensive to encode, so enabling this may reduce performance when using software encoding.
         </div>
       </div>
+      <!--AV1 Support -->
+      <div class="mb-3">
+        <label for="av1_mode" class="form-label">AV1 Support</label>
+        <select id="av1_mode" class="form-select" v-model="config.av1_mode">
+          <option value="0">
+            Sunshine will specify support for AV1 based on encoder
+          </option>
+          <option value="1">
+            Sunshine will not advertise support for AV1
+          </option>
+          <option value="2">
+            Sunshine will advertise support for AV1 Main 8-bit profile
+          </option>
+          <option value="3">
+            Sunshine will advertise support for AV1 Main 8-bit and 10-bit (HDR) profiles
+          </option>
+        </select>
+        <div class="form-text">
+          Allows the client to request AV1 Main 8-bit or 10-bit video streams.<br />
+          AV1 is more CPU-intensive to encode, so enabling this may reduce performance when using software encoding.
+        </div>
+      </div>
       <!--Capture-->
       <div class="mb-3" v-if="platform === 'linux'">
         <label for="capture" class="form-label">Force a Specific Capture Method</label>
@@ -1032,6 +1054,7 @@
     "fps": "[10,30,60,90,120]",
     "gamepad": "auto",
     "hevc_mode": 0,
+    "av1_mode": 0,
     "key_rightalt_to_key_win": "disabled",
     "keyboard": "enabled",
     "min_log_level": 2,


### PR DESCRIPTION
## Description
This PR implements support for encoding AV1 using FFmpeg and standalone NVENC. For the former, we require the changes in https://github.com/LizardByte/build-deps/pull/136, however we can't merge that yet due to the QSV memory leak introduced in FFmpeg 6.0. I tested the `av1_qsv` and `av1_amf` encoders using the WIP FFmpeg 6.0 build to ensure the encoder parameters and output bitstream were valid.

I added the `av1_vaapi` and `av1_videotoolbox` encoder names though they are not upstreamed in FFmpeg yet, so hopefully they will work when they get added.

The net effect of this PR alone is that it will turn on AV1 support for standalone NVENC (Windows). AV1 will be enabled for the other encoders when we update to FFmpeg 6.1.

Tested:
- Standalone NVENC + RFI
- QSV (requires FFmpeg 6.0+ build)
- AMF (requires FFmpeg 6.0+ build)
- libsvtav1 (broken and disabled due to inability to return IDR frames on demand)

cc: @ns6089 for the NVENC stuff and @psyke83 for the AMD stuff (and the change to disable `filler_data`)

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Partially resolves #1325 (NVENC Windows only)
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
