### PR TITLE
Manual DS4 mode: Allow Back/Select to trigger Touchpad click

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -152,6 +152,23 @@ gamepad
    .. code-block:: text
 
       gamepad = auto
+      
+ds4_back_as_touchpad_click
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   .. Hint:: Only applies when gamepad is set to ds4 manually. Unused in other gamepad modes. 
+
+   Allow Select/Back inputs to also trigger DS4 touchpad click. Useful for clients looking to emulate touchpad click
+   on Xinput devices.
+
+**Default**
+   ``enabled``
+
+**Example**
+   .. code-block:: text
+
+      ds4_back_as_touchpad_click = enabled
 
 back_button_timeout
 ^^^^^^^^^^^^^^^^^^^

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -418,6 +418,7 @@ namespace config {
       platf::supported_gamepads().front().data(),
       platf::supported_gamepads().front().size(),
     },  // Default gamepad
+    true,  // back as touchpad click enabled (manual DS4 only)
 
     true,  // keyboard enabled
     true,  // mouse enabled
@@ -1041,6 +1042,7 @@ namespace config {
     }
 
     string_restricted_f(vars, "gamepad"s, input.gamepad, platf::supported_gamepads());
+    bool_f(vars, "ds4_back_as_touchpad", input.ds4_back_as_touchpad);
 
     bool_f(vars, "mouse", input.mouse);
     bool_f(vars, "keyboard", input.keyboard);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1042,7 +1042,7 @@ namespace config {
     }
 
     string_restricted_f(vars, "gamepad"s, input.gamepad, platf::supported_gamepads());
-    bool_f(vars, "ds4_back_as_touchpad", input.ds4_back_as_touchpad);
+    bool_f(vars, "ds4_back_as_touchpad_click", input.ds4_back_as_touchpad_click);
 
     bool_f(vars, "mouse", input.mouse);
     bool_f(vars, "keyboard", input.keyboard);

--- a/src/config.h
+++ b/src/config.h
@@ -113,7 +113,7 @@ namespace config {
 
     std::string gamepad;
     bool ds4_back_as_touchpad_click;
-    
+
     bool keyboard;
     bool mouse;
     bool controller;

--- a/src/config.h
+++ b/src/config.h
@@ -112,7 +112,7 @@ namespace config {
     std::chrono::duration<double> key_repeat_period;
 
     std::string gamepad;
-    bool ds4_back_as_touchpad;
+    bool ds4_back_as_touchpad_click;
     
     bool keyboard;
     bool mouse;

--- a/src/config.h
+++ b/src/config.h
@@ -112,7 +112,8 @@ namespace config {
     std::chrono::duration<double> key_repeat_period;
 
     std::string gamepad;
-
+    bool ds4_back_as_touchpad;
+    
     bool keyboard;
     bool mouse;
     bool controller;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1333,11 +1333,9 @@ namespace platf {
 
     // Allow either PS4/PS5 clickpad button or Xbox Series X share button to activate DS4 clickpad
     if (gamepad_state.buttonFlags & (TOUCHPAD_BUTTON | MISC_BUTTON)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
-    
+
     // Manual DS4 emulation: check if BACK button should also trigger DS4 touchpad click
-    if (config::input.gamepad == "ds4"sv 
-      && config::input.ds4_back_as_touchpad_click
-      && (gamepad_state.buttonFlags & BACK)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
+    if (config::input.gamepad == "ds4"sv && config::input.ds4_back_as_touchpad_click && (gamepad_state.buttonFlags & BACK)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
 
     return (DS4_SPECIAL_BUTTONS) buttons;
   }

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1333,6 +1333,11 @@ namespace platf {
 
     // Allow either PS4/PS5 clickpad button or Xbox Series X share button to activate DS4 clickpad
     if (gamepad_state.buttonFlags & (TOUCHPAD_BUTTON | MISC_BUTTON)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
+    
+    // Manual DS4 emulation: check if BACK button should also trigger DS4 touchpad click
+    if ((config::input.gamepad == "ps4"sv || config::input.gamepad == "ds4"sv) 
+      && config::input.ds4_back_as_touchpad
+      && (gamepad_state.buttonFlags & BACK)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
 
     return (DS4_SPECIAL_BUTTONS) buttons;
   }

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1335,8 +1335,8 @@ namespace platf {
     if (gamepad_state.buttonFlags & (TOUCHPAD_BUTTON | MISC_BUTTON)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
     
     // Manual DS4 emulation: check if BACK button should also trigger DS4 touchpad click
-    if ((config::input.gamepad == "ps4"sv || config::input.gamepad == "ds4"sv) 
-      && config::input.ds4_back_as_touchpad
+    if (config::input.gamepad == "ds4"sv 
+      && config::input.ds4_back_as_touchpad_click
       && (gamepad_state.buttonFlags & BACK)) buttons |= DS4_SPECIAL_BUTTON_TOUCHPAD;
 
     return (DS4_SPECIAL_BUTTONS) buttons;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1174,7 +1174,7 @@ namespace platf {
       BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be Xbox 360 controller (manual selection)"sv;
       selectedGamepadType = Xbox360Wired;
     }
-    else if (config::input.gamepad == "ps4"sv || config::input.gamepad == "ds4"sv) {
+    else if (config::input.gamepad == "ds4"sv) {
       BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualShock 4 controller (manual selection)"sv;
       selectedGamepadType = DualShock4Wired;
     }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -105,6 +105,29 @@
         </select>
         <div class="form-text">Choose which type of gamepad to emulate on the host</div>
       </div>
+      <div class="accordion" v-if="config.gamepad === 'ds4'">
+        <div class="accordion-item">
+          <h2 class="accordion-header">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse"
+              data-bs-target="#panelsStayOpen-collapseOne">
+              Manual DS4 options
+            </button>
+          </h2>
+          <div id="panelsStayOpen-collapseOne" class="accordion-collapse collapse show"
+            aria-labelledby="panelsStayOpen-headingOne">
+            <div class="accordion-body">
+              <div>
+                <label for="ds4_back_as_touchpad" class="form-label">Map Back/Select to Touchpad Click</label>
+                <select id="ds4_back_as_touchpad" class="form-select" v-model="config.ds4_back_as_touchpad">
+                  <option value="disabled">Disabled</option>
+                  <option value="enabled">Enabled (default)</option>
+                </select>
+                <div class="form-text">When forcing DS4 emulation, map Back/Select to Touchpad Click</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       <!--Ping Timeout-->
       <div class="mb-3">
         <label for="ping_timeout" class="form-label">Ping Timeout</label>
@@ -1140,6 +1163,7 @@
     "encoder": "",
     "fps": "[10,30,60,90,120]",
     "gamepad": "auto",
+    "ds4_back_as_touchpad": "enabled",
     "hevc_mode": 0,
     "av1_mode": 0,
     "key_rightalt_to_key_win": "disabled",

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -117,8 +117,8 @@
             aria-labelledby="panelsStayOpen-headingOne">
             <div class="accordion-body">
               <div>
-                <label for="ds4_back_as_touchpad" class="form-label">Map Back/Select to Touchpad Click</label>
-                <select id="ds4_back_as_touchpad" class="form-select" v-model="config.ds4_back_as_touchpad">
+                <label for="ds4_back_as_touchpad_click" class="form-label">Map Back/Select to Touchpad Click</label>
+                <select id="ds4_back_as_touchpad_click" class="form-select" v-model="config.ds4_back_as_touchpad_click">
                   <option value="disabled">Disabled</option>
                   <option value="enabled">Enabled (default)</option>
                 </select>
@@ -1159,11 +1159,11 @@
     "capture": "",
     "controller": "enabled",
     "install_steam_audio_drivers": "enabled",
+    "ds4_back_as_touchpad_click": "enabled",
     "dwmflush": "enabled",
     "encoder": "",
     "fps": "[10,30,60,90,120]",
     "gamepad": "auto",
-    "ds4_back_as_touchpad": "enabled",
     "hevc_mode": 0,
     "av1_mode": 0,
     "key_rightalt_to_key_win": "disabled",


### PR DESCRIPTION
## Description
When forcing manual DS4 emulation, there isn't a natural way to trigger Touchpad click for standard XInput. Current impl supports passing MISC_BUTTON (Xbox Series X Share button), but Steam Input doesn't expose this mapping, and most other XInput controllers on client don't have this button available.

Allow additional accessibility for clients wishing to emulate DS4 by having Back/Select also trigger Touchpad click. In most games supporting native DS4 input, Back/Share does not do anything anyway and typically should translate to a Touchpad click.

My specific usecase here is using Sunshine via Steam Deck Moonlight client. A DualShock 4 or DualSense controller configured via Steam Input cannot map the Touchpad click to Xbox 'Share' and the only way to pass through Touchpad clicks through to Sunshine is by disabling Steam Input altogether. 

### Screenshot
![Screenshot 2023-10-21 194002](https://github.com/LizardByte/Sunshine/assets/10266208/f54089ce-cccb-4e31-9871-1ad7fdd59340)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
