### PR TITLE
Codec support checks and improvements

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -796,7 +796,7 @@ hevc_mode
    =====     ===========
    Value     Description
    =====     ===========
-   0         advertise support for HEVC based on encoder
+   0         advertise support for HEVC based on encoder capabilities (recommended)
    1         do not advertise support for HEVC
    2         advertise support for HEVC Main profile
    3         advertise support for HEVC Main and Main10 (HDR) profiles
@@ -827,7 +827,7 @@ av1_mode
    =====     ===========
    Value     Description
    =====     ===========
-   0         advertise support for AV1 based on encoder
+   0         advertise support for AV1 based on encoder capabilities (recommended)
    1         do not advertise support for AV1
    2         advertise support for AV1 Main 8-bit profile
    3         advertise support for AV1 Main 8-bit and 10-bit (HDR) profiles

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -480,6 +480,17 @@ namespace platf {
       return false;
     }
 
+    /**
+     * @brief Checks that a given codec is supported by the display device.
+     * @param name The FFmpeg codec name (or similar for non-FFmpeg codecs).
+     * @param config The codec configuration.
+     * @return true if supported, false otherwise.
+     */
+    virtual bool
+    is_codec_supported(std::string_view name, const ::video::config_t &config) {
+      return true;
+    }
+
     virtual ~display_t() = default;
 
     // Offsets for when streaming a specific monitor. By default, they are 0.

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -219,6 +219,9 @@ namespace platf::dxgi {
     int
     init(const ::video::config_t &config, const std::string &display_name);
 
+    bool
+    is_codec_supported(std::string_view name, const ::video::config_t &config) override;
+
     std::unique_ptr<avcodec_encode_device_t>
     make_avcodec_encode_device(pix_fmt_e pix_fmt) override;
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -25,6 +25,8 @@ extern "C" {
 
 #include <AMF/core/Factory.h>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #define SUNSHINE_SHADERS_DIR SUNSHINE_ASSETS_DIR "/shaders/directx"
 namespace platf {
   using namespace std::literals;
@@ -1326,60 +1328,6 @@ namespace platf::dxgi {
       return -1;
     }
 
-    DXGI_ADAPTER_DESC adapter_desc;
-    adapter->GetDesc(&adapter_desc);
-
-    // Perform AMF version checks if we're using an AMD GPU. This check is placed in display_vram_t
-    // to avoid hitting the display_ram_t path which uses software encoding and doesn't touch AMF.
-    if ((config.dynamicRange || config.videoFormat == 2) && adapter_desc.VendorId == 0x1002) {
-      HMODULE amfrt = LoadLibraryW(AMF_DLL_NAME);
-      if (amfrt) {
-        auto unload_amfrt = util::fail_guard([amfrt]() {
-          FreeLibrary(amfrt);
-        });
-
-        auto fnAMFQueryVersion = (AMFQueryVersion_Fn) GetProcAddress(amfrt, AMF_QUERY_VERSION_FUNCTION_NAME);
-        if (fnAMFQueryVersion) {
-          amf_uint64 version;
-          auto result = fnAMFQueryVersion(&version);
-          if (result == AMF_OK) {
-            if (config.videoFormat == 2 && version < AMF_MAKE_FULL_VERSION(1, 4, 30, 0)) {
-              // AMF 1.4.30 adds ultra low latency mode for AV1. Don't use AV1 on earlier versions.
-              // This corresponds to driver version 23.5.2 (23.10.01.45) or newer.
-              BOOST_LOG(warning) << "AV1 encoding is disabled on AMF version "sv
-                                 << AMF_GET_MAJOR_VERSION(version) << '.'
-                                 << AMF_GET_MINOR_VERSION(version) << '.'
-                                 << AMF_GET_SUBMINOR_VERSION(version) << '.'
-                                 << AMF_GET_BUILD_VERSION(version);
-              BOOST_LOG(warning) << "If your AMD GPU supports AV1 encoding, update your graphics drivers!"sv;
-              return -1;
-            }
-            else if (config.dynamicRange && version < AMF_MAKE_FULL_VERSION(1, 4, 23, 0)) {
-              // Older versions of the AMD AMF runtime can crash when fed P010 surfaces.
-              // Fail if AMF version is below 1.4.23 where HEVC Main10 encoding was introduced.
-              // AMF 1.4.23 corresponds to driver version 21.12.1 (21.40.11.03) or newer.
-              BOOST_LOG(warning) << "HDR encoding is disabled on AMF version "sv
-                                 << AMF_GET_MAJOR_VERSION(version) << '.'
-                                 << AMF_GET_MINOR_VERSION(version) << '.'
-                                 << AMF_GET_SUBMINOR_VERSION(version) << '.'
-                                 << AMF_GET_BUILD_VERSION(version);
-              BOOST_LOG(warning) << "If your AMD GPU supports HEVC Main10 encoding, update your graphics drivers!"sv;
-              return -1;
-            }
-          }
-          else {
-            BOOST_LOG(warning) << "AMFQueryVersion() failed: "sv << result;
-          }
-        }
-        else {
-          BOOST_LOG(warning) << "AMF DLL missing export: "sv << AMF_QUERY_VERSION_FUNCTION_NAME;
-        }
-      }
-      else {
-        BOOST_LOG(warning) << "Detected AMD GPU but AMF failed to load"sv;
-      }
-    }
-
     D3D11_SAMPLER_DESC sampler_desc {};
     sampler_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
     sampler_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
@@ -1579,6 +1527,91 @@ namespace platf::dxgi {
       DXGI_FORMAT_B8G8R8X8_UNORM,
       DXGI_FORMAT_R8G8B8A8_UNORM,
     };
+  }
+
+  /**
+   * @brief Checks that a given codec is supported by the display device.
+   * @param name The FFmpeg codec name (or similar for non-FFmpeg codecs).
+   * @param config The codec configuration.
+   * @return true if supported, false otherwise.
+   */
+  bool
+  display_vram_t::is_codec_supported(std::string_view name, const ::video::config_t &config) {
+    DXGI_ADAPTER_DESC adapter_desc;
+    adapter->GetDesc(&adapter_desc);
+
+    if (adapter_desc.VendorId == 0x1002) {  // AMD
+      // If it's not an AMF encoder, it's not compatible with an AMD GPU
+      if (!boost::algorithm::ends_with(name, "_amf")) {
+        return false;
+      }
+
+      // Perform AMF version checks if we're using an AMD GPU. This check is placed in display_vram_t
+      // to avoid hitting the display_ram_t path which uses software encoding and doesn't touch AMF.
+      HMODULE amfrt = LoadLibraryW(AMF_DLL_NAME);
+      if (amfrt) {
+        auto unload_amfrt = util::fail_guard([amfrt]() {
+          FreeLibrary(amfrt);
+        });
+
+        auto fnAMFQueryVersion = (AMFQueryVersion_Fn) GetProcAddress(amfrt, AMF_QUERY_VERSION_FUNCTION_NAME);
+        if (fnAMFQueryVersion) {
+          amf_uint64 version;
+          auto result = fnAMFQueryVersion(&version);
+          if (result == AMF_OK) {
+            if (config.videoFormat == 2 && version < AMF_MAKE_FULL_VERSION(1, 4, 30, 0)) {
+              // AMF 1.4.30 adds ultra low latency mode for AV1. Don't use AV1 on earlier versions.
+              // This corresponds to driver version 23.5.2 (23.10.01.45) or newer.
+              BOOST_LOG(warning) << "AV1 encoding is disabled on AMF version "sv
+                                 << AMF_GET_MAJOR_VERSION(version) << '.'
+                                 << AMF_GET_MINOR_VERSION(version) << '.'
+                                 << AMF_GET_SUBMINOR_VERSION(version) << '.'
+                                 << AMF_GET_BUILD_VERSION(version);
+              BOOST_LOG(warning) << "If your AMD GPU supports AV1 encoding, update your graphics drivers!"sv;
+              return false;
+            }
+            else if (config.dynamicRange && version < AMF_MAKE_FULL_VERSION(1, 4, 23, 0)) {
+              // Older versions of the AMD AMF runtime can crash when fed P010 surfaces.
+              // Fail if AMF version is below 1.4.23 where HEVC Main10 encoding was introduced.
+              // AMF 1.4.23 corresponds to driver version 21.12.1 (21.40.11.03) or newer.
+              BOOST_LOG(warning) << "HDR encoding is disabled on AMF version "sv
+                                 << AMF_GET_MAJOR_VERSION(version) << '.'
+                                 << AMF_GET_MINOR_VERSION(version) << '.'
+                                 << AMF_GET_SUBMINOR_VERSION(version) << '.'
+                                 << AMF_GET_BUILD_VERSION(version);
+              BOOST_LOG(warning) << "If your AMD GPU supports HEVC Main10 encoding, update your graphics drivers!"sv;
+              return false;
+            }
+          }
+          else {
+            BOOST_LOG(warning) << "AMFQueryVersion() failed: "sv << result;
+          }
+        }
+        else {
+          BOOST_LOG(warning) << "AMF DLL missing export: "sv << AMF_QUERY_VERSION_FUNCTION_NAME;
+        }
+      }
+      else {
+        BOOST_LOG(warning) << "Detected AMD GPU but AMF failed to load"sv;
+      }
+    }
+    else if (adapter_desc.VendorId == 0x8086) {  // Intel
+      // If it's not a QSV encoder, it's not compatible with an Intel GPU
+      if (!boost::algorithm::ends_with(name, "_qsv")) {
+        return false;
+      }
+    }
+    else if (adapter_desc.VendorId == 0x10de) {  // Nvidia
+      // If it's not an NVENC encoder, it's not compatible with an Nvidia GPU
+      if (!boost::algorithm::ends_with(name, "_nvenc")) {
+        return false;
+      }
+    }
+    else {
+      BOOST_LOG(warning) << "Unknown GPU vendor ID: " << util::hex(adapter_desc.VendorId).to_string_view();
+    }
+
+    return true;
   }
 
   std::unique_ptr<avcodec_encode_device_t>

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -674,7 +674,7 @@
         <label for="hevc_mode" class="form-label">HEVC Support</label>
         <select id="hevc_mode" class="form-select" v-model="config.hevc_mode">
           <option value="0">
-            Sunshine will specify support for HEVC based on encoder
+            Sunshine will advertise support for HEVC based on encoder capabilities (recommended)
           </option>
           <option value="1">
             Sunshine will not advertise support for HEVC
@@ -696,7 +696,7 @@
         <label for="av1_mode" class="form-label">AV1 Support</label>
         <select id="av1_mode" class="form-select" v-model="config.av1_mode">
           <option value="0">
-            Sunshine will specify support for AV1 based on encoder
+            Sunshine will advertise support for AV1 based on encoder capabilities (recommended)
           </option>
           <option value="1">
             Sunshine will not advertise support for AV1


### PR DESCRIPTION
## Description
This PR contains 2 changes to address some usability issues and inefficencies with our codec selection.

The first commit introduces a new `is_codec_supported()` function to `display_t` which can be used to allow displays to reject specific codecs. Rejecting specific AMF versions in the `display_t::init()` like I was doing before has negative side-effects because the caller assumes the error was caused by a capture failure and retries after 500ms. I moved the AMF check into the new `is_codec_supported()` function instead (in addition to adding basic GPU vendor checks for QSV and NVENC encoders).

The second commit changes the behavior around the codec mode options to address a user misconfiguration that led to all hardware encoding being disabled. We already treated HEVC/AV1 codec mode 3 (8+10bit) as a soft requirement, so we would still return that encoder if it was otherwise a match but didn't support HDR. However, if the HEVC or AV1 codec wasn't supported _at all_, that would cause the entire encoder to fail initialization and you'd get no hardware acceleration at all. This commit turns this case into a warning rather than a fatal encoder initialization failure.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
