### PR TITLE
Fix FFmpeg codec debug logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -534,6 +534,31 @@ main(int argc, char *argv[]) {
   else {
     av_log_set_level(AV_LOG_DEBUG);
   }
+  av_log_set_callback([](void *ptr, int level, const char *fmt, va_list vl) {
+    static int print_prefix = 1;
+    char buffer[1024];
+
+    av_log_format_line(ptr, level, fmt, vl, buffer, sizeof(buffer), &print_prefix);
+    if (level <= AV_LOG_FATAL) {
+      BOOST_LOG(fatal) << buffer;
+    }
+    else if (level <= AV_LOG_ERROR) {
+      BOOST_LOG(error) << buffer;
+    }
+    else if (level <= AV_LOG_WARNING) {
+      BOOST_LOG(warning) << buffer;
+    }
+    else if (level <= AV_LOG_INFO) {
+      BOOST_LOG(info) << buffer;
+    }
+    else if (level <= AV_LOG_VERBOSE) {
+      // AV_LOG_VERBOSE is less verbose than AV_LOG_DEBUG
+      BOOST_LOG(debug) << buffer;
+    }
+    else {
+      BOOST_LOG(verbose) << buffer;
+    }
+  });
 
   sink = boost::make_shared<text_sink>();
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -761,6 +761,7 @@ namespace video {
       // Common options
       {
         { "filler_data"s, false },
+        { "log_to_dbg"s, config::sunshine.min_log_level < 2 ? 1 : 0 },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
         { "quality"s, &config::video.amd.amd_quality_av1 },
         { "rc"s, &config::video.amd.amd_rc_av1 },
@@ -775,6 +776,7 @@ namespace video {
       // Common options
       {
         { "filler_data"s, false },
+        { "log_to_dbg"s, config::sunshine.min_log_level < 2 ? 1 : 0 },
         { "gops_per_idr"s, 1 },
         { "header_insertion_mode"s, "idr"s },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
@@ -794,7 +796,7 @@ namespace video {
       // Common options
       {
         { "filler_data"s, false },
-        { "log_to_dbg"s, "1"s },
+        { "log_to_dbg"s, config::sunshine.min_log_level < 2 ? 1 : 0 },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
         { "qmax"s, 51 },
         { "qmin"s, 0 },


### PR DESCRIPTION
## Description
We didn't override the default FFmpeg log callback to use our loggers, so our FFmpeg logs would go to stdout rather than our log file. As a result, you wouldn't see the debug output unless you ran Sunshine from a terminal. This makes it difficult to debug issues like #1559.

Additionally, the HEVC and AV1 AMF encoders were never configured to log, while the H.264 encoder was always configured to log (though the output would be filtered by our configured log level). I changed the logging configuration to be conditional based on the configured log level for Sunshine, which is how we control our FFmpeg logging globally too.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/2a1a06d9-7f1b-472d-8de3-fd1e6fc6277e)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
