### PR TITLE
Fix shutdown when called from tray callback

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -115,11 +115,12 @@ namespace system_tray {
     // If we're running in a service, return a special status to
     // tell it to terminate too, otherwise it will just respawn us.
     if (GetConsoleWindow() == NULL) {
-      lifetime::exit_sunshine(ERROR_SHUTDOWN_IN_PROGRESS, false);
+      lifetime::exit_sunshine(ERROR_SHUTDOWN_IN_PROGRESS, true);
+      return;
     }
   #endif
 
-    lifetime::exit_sunshine(0, false);
+    lifetime::exit_sunshine(0, true);
   }
 
   // Tray menu


### PR DESCRIPTION
## Description
When sunshine is closed using the "Quit" button on the tray menu, the shutdown does deadlock, causing the 10s timeout to intervene. This change plans to fix this. Tested on Windows in foreground and service mode

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
