### PR TITLE
Link the `/opt/homebrew/lib` directory on macOS

### DIFF
--- a/cmake/compile_definitions/macos.cmake
+++ b/cmake/compile_definitions/macos.cmake
@@ -4,6 +4,7 @@ add_compile_definitions(SUNSHINE_PLATFORM="macos")
 
 link_directories(/opt/local/lib)
 link_directories(/usr/local/lib)
+link_directories(/opt/homebrew/lib)
 ADD_DEFINITIONS(-DBOOST_LOG_DYN_LINK)
 
 list(APPEND SUNSHINE_EXTERNAL_LIBRARIES


### PR DESCRIPTION
## Description
Homebrew installs packages in a new location on Apple silicon Macs. The `macos.cmake` does not link this directory causing packages such as `opus` installed via homebrew to not be found.

The solution is to link this directory when performing the macOS build.


### Screenshot

### Issues Fixed or Closed

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
