### PR TITLE
Fix chroma subsample position

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -224,7 +224,7 @@ namespace nvenc {
       enc_config.rcParams.vbvBufferSize = client_config.bitrate * 1000 / client_config.framerate;
     }
 
-    auto set_common_format_config = [&](auto &format_config) {
+    auto set_h264_hevc_common_format_config = [&](auto &format_config) {
       format_config.repeatSPSPPS = 1;
       format_config.idrPeriod = NVENC_INFINITE_GOPLENGTH;
       format_config.sliceMode = 3;
@@ -259,7 +259,7 @@ namespace nvenc {
       }
     };
 
-    auto fill_vui = [&colorspace](auto &vui_config) {
+    auto fill_h264_hevc_vui = [&colorspace](auto &vui_config) {
       vui_config.videoSignalTypePresentFlag = 1;
       vui_config.videoFormat = NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED;
       vui_config.videoFullRangeFlag = colorspace.full_range;
@@ -277,7 +277,7 @@ namespace nvenc {
         // H.264
         enc_config.profileGUID = buffer_is_yuv444() ? NV_ENC_H264_PROFILE_HIGH_444_GUID : NV_ENC_H264_PROFILE_HIGH_GUID;
         auto &format_config = enc_config.encodeCodecConfig.h264Config;
-        set_common_format_config(format_config);
+        set_h264_hevc_common_format_config(format_config);
         if (config.h264_cavlc || !get_encoder_cap(NV_ENC_CAPS_SUPPORT_CABAC)) {
           format_config.entropyCodingMode = NV_ENC_H264_ENTROPY_CODING_MODE_CAVLC;
         }
@@ -286,20 +286,20 @@ namespace nvenc {
         }
         set_ref_frames(format_config.maxNumRefFrames, format_config.numRefL0, 5);
         set_minqp_if_enabled(config.min_qp_h264);
-        fill_vui(format_config.h264VUIParameters);
+        fill_h264_hevc_vui(format_config.h264VUIParameters);
         break;
       }
 
       case 1: {
         // HEVC
         auto &format_config = enc_config.encodeCodecConfig.hevcConfig;
-        set_common_format_config(format_config);
+        set_h264_hevc_common_format_config(format_config);
         if (buffer_is_10bit()) {
           format_config.pixelBitDepthMinus8 = 2;
         }
         set_ref_frames(format_config.maxNumRefFramesInDPB, format_config.numRefL0, 5);
         set_minqp_if_enabled(config.min_qp_hevc);
-        fill_vui(format_config.hevcVUIParameters);
+        fill_h264_hevc_vui(format_config.hevcVUIParameters);
         break;
       }
 

--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -267,6 +267,9 @@ namespace nvenc {
       vui_config.colourPrimaries = colorspace.primaries;
       vui_config.transferCharacteristics = colorspace.tranfer_function;
       vui_config.colourMatrix = colorspace.matrix;
+      vui_config.chromaSampleLocationFlag = 1;
+      vui_config.chromaSampleLocationTop = 0;
+      vui_config.chromaSampleLocationBot = 0;
     };
 
     switch (client_config.videoFormat) {
@@ -315,6 +318,7 @@ namespace nvenc {
         format_config.transferCharacteristics = colorspace.tranfer_function;
         format_config.matrixCoefficients = colorspace.matrix;
         format_config.colorRange = colorspace.full_range;
+        format_config.chromaSamplePosition = 1;
         set_ref_frames(format_config.maxNumRefFramesInDPB, format_config.numFwdRefs, 8);
         set_minqp_if_enabled(config.min_qp_av1);
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -435,7 +435,6 @@ namespace platf::dxgi {
         return;
       }
 
-      device_ctx->VSSetConstantBuffers(0, 1, &info_scene);
       device_ctx->PSSetConstantBuffers(0, 1, &color_matrix);
       this->color_matrix = std::move(color_matrix);
     }
@@ -471,6 +470,7 @@ namespace platf::dxgi {
         BOOST_LOG(error) << "Failed to create info scene buffer"sv;
         return -1;
       }
+      device_ctx->VSSetConstantBuffers(0, 1, &info_scene);
 
       D3D11_RENDER_TARGET_VIEW_DESC nv12_rt_desc {
         format == DXGI_FORMAT_P010 ? DXGI_FORMAT_R16_UNORM : DXGI_FORMAT_R8_UNORM,
@@ -607,6 +607,7 @@ namespace platf::dxgi {
         BOOST_LOG(error) << "Failed to create color matrix buffer"sv;
         return -1;
       }
+      device_ctx->PSSetConstantBuffers(0, 1, &color_matrix);
 
       D3D11_INPUT_ELEMENT_DESC layout_desc {
         "SV_Position", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0
@@ -640,8 +641,6 @@ namespace platf::dxgi {
       }
 
       device_ctx->IASetInputLayout(input_layout.get());
-      device_ctx->PSSetConstantBuffers(0, 1, &color_matrix);
-      device_ctx->VSSetConstantBuffers(0, 1, &info_scene);
 
       device_ctx->OMSetBlendState(blend_disable.get(), nullptr, 0xFFFFFFFFu);
       device_ctx->PSSetSamplers(0, 1, &sampler_linear);
@@ -1367,7 +1366,7 @@ namespace platf::dxgi {
         return -1;
       }
 
-      device_ctx->PSSetConstantBuffers(0, 1, &sdr_multiplier);
+      device_ctx->PSSetConstantBuffers(1, 1, &sdr_multiplier);
     }
     else {
       status = device->CreatePixelShader(scene_ps_hlsl->GetBufferPointer(), scene_ps_hlsl->GetBufferSize(), nullptr, &scene_ps);

--- a/src_assets/windows/assets/shaders/directx/ScenePS_NW.hlsl
+++ b/src_assets/windows/assets/shaders/directx/ScenePS_NW.hlsl
@@ -8,7 +8,7 @@ struct PS_INPUT
     float2 tex : TEXCOORD;
 };
 
-cbuffer SdrScaling : register(b0) {
+cbuffer SdrScaling : register(b1) {
     float scale_factor;
 };
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

It was offset because of missing shader constant buffer.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
