### PR TITLE
fix: ensure user supplied framerates are used

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -836,6 +836,7 @@ namespace config {
     std::vector<std::string> list;
     list_string_f(vars, name, list);
 
+    input.clear();
     for (auto &el : list) {
       std::string_view val = el;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -840,7 +840,6 @@ namespace config {
     // If the list is not cleared, then the specified parameters do not affect the behavior of the sunshine server. 
     // That is, if you set only 30 fps in the configuration file, it will not work because by default, during initialization the list includes 10, 30, 60, 90 and 120 fps.
     input.clear();
-    
     for (auto &el : list) {
       std::string_view val = el;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -836,9 +836,9 @@ namespace config {
     std::vector<std::string> list;
     list_string_f(vars, name, list);
 
-    //The framerate list must be cleared before adding values from the file configuration. 
-    //If the list is not cleared, then the specified parameters do not affect the behavior of the sunshine server. 
-    //That is, if you set only 30 fps in the configuration file, it will not work because by default, during initialization the list includes 10, 30, 60, 90 and 120 fps.
+    // The framerate list must be cleared before adding values from the file configuration. 
+    // If the list is not cleared, then the specified parameters do not affect the behavior of the sunshine server. 
+    // That is, if you set only 30 fps in the configuration file, it will not work because by default, during initialization the list includes 10, 30, 60, 90 and 120 fps.
     input.clear();
     
     for (auto &el : list) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -836,7 +836,11 @@ namespace config {
     std::vector<std::string> list;
     list_string_f(vars, name, list);
 
+    //The framerate list must be cleared before adding values from the file configuration. 
+    //If the list is not cleared, then the specified parameters do not affect the behavior of the sunshine server. 
+    //That is, if you set only 30 fps in the configuration file, it will not work because by default, during initialization the list includes 10, 30, 60, 90 and 120 fps.
     input.clear();
+    
     for (auto &el : list) {
       std::string_view val = el;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -836,8 +836,8 @@ namespace config {
     std::vector<std::string> list;
     list_string_f(vars, name, list);
 
-    // The framerate list must be cleared before adding values from the file configuration. 
-    // If the list is not cleared, then the specified parameters do not affect the behavior of the sunshine server. 
+    // The framerate list must be cleared before adding values from the file configuration.
+    // If the list is not cleared, then the specified parameters do not affect the behavior of the sunshine server.
     // That is, if you set only 30 fps in the configuration file, it will not work because by default, during initialization the list includes 10, 30, 60, 90 and 120 fps.
     input.clear();
     for (auto &el : list) {


### PR DESCRIPTION
## Description
The framerates list is not cleared before adding values from the file configuration.
If the list is not cleared, then the set parameters do not affect the behavior of sunshine server.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
