### PR TITLE
fix(audio:windows): set cbSize correctly

### DIFF
--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -156,7 +156,7 @@ namespace platf::audio {
     wave_format.Format.wBitsPerSample = 16;
     wave_format.Format.nBlockAlign = wave_format.Format.nChannels * wave_format.Format.wBitsPerSample / 8;
     wave_format.Format.nAvgBytesPerSec = wave_format.Format.nSamplesPerSec * wave_format.Format.nBlockAlign;
-    wave_format.Format.cbSize = sizeof(wave_format);
+    wave_format.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
 
     wave_format.Samples.wValidBitsPerSample = 16;
     wave_format.dwChannelMask = format.channel_mask;


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
We should set WAVEFORMATEXTENSIBLE::Format::cbSize to `sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)` instead of `sizeof(WAVEFORMATEXTENSIBLE)`. Incorrect cbSize can lead to audio capture failures on newer versions of Windows.

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Fixes #1783

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
