### PR TITLE
bugfix: fixed an issue that caused SUNSHINE_CLIENT_HDR to always be false

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -287,7 +287,7 @@ namespace nvhttp {
     launch_session.enable_sops = util::from_view(get_arg(args, "sops", "0"));
     launch_session.surround_info = util::from_view(get_arg(args, "surroundAudioInfo", "196610"));
     launch_session.gcmap = util::from_view(get_arg(args, "gcmap", "0"));
-    launch_session.enable_hdr = util::from_view(get_arg(args, "enableHdr", "0"));
+    launch_session.enable_hdr = util::from_view(get_arg(args, "hdrMode", "0"));
 
     uint32_t prepend_iv = util::endian::big<uint32_t>(util::from_view(get_arg(args, "rikeyid")));
     auto prepend_iv_p = (uint8_t *) &prepend_iv;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -294,7 +294,6 @@ namespace nvhttp {
 
     auto next = std::copy(prepend_iv_p, prepend_iv_p + sizeof(prepend_iv), std::begin(launch_session.iv));
     std::fill(next, std::end(launch_session.iv), 0);
-    BOOST_LOG(error) << launch_session.width << " h: " << launch_session.height << " fps: " << launch_session.fps;
     return launch_session;
   }
 


### PR DESCRIPTION
## Description
Fixes an issue that caused the SUNSHINE_CLIENT_HDR setting to be always false.



### Issues Fixed or Closed
- Fixes #1536 



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
