### PR TITLE
Add problems with nvcc PATH to linux troubleshooting

### DIFF
--- a/docs/source/troubleshooting/linux.rst
+++ b/docs/source/troubleshooting/linux.rst
@@ -30,6 +30,15 @@ If screencasting fails with KMS, you may need to run the following to force unpr
 
       sudo setcap -r $(readlink -f $(which sunshine))
 
+NvFBC Capture fails
+-------------------
+Some users have had issues using nvfbc even though they have correctly patched nvidia drivers and cuda is installed. The problem occurs when nvcc is not in the PATH and cuda is not correctly compiled into Sunshine. This will not cause an error because not all users have nvidia cards. The solution is to ensure that nvcc is in your PATH before building sunshine. For example add the following to ~/.bashrc:
+
+   .. code-block:: bash
+
+      export PATH=/usr/local/cuda/bin:$PATH
+      export LD_LIBRARY_PATH=/usr/local/cuda/lib:$PATH
+
 Gamescope compatibility
 -----------------------
 Some users have reported stuttering issues when streaming games running within Gamescope.

--- a/docs/source/troubleshooting/linux.rst
+++ b/docs/source/troubleshooting/linux.rst
@@ -32,7 +32,7 @@ If screencasting fails with KMS, you may need to run the following to force unpr
 
 NvFBC Capture fails
 -------------------
-Some users have had issues using nvfbc even though they have correctly patched nvidia drivers and cuda is installed. The problem occurs when nvcc is not in the PATH and cuda is not correctly compiled into Sunshine. This will not cause an error because not all users have nvidia cards. The solution is to ensure that nvcc is in your PATH before building sunshine. For example add the following to ~/.bashrc:
+Some users have had issues using nvfbc even though they have correctly patched nvidia drivers and cuda is installed. The problem occurs when nvcc is not set up correctly in the PATH/LD_LIBRARY_PATH environment variables so cuda is not correctly compiled into Sunshine. This does not prevent Sunshine from building because an error because not all users have nvidia cards. The solution is to ensure that the variables contain nvcc and cuda libraries. For example add the following to ~/.bashrc:
 
    .. code-block:: bash
 


### PR DESCRIPTION
Add issue with nvcc path to troubleshooting

## Description
Some people have trouble using nvfbc cature even though everything appears to be set up correctly. This is because nvidia packages for cuda don't always set up the PATH correctly to nvcc. This adds an item to troubleshooting to document this problem.


### Screenshot
n/a


### Issues Fixed or Closed
Documents #1668

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
