### PR TITLE
Replace Dead Link In src/platform/windows/PolicyConfig.h

### DIFF
--- a/src/platform/windows/PolicyConfig.h
+++ b/src/platform/windows/PolicyConfig.h
@@ -3,7 +3,6 @@
  * @brief Undocumented COM-interface IPolicyConfig.
  * @details Use for setting default audio render endpoint.
  * @author EreTIk
- * @see http://eretik.omegahg.com/
  */
 
 #pragma once

--- a/src/platform/windows/PolicyConfig.h
+++ b/src/platform/windows/PolicyConfig.h
@@ -3,6 +3,7 @@
  * @brief Undocumented COM-interface IPolicyConfig.
  * @details Use for setting default audio render endpoint.
  * @author EreTIk
+ * @see https://kitere.github.io/
  */
 
 #pragma once


### PR DESCRIPTION
## Description
In the file src/platform/windows/PolicyConfig.h, there is a link to http://eretik.omegahg.com/ . As of the date this pull request is made, this is a dead link. So I replaced it with https://kitere.github.io/. I used [link-inspector](https://github.com/justindhillon/link-inspector) to find this broken link.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
