### PR TITLE
Updated Homebrew build requirements to include `pkg-config`

### DIFF
--- a/docs/source/building/macos.rst
+++ b/docs/source/building/macos.rst
@@ -19,7 +19,7 @@ Homebrew
 Install Requirements
    .. code-block:: bash
 
-      brew install boost cmake node opus
+      brew install boost cmake node opus pkg-config
       # if there are issues with an SSL header that is not found:
       cd /usr/local/include
       ln -s ../opt/openssl/include/openssl .


### PR DESCRIPTION
## Description
Ran into a missing `PkgConfig` error while following the building for macOS instructions. Installing `pkg-config` with Homebrew fixed this issue:

`Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)`

This PR updates the macOS Homebrew build requirements to include `pkg-config`.

### Screenshot

### Issues Fixed or Closed

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
