### PR TITLE
Evaluate log_to_dbg value at encoder init

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -350,7 +350,7 @@ namespace video {
       option_t(const option_t &) = default;
 
       std::string name;
-      std::variant<int, int *, std::optional<int> *, std::string, std::string *> value;
+      std::variant<int, int *, std::optional<int> *, std::function<int()>, std::string, std::string *> value;
 
       option_t(std::string &&name, decltype(value) &&value):
           name { std::move(name) }, value { std::move(value) } {}
@@ -761,7 +761,7 @@ namespace video {
       // Common options
       {
         { "filler_data"s, false },
-        { "log_to_dbg"s, config::sunshine.min_log_level < 2 ? 1 : 0 },
+        { "log_to_dbg"s, []() { return config::sunshine.min_log_level < 2 ? 1 : 0; } },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
         { "quality"s, &config::video.amd.amd_quality_av1 },
         { "rc"s, &config::video.amd.amd_rc_av1 },
@@ -776,7 +776,7 @@ namespace video {
       // Common options
       {
         { "filler_data"s, false },
-        { "log_to_dbg"s, config::sunshine.min_log_level < 2 ? 1 : 0 },
+        { "log_to_dbg"s, []() { return config::sunshine.min_log_level < 2 ? 1 : 0; } },
         { "gops_per_idr"s, 1 },
         { "header_insertion_mode"s, "idr"s },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
@@ -796,7 +796,7 @@ namespace video {
       // Common options
       {
         { "filler_data"s, false },
-        { "log_to_dbg"s, config::sunshine.min_log_level < 2 ? 1 : 0 },
+        { "log_to_dbg"s, []() { return config::sunshine.min_log_level < 2 ? 1 : 0; } },
         { "preanalysis"s, &config::video.amd.amd_preanalysis },
         { "qmax"s, 51 },
         { "qmin"s, 0 },
@@ -1529,6 +1529,7 @@ namespace video {
           [&](int v) { av_dict_set_int(&options, option.name.c_str(), v, 0); },
           [&](int *v) { av_dict_set_int(&options, option.name.c_str(), *v, 0); },
           [&](std::optional<int> *v) { if(*v) av_dict_set_int(&options, option.name.c_str(), **v, 0); },
+          [&](std::function<int()> v) { av_dict_set_int(&options, option.name.c_str(), v(), 0); },
           [&](const std::string &v) { av_dict_set(&options, option.name.c_str(), v.c_str(), 0); },
           [&](std::string *v) { if(!v->empty()) av_dict_set(&options, option.name.c_str(), v->c_str(), 0); } },
         option.value);


### PR DESCRIPTION
## Description
The values used for initialization of a static `encoder_t` should not depend on runtime state. This only ever worked because the config was read before the `amdvce` `encoder_t` was constructed, but that is not guaranteed to be the case.

cc: @psyke83 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
