### PR TITLE
Removed legacy pairing method

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -612,33 +612,6 @@ cert
 
       cert = /dir/cert.pem
 
-origin_pin_allowed
-^^^^^^^^^^^^^^^^^^
-
-**Description**
-   The origin of the remote endpoint address that is not denied for HTTP method /pin.
-
-**Choices**
-
-.. table::
-   :widths: auto
-
-   =====     ===========
-   Value     Description
-   =====     ===========
-   pc        Only localhost may access /pin
-   lan       Only LAN devices may access /pin
-   wan       Anyone may access /pin
-   =====     ===========
-
-**Default**
-   ``pc``
-
-**Example**
-   .. code-block:: text
-
-      origin_pin_allowed = pc
-
 origin_web_ui_allowed
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -380,7 +380,6 @@ namespace config {
   };
 
   nvhttp_t nvhttp {
-    "pc",  // origin_pin
     "lan",  // origin web manager
 
     PRIVATE_KEY_FILE,
@@ -997,7 +996,6 @@ namespace config {
     string_f(vars, "virtual_sink", audio.virtual_sink);
     bool_f(vars, "install_steam_audio_drivers", audio.install_steam_drivers);
 
-    string_restricted_f(vars, "origin_pin_allowed", nvhttp.origin_pin_allowed, { "pc"sv, "lan"sv, "wan"sv });
     string_restricted_f(vars, "origin_web_ui_allowed", nvhttp.origin_web_ui_allowed, { "pc"sv, "lan"sv, "wan"sv });
 
     int to = -1;

--- a/src/config.h
+++ b/src/config.h
@@ -90,7 +90,6 @@ namespace config {
   struct nvhttp_t {
     // Could be any of the following values:
     // pc|lan|wan
-    std::string origin_pin_allowed;
     std::string origin_web_ui_allowed;
 
     std::string pkey;  // must be 2048 bits

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -41,13 +41,11 @@ namespace http {
   user_creds_exist(const std::string &file);
 
   std::string unique_id;
-  net::net_e origin_pin_allowed;
   net::net_e origin_web_ui_allowed;
 
   int
   init() {
     bool clean_slate = config::sunshine.flags[config::flag::FRESH_STATE];
-    origin_pin_allowed = net::from_enum_string(config::nvhttp.origin_pin_allowed);
     origin_web_ui_allowed = net::from_enum_string(config::nvhttp.origin_web_ui_allowed);
 
     if (clean_slate) {

--- a/src/httpcommon.h
+++ b/src/httpcommon.h
@@ -30,7 +30,6 @@ namespace http {
   url_get_host(const std::string &url);
 
   extern std::string unique_id;
-  extern net::net_e origin_pin_allowed;
   extern net::net_e origin_web_ui_allowed;
 
 }  // namespace http

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -589,32 +589,6 @@ namespace nvhttp {
 
   template <class T>
   void
-  pin(std::shared_ptr<typename SimpleWeb::ServerBase<T>::Response> response, std::shared_ptr<typename SimpleWeb::ServerBase<T>::Request> request) {
-    print_req<T>(request);
-
-    response->close_connection_after_response = true;
-
-    auto address = net::addr_to_normalized_string(request->remote_endpoint().address());
-    auto ip_type = net::from_address(address);
-    if (ip_type > http::origin_pin_allowed) {
-      BOOST_LOG(info) << "/pin: ["sv << address << "] -- denied"sv;
-
-      response->write(SimpleWeb::StatusCode::client_error_forbidden);
-
-      return;
-    }
-
-    bool pinResponse = pin(request->path_match[1]);
-    if (pinResponse) {
-      response->write(SimpleWeb::StatusCode::success_ok);
-    }
-    else {
-      response->write(SimpleWeb::StatusCode::client_error_im_a_teapot);
-    }
-  }
-
-  template <class T>
-  void
   serverinfo(std::shared_ptr<typename SimpleWeb::ServerBase<T>::Response> response, std::shared_ptr<typename SimpleWeb::ServerBase<T>::Request> request) {
     print_req<T>(request);
 
@@ -1040,7 +1014,6 @@ namespace nvhttp {
     https_server.resource["^/applist$"]["GET"] = applist;
     https_server.resource["^/appasset$"]["GET"] = appasset;
     https_server.resource["^/launch$"]["GET"] = [&host_audio](auto resp, auto req) { launch(host_audio, resp, req); };
-    https_server.resource["^/pin/([0-9]+)$"]["GET"] = pin<SimpleWeb::HTTPS>;
     https_server.resource["^/resume$"]["GET"] = [&host_audio](auto resp, auto req) { resume(host_audio, resp, req); };
     https_server.resource["^/cancel$"]["GET"] = cancel;
 
@@ -1051,7 +1024,6 @@ namespace nvhttp {
     http_server.default_resource["GET"] = not_found<SimpleWeb::HTTP>;
     http_server.resource["^/serverinfo$"]["GET"] = serverinfo<SimpleWeb::HTTP>;
     http_server.resource["^/pair$"]["GET"] = [&add_cert](auto resp, auto req) { pair<SimpleWeb::HTTP>(add_cert, resp, req); };
-    http_server.resource["^/pin/([0-9]+)$"]["GET"] = pin<SimpleWeb::HTTP>;
 
     http_server.config.reuse_address = true;
     http_server.config.address = net::af_to_any_address_string(address_family);

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -871,24 +871,6 @@
           Store Username/Password separately from Sunshine's state file.
         </div>
       </div>
-      <!--Origin PIN Allowed-->
-      <div class="mb-3">
-        <label for="origin_pin_allowed" class="form-label"
-          >Origin PIN Allowed</label
-        >
-        <select
-          id="origin_pin_allowed"
-          class="form-select"
-          v-model="config.origin_pin_allowed"
-        >
-          <option value="pc">Only localhost may access /pin</option>
-          <option value="lan">Only those in LAN may access /pin</option>
-          <option value="wan">Anyone may access /pin</option>
-        </select>
-        <div class="form-text">
-          The origin of the remote endpoint address that is not denied for HTTP method /pin
-        </div>
-      </div>
       <!--External IP-->
       <div class="mb-3">
         <label for="external_ip" class="form-label">External IP</label>
@@ -1168,7 +1150,6 @@
     "nvenc_preset": "1",
     "nvenc_realtime_hags": "enabled",
     "nvenc_twopass": "quarter_res",
-    "origin_pin_allowed": "pc",
     "origin_web_ui_allowed": "lan",
     "qsv_coder": "auto",
     "qsv_preset": "medium",


### PR DESCRIPTION
## Description
Removes the old method used in pairing that was present before the WebUI was implemented

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
