### PR TITLE
Fix incorrect portrait mode rotation center on Windows

### DIFF
--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -29,7 +29,7 @@ vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, int rotate_texture_
         float2x2 rotation_matrix = { cos(rotation_radians), -sin(rotation_radians),
                                      sin(rotation_radians), cos(rotation_radians) };
         float2 rotation_center = { 0.5, 0.5 };
-        tex_coord = round(tex_coord + mul(rotation_matrix, tex_coord - rotation_center));
+        tex_coord = round(rotation_center + mul(rotation_matrix, tex_coord - rotation_center));
     }
 
 #if defined(LEFT_SUBSAMPLING)

--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -2,7 +2,7 @@
 
 #if defined(LEFT_SUBSAMPLING)
 vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float subsample_offset, int rotate_texture_steps)
-#elif defined (TOPLEFT_SUBSAMPLING)
+#elif defined(TOPLEFT_SUBSAMPLING)
 vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float2 subsample_offset, int rotate_texture_steps)
 #else
 vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, int rotate_texture_steps)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

The regression was introduced in https://github.com/LizardByte/Sunshine/pull/1621 due to wrong copy-paste.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
![image](https://github.com/LizardByte/Sunshine/assets/61738816/0c82620f-6260-40f7-9a61-edc650271b48)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
