### PR TITLE
Add missing dependencies for tray icon support

### DIFF
--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -79,7 +79,8 @@ if(${SUNSHINE_TRAY} STREQUAL 1)
 
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                     ${CPACK_DEBIAN_PACKAGE_DEPENDS}, \
-                    libappindicator3-1")
+                    libayatana-appindicator3-1, \
+                    libnotify4")
     set(CPACK_RPM_PACKAGE_REQUIRES "\
                     ${CPACK_RPM_PACKAGE_REQUIRES}, \
                     libappindicator-gtk3 >= 12.10.0")


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The deb from the Docker image does not have all of its dependencies listed when packaged with `SUNSHINE_TRAY=1`:
```sh
$ ldd $(which sunshine) | grep "not found"
	libayatana-appindicator3.so.1 => not found
	libnotify.so.4 => not found
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
