### PR TITLE
Miscellaneous process fixes

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -547,7 +547,7 @@ namespace platf {
   display_names(mem_type_e hwdevice_type);
 
   boost::process::child
-  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
+  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
 
   enum class thread_priority_e : int {
     low,

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -157,7 +157,7 @@ namespace platf {
   }
 
   bp::child
-  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     if (!group) {
       if (!file) {
         return bp::child(cmd, env, bp::start_dir(working_dir), bp::std_out > bp::null, bp::std_err > bp::null, ec);

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -161,7 +161,7 @@ namespace platf {
   }
 
   bp::child
-  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     if (!group) {
       if (!file) {
         return bp::child(cmd, env, bp::start_dir(working_dir), bp::std_out > bp::null, bp::std_err > bp::null, ec);

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -40,6 +40,11 @@
   #define UDP_SEND_MSG_SIZE 2
 #endif
 
+// PROC_THREAD_ATTRIBUTE_JOB_LIST is currently missing from MinGW headers
+#ifndef PROC_THREAD_ATTRIBUTE_JOB_LIST
+  #define PROC_THREAD_ATTRIBUTE_JOB_LIST ProcThreadAttributeValue(13, FALSE, TRUE, FALSE)
+#endif
+
 #include <qos2.h>
 
 #ifndef WLAN_API_MAKE_VERSION
@@ -411,11 +416,10 @@ namespace platf {
    * @param cmd The command that was used to launch the process.
    * @param ec A reference to an `std::error_code` object that will store any error that occurred during the launch.
    * @param process_info A reference to a `PROCESS_INFORMATION` structure that contains information about the new process.
-   * @param group A pointer to a `bp::group` object that will add the new process to its group, if not null.
    * @return A `bp::child` object representing the new process, or an empty `bp::child` object if the launch failed.
    */
   bp::child
-  create_boost_child_from_results(bool process_launched, const std::string &cmd, std::error_code &ec, PROCESS_INFORMATION &process_info, bp::group *group) {
+  create_boost_child_from_results(bool process_launched, const std::string &cmd, std::error_code &ec, PROCESS_INFORMATION &process_info) {
     // Use RAII to ensure the process is closed when we're done with it, even if there was an error.
     auto close_process_handles = util::fail_guard([process_launched, process_info]() {
       if (process_launched) {
@@ -432,11 +436,6 @@ namespace platf {
     if (process_launched) {
       // If the launch was successful, create a new bp::child object representing the new process
       auto child = bp::child((bp::pid_t) process_info.dwProcessId);
-      if (group) {
-        // If a group was provided, add the new process to the group
-        group->add(child);
-      }
-
       BOOST_LOG(info) << cmd << " running with PID "sv << child.id();
       return child;
     }
@@ -491,17 +490,18 @@ namespace platf {
   /**
    * @brief A function to create a `STARTUPINFOEXW` structure for launching a process.
    * @param file A pointer to a `FILE` object that will be used as the standard output and error for the new process, or null if not needed.
+   * @param job A job object handle to insert the new process into. This pointer must remain valid for the life of this startup info!
    * @param ec A reference to a `std::error_code` object that will store any error that occurred during the creation of the structure.
    * @return A `STARTUPINFOEXW` structure that contains information about how to launch the new process.
    */
   STARTUPINFOEXW
-  create_startup_info(FILE *file, std::error_code &ec) {
+  create_startup_info(FILE *file, HANDLE *job, std::error_code &ec) {
     // Initialize a zeroed-out STARTUPINFOEXW structure and set its size
     STARTUPINFOEXW startup_info = {};
     startup_info.StartupInfo.cb = sizeof(startup_info);
 
-    // Allocate a process attribute list with space for 1 element
-    startup_info.lpAttributeList = allocate_proc_thread_attr_list(1);
+    // Allocate a process attribute list with space for 2 elements
+    startup_info.lpAttributeList = allocate_proc_thread_attr_list(2);
     if (startup_info.lpAttributeList == NULL) {
       // If the allocation failed, set ec to an appropriate error code and return the structure
       ec = std::make_error_code(std::errc::not_enough_memory);
@@ -532,6 +532,20 @@ namespace platf {
         NULL);
     }
 
+    if (job) {
+      // Atomically insert the new process into the specified job.
+      //
+      // Note: The value we point to here must be valid for the lifetime of the attribute list,
+      // so we take a HANDLE* instead of just a HANDLE to use the caller's stack storage.
+      UpdateProcThreadAttribute(startup_info.lpAttributeList,
+        0,
+        PROC_THREAD_ATTRIBUTE_JOB_LIST,
+        job,
+        sizeof(*job),
+        NULL,
+        NULL);
+    }
+
     return startup_info;
   }
 
@@ -557,7 +571,8 @@ namespace platf {
     std::wstring wcmd = converter.from_bytes(cmd);
     std::wstring start_dir = converter.from_bytes(working_dir.string());
 
-    STARTUPINFOEXW startup_info = create_startup_info(file, ec);
+    HANDLE job = group ? group->native_handle() : nullptr;
+    STARTUPINFOEXW startup_info = create_startup_info(file, job ? &job : nullptr, ec);
     PROCESS_INFORMATION process_info;
 
     // Clone the environment to create a local copy. Boost.Process (bp) shares the environment with all spawned processes.
@@ -649,7 +664,7 @@ namespace platf {
     }
 
     // Use the results of the launch to create a bp::child object
-    return create_boost_child_from_results(ret, cmd, ec, process_info, group);
+    return create_boost_child_from_results(ret, cmd, ec, process_info);
   }
 
   /**

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -565,7 +565,7 @@ namespace platf {
    * @return A `bp::child` object representing the new process, or an empty `bp::child` object if the launch fails.
    */
   bp::child
-  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
     BOOL ret;
     // Convert cmd, env, and working_dir to the appropriate character sets for Win32 APIs
     std::wstring wcmd = converter.from_bytes(cmd);


### PR DESCRIPTION
## Description
The first commit contains a small fix for the process code to avoid a race condition where a process could spawn a child before we added it into our job for tracking purposes. This child would escape our control and wouldn't be terminated when the user quit the app. 

The second is cleanup related to #1456 to pass the environment as a const ref to avoid anyone being tempted to modify the passed in `env` parameter again.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
