### PR TITLE
build(cmake): Use GNUInstallDirs to install data and lib directories

### DIFF
--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -9,9 +9,9 @@ if(${SUNSHINE_BUILD_APPIMAGE} OR ${SUNSHINE_BUILD_FLATPAK})
             DESTINATION "${SUNSHINE_ASSETS_DIR}/systemd/user")
 else()
     install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/85-sunshine.rules"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d")
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/udev/rules.d")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/systemd/user")
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/user")
 endif()
 
 # Post install
@@ -63,19 +63,19 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
 
 # application icon
 install(FILES "${CMAKE_SOURCE_DIR}/sunshine.svg"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps")
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps")
 
 # tray icon
 if(${SUNSHINE_TRAY} STREQUAL 1)
     install(FILES "${CMAKE_SOURCE_DIR}/sunshine.svg"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/status"
+            DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status"
             RENAME "sunshine-tray.svg")
     install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/web/public/images/sunshine-playing.svg"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/status")
+            DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status")
     install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/web/public/images/sunshine-pausing.svg"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/status")
+            DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status")
     install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/web/public/images/sunshine-locked.svg"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/status")
+            DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status")
 
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                     ${CPACK_DEBIAN_PACKAGE_DEPENDS}, \
@@ -89,17 +89,17 @@ endif()
 # desktop file
 # todo - validate desktop files with `desktop-file-validate`
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.desktop"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
 if(NOT ${SUNSHINE_BUILD_APPIMAGE})
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine_terminal.desktop"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
+            DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
 endif()
 if(${SUNSHINE_BUILD_FLATPAK})
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine_kms.desktop"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
+            DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
 endif()
 
 # metadata file
 # todo - validate file with `appstream-util validate-relax`
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.appdata.xml"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/metainfo")
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")

--- a/cmake/packaging/unix.cmake
+++ b/cmake/packaging/unix.cmake
@@ -1,6 +1,8 @@
 # unix specific packaging
 # put anything here that applies to both linux and macos
 
+include(GNUInstallDirs)
+
 # return here if building a macos package
 if(SUNSHINE_PACKAGE_MACOS)
     return()

--- a/packaging/linux/flatpak/sunshine.desktop
+++ b/packaging/linux/flatpak/sunshine.desktop
@@ -12,9 +12,9 @@ Actions=RunInTerminal;KMS;
 [Desktop Action RunInTerminal]
 Name=Run in Terminal
 Icon=application-x-executable
-Exec=gio launch @CMAKE_INSTALL_PREFIX@/share/applications/sunshine_terminal.desktop
+Exec=gio launch @CMAKE_INSTALL_DATAROOTDIR@/applications/sunshine_terminal.desktop
 
 [Desktop Action KMS]
 Name=Run in Terminal (KMS)
 Icon=application-x-executable
-Exec=gio launch @CMAKE_INSTALL_PREFIX@/share/applications/sunshine_kms.desktop
+Exec=gio launch @CMAKE_INSTALL_DATAROOTDIR@/applications/sunshine_kms.desktop

--- a/packaging/linux/sunshine.desktop
+++ b/packaging/linux/sunshine.desktop
@@ -12,4 +12,4 @@ Actions=RunInTerminal;
 [Desktop Action RunInTerminal]
 Name=Run in Terminal
 Icon=application-x-executable
-Exec=gio launch @CMAKE_INSTALL_PREFIX@/share/applications/sunshine_terminal.desktop
+Exec=gio launch @CMAKE_INSTALL_DATAROOTDIR@/applications/sunshine_terminal.desktop


### PR DESCRIPTION
## Description
GNUInstallDirs (https://cmake.org/cmake/help/v3.18/module/GNUInstallDirs.html) is a CMake module which provides similar params as autotools allowing to adjust where files are installed.

On multiarch and/or cross layouts the prefix might be something like /usr/${arch} but arch independent files should still go into /usr/share.

### Screenshot

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
