### PR TITLE
Fix Command Failure on cold starts with Desktop

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -180,19 +180,18 @@ namespace proc {
       auto child = platf::run_command(cmd.elevated, true, cmd.do_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
 
       if (ec) {
-        auto msg = ec == std::errc::no_such_process ? "no active user sessions available" : ec.message();
-        BOOST_LOG(error) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << msg;
+        BOOST_LOG(error) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << ec.message();
         // We don't want any prep commands failing launch of the desktop.
         // This is to prevent the issue where users reboot their PC and need to log in with Sunshine.
-        // no_such_process is returned when the impersonation fails, which is typically when there is no user session active.
-        if (!(_app.cmd.empty() && ec == std::errc::no_such_process)) {
+        // permission_denied is typically returned when the user impersonation fails, which can happen when user is not signed in yet.
+        if (!(_app.cmd.empty() && ec == std::errc::permission_denied)) {
           return -1;
         }
       }
 
       child.wait();
       auto ret = child.exit_code();
-      if (ret != 0 && ec != std::errc::no_such_process) {
+      if (ret != 0 && ec != std::errc::permission_denied) {
         BOOST_LOG(error) << '[' << cmd.do_cmd << "] failed with code ["sv << ret << ']';
         return -1;
       }


### PR DESCRIPTION
## Description
A recent pull request merged into nightly was not using the correct error codes to determine when to whitelist an error from prep commands. This corrects it to use the proper error code, allowing users to sign into their computer from a cold start if impacted.






## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
