### PR TITLE
Command Resource Exhaustion bug fix

### DIFF
--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -562,7 +562,7 @@ namespace platf {
 
     // Clone the environment to create a local copy. Boost.Process (bp) shares the environment with all spawned processes.
     // Since we're going to modify the 'env' variable by merging user-specific environment variables into it,
-    // we make a clone to prevent side effects to the shared environment. 
+    // we make a clone to prevent side effects to the shared environment.
     bp::environment cloned_env = env;
 
     if (ec) {

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -560,9 +560,11 @@ namespace platf {
     STARTUPINFOEXW startup_info = create_startup_info(file, ec);
     PROCESS_INFORMATION process_info;
 
-    // We need to clone the environment because boost shares it with all processes.
-    // Since we are making actual mutations to the environment, this is done to avoid side effects.
+    // Clone the environment to create a local copy. Boost.Process (bp) shares the environment with all spawned processes.
+    // Since we're going to modify the 'env' variable by merging user-specific environment variables into it,
+    // we make a clone to prevent side effects to the shared environment.
     bp::environment cloned_env = env;
+
 
     if (ec) {
       // In the event that startup_info failed, return a blank child process.

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -604,7 +604,7 @@ namespace platf {
 
       // Open the process as the current user account, elevation is handled in the token itself.
       ec = impersonate_current_user(user_token, [&]() {
-        std::wstring env_block = create_environment_block(env);
+        std::wstring env_block = create_environment_block(cloned_env);
         ret = CreateProcessAsUserW(user_token,
           NULL,
           (LPWSTR) wcmd.c_str(),
@@ -637,7 +637,7 @@ namespace platf {
         return bp::child();
       }
 
-      std::wstring env_block = create_environment_block(env);
+      std::wstring env_block = create_environment_block(cloned_env);
       ret = CreateProcessW(NULL,
         (LPWSTR) wcmd.c_str(),
         NULL,

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -562,7 +562,7 @@ namespace platf {
 
     // Clone the environment to create a local copy. Boost.Process (bp) shares the environment with all spawned processes.
     // Since we're going to modify the 'env' variable by merging user-specific environment variables into it,
-    // we make a clone to prevent side effects to the shared environment.
+    // we make a clone to prevent side effects to the shared environment. 
     bp::environment cloned_env = env;
 
     if (ec) {

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -565,7 +565,6 @@ namespace platf {
     // we make a clone to prevent side effects to the shared environment.
     bp::environment cloned_env = env;
 
-
     if (ec) {
       // In the event that startup_info failed, return a blank child process.
       return bp::child();

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -539,26 +539,6 @@ namespace platf {
     return startup_info;
   }
 
-  PVOID
-  CloneEnvironmentBlock(PVOID env_block) {
-    // Calculate the size of the original environment block
-    PWCHAR c = (PWCHAR) env_block;
-    size_t size = 0;
-    while (*c != UNICODE_NULL) {
-      size += (wcslen(c) + 1) * sizeof(WCHAR);
-      c += wcslen(c) + 1;
-    }
-    size += sizeof(WCHAR);  // Add size for the final null character
-
-    // Allocate new memory for the clone
-    PVOID clone = (PVOID) new WCHAR[size / sizeof(WCHAR)];
-
-    // Copy the contents
-    memcpy(clone, env_block, size);
-
-    return clone;
-  }
-
   /**
    * @brief Run a command on the users profile.
    *
@@ -586,7 +566,7 @@ namespace platf {
 
     // Clone the environment, since it is shared with all commands and we are making modifications to it.
     bp::environment cloned_env = env;
-    
+
     if (ec) {
       // In the event that startup_info failed, return a blank child process.
       return bp::child();


### PR DESCRIPTION
Fixes a bug that caused Sunshine to fail to execute commands after a certain amount of times, caused by mutations to the environment that is shared with all processes in boost. When the PATH variable was being concatenated, it would continually append itself causing it to exceed the allowed limit and eventually prevent commands from running.


## Description
Erases environment variables before setting them again, to avoid a potential leak.


### Screenshot



### Issues Fixed or Closed
- Fixes #1456 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
