### PR TITLE
nvenc: improve rfi logic

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -246,6 +246,7 @@ namespace nvenc {
         ref_frames_option = 1;
         encoder_params.rfi = false;
       }
+      encoder_params.ref_frames_in_dpb = ref_frames_option;
       // This limits ref frames any frame can use to 1, but allows larger buffer size for fallback if some frames are invalidated through rfi
       L0_option = NV_ENC_NUM_REF_FRAMES_1;
     };
@@ -489,33 +490,31 @@ namespace nvenc {
   nvenc_base::invalidate_ref_frames(uint64_t first_frame, uint64_t last_frame) {
     if (!encoder || !encoder_params.rfi) return false;
 
-    if (last_frame < first_frame ||
-        encoder_state.last_encoded_frame_index < first_frame ||
-        encoder_state.last_encoded_frame_index > first_frame + 100) {
-      BOOST_LOG(error) << "NvEnc: rfi request " << first_frame << "-" << last_frame << " invalid range (last encoded frame " << encoder_state.last_encoded_frame_index << ")";
-      return false;
-    }
-
-    if (first_frame >= encoder_state.last_rfi_range.first &&
+    if (first_frame == encoder_state.last_rfi_range.first &&
         last_frame <= encoder_state.last_rfi_range.second) {
       BOOST_LOG(debug) << "NvEnc: rfi request " << first_frame << "-" << last_frame << " already done";
       return true;
     }
 
     BOOST_LOG(debug) << "NvEnc: rfi request " << first_frame << "-" << last_frame << " expanding to last encoded frame " << encoder_state.last_encoded_frame_index;
+    last_frame = encoder_state.last_encoded_frame_index;
+
+    if (last_frame < first_frame || last_frame - first_frame + 1 >= encoder_params.ref_frames_in_dpb) {
+      BOOST_LOG(debug) << "NvEnc: rfi request too large, generating IDR";
+      return false;
+    }
 
     encoder_state.rfi_needs_confirmation = true;
-    encoder_state.last_rfi_range = { first_frame, encoder_state.last_encoded_frame_index };
+    encoder_state.last_rfi_range = { first_frame, last_frame };
 
-    bool result = true;
-    for (auto i = first_frame; i <= encoder_state.last_encoded_frame_index; i++) {
+    for (auto i = first_frame; i <= last_frame; i++) {
       if (nvenc_failed(nvenc->nvEncInvalidateRefFrames(encoder, i))) {
         BOOST_LOG(error) << "NvEncInvalidateRefFrames " << i << " failed: " << last_error_string;
-        result = false;
+        return false;
       }
     }
 
-    return result;
+    return true;
   }
 
   bool

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -56,6 +56,7 @@ namespace nvenc {
       uint32_t width = 0;
       uint32_t height = 0;
       NV_ENC_BUFFER_FORMAT buffer_format = NV_ENC_BUFFER_FORMAT_UNDEFINED;
+      uint32_t ref_frames_in_dpb = 0;
       bool rfi = false;
     } encoder_params;
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

Narrows down rfi arguments check to ref frames buffer size and removes log error message.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
