### PR TITLE
Fix pen tilt angle calculation

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1098,14 +1098,17 @@ namespace platf {
       penInfo.rotation = 0;
     }
 
-    // We require rotation and tilt to perform the polar to cartesian conversion
+    // We require rotation and tilt to perform the conversion to X and Y tilt angles
     if (pen.tilt != LI_TILT_UNKNOWN && pen.rotation != LI_ROT_UNKNOWN) {
       auto rotationRads = pen.rotation * (M_PI / 180.f);
+      auto tiltRads = pen.tilt * (M_PI / 180.f);
+      auto r = std::sin(tiltRads);
+      auto z = std::cos(tiltRads);
 
-      // Convert into cartesian coordinates
+      // Convert polar coordinates into X and Y tilt angles
       penInfo.penMask |= PEN_MASK_TILT_X | PEN_MASK_TILT_Y;
-      penInfo.tiltX = (INT32) (std::cos(rotationRads) * pen.tilt);
-      penInfo.tiltY = (INT32) (std::sin(rotationRads) * pen.tilt);
+      penInfo.tiltX = (INT32) (std::atan2(std::sin(-rotationRads) * r, z) * 180.f / M_PI);
+      penInfo.tiltY = (INT32) (std::atan2(std::cos(-rotationRads) * r, z) * 180.f / M_PI);
     }
     else {
       penInfo.tiltX = 0;


### PR DESCRIPTION
## Description
Our pen tilt calculation wasn't correct, so applications could get incorrect tilt information. I adjusted it to use the same calculation logic that [Chromium uses](https://github.com/chromium/chromium/blob/6339259149a4291c7131ecafe340d8d5e87172c4/ui/events/android/motion_event_android.cc#L193-L203) and confirmed the results now match between client and host.

Tested with https://patrickhlauke.github.io/touch/pen-tracker/ and the Moonlight Android client.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
