### PR TITLE
Don't hardcode the signature length to RSA-2048

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -605,7 +605,9 @@ pkey
 ^^^^
 
 **Description**
-   The private key. This must be 2048 bits.
+   The private key used for the web UI and Moonlight client pairing. For best compatibility, this should be an RSA-2048 private key.
+
+   .. Warning:: Not all Moonlight clients support ECDSA keys or RSA key lengths other than 2048 bits.
 
 **Default**
    ``credentials/cakey.pem``
@@ -619,7 +621,9 @@ cert
 ^^^^
 
 **Description**
-   The certificate. Must be signed with a 2048 bit key.
+   The certificate used for the web UI and Moonlight client pairing. For best compatibility, this should have an RSA-2048 public key.
+
+   .. Warning:: Not all Moonlight clients support ECDSA keys or RSA key lengths other than 2048 bits.
 
 **Default**
    ``credentials/cacert.pem``

--- a/src/config.h
+++ b/src/config.h
@@ -92,8 +92,8 @@ namespace config {
     // pc|lan|wan
     std::string origin_web_ui_allowed;
 
-    std::string pkey;  // must be 2048 bits
-    std::string cert;  // must be signed with a key of 2048 bits
+    std::string pkey;
+    std::string cert;
 
     std::string sunshine_name;
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -409,11 +409,12 @@ namespace crypto {
       return {};
     }
 
-    std::size_t slen = digest_size;
+    std::size_t slen;
+    if (EVP_DigestSignFinal(ctx.get(), nullptr, &slen) != 1) {
+      return {};
+    }
 
-    std::vector<uint8_t> digest;
-    digest.resize(slen);
-
+    std::vector<uint8_t> digest(slen);
     if (EVP_DigestSignFinal(ctx.get(), digest.data(), &slen) != 1) {
       return {};
     }

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -17,7 +17,6 @@ namespace crypto {
     std::string x509;
     std::string pkey;
   };
-  constexpr std::size_t digest_size = 256;
 
   void
   md_ctx_destroy(EVP_MD_CTX *);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -380,11 +380,15 @@ namespace nvhttp {
     auto &client = sess.client;
 
     auto pairingsecret = util::from_hex_vec(get_arg(args, "clientpairingsecret"), true);
+    if (pairingsecret.size() <= 16) {
+      tree.put("root.paired", 0);
+      tree.put("root.<xmlattr>.status_code", 400);
+      tree.put("root.<xmlattr>.status_message", "Clientpairingsecret too short");
+      return;
+    }
 
     std::string_view secret { pairingsecret.data(), 16 };
-    std::string_view sign { pairingsecret.data() + secret.size(), crypto::digest_size };
-
-    assert((secret.size() + sign.size()) == pairingsecret.size());
+    std::string_view sign { pairingsecret.data() + secret.size(), pairingsecret.size() - secret.size() };
 
     auto x509 = crypto::x509(client.cert);
     auto x509_sign = crypto::signature(x509);

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -316,11 +316,13 @@
           placeholder="/dir/pkey.pem"
           v-model="config.pkey"
         />
-        <div class="form-text">The private key must be 2048 bits</div>
+        <div class="form-text">
+          The private key used for the web UI and Moonlight client pairing. For best compatibility, this should be an RSA-2048 private key.
+        </div>
       </div>
-      <!--Cert-->
+      <!--Certificate-->
       <div class="mb-3">
-        <label for="cert" class="form-label">Cert</label>
+        <label for="cert" class="form-label">Certificate</label>
         <input
           type="text"
           class="form-control"
@@ -329,7 +331,7 @@
           v-model="config.cert"
         />
         <div class="form-text">
-          The certificate must be signed with a 2048 bit key
+          The certificate used for the web UI and Moonlight client pairing. For best compatibility, this should have an RSA-2048 public key.
         </div>
       </div>
 


### PR DESCRIPTION
## Description
This PR fixes the hardcoded assumption that signatures will always be 256 bytes long (corresponding to RSA-2048). With this change, we can support larger 3072 or 4096 bit RSA keys or other algorithms like ECDSA. Moonlight clients also need to be running updated code that corrects this assumption on their side too.

Interestingly, GFE has the same bug and won't tolerate anything but RSA-2048 keys.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/59a86592-35d3-448c-bad5-25728f865f37)


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
