### PR TITLE
Fix discovery of Windows hosts by iOS/tvOS devices

### DIFF
--- a/src/platform/windows/publish.cpp
+++ b/src/platform/windows/publish.cpp
@@ -119,6 +119,21 @@ namespace platf::publish {
     instance.wPort = map_port(nvhttp::PORT_HTTP);
     instance.pszHostName = host.data();
 
+    // Setting these values ensures Windows mDNS answers comply with RFC 1035.
+    // If these are unset, Windows will send a TXT record that has zero strings,
+    // which is illegal. Setting them to a single empty value causes Windows to
+    // send a single empty string for the TXT record, which is the correct thing
+    // to do when advertising a service without any TXT strings.
+    //
+    // Most clients aren't strictly checking TXT record compliance with RFC 1035,
+    // but Apple's mDNS resolver does and rejects the entire answer if an invalid
+    // TXT record is present.
+    PWCHAR keys[] = { nullptr };
+    PWCHAR values[] = { nullptr };
+    instance.dwPropertyCount = 1;
+    instance.keys = keys;
+    instance.values = values;
+
     DNS_SERVICE_REGISTER_REQUEST req {};
     req.Version = DNS_QUERY_REQUEST_VERSION1;
     req.pQueryContext = alarm.get();


### PR DESCRIPTION
## Description
The configuration we specify in `DNS_SERVICE_INSTANCE` causes Windows to respond with TXT records that violate RFC 1035. This API behavior isn't documented anywhere, but you have to specify one empty entry for Windows to produce compliant TXT records.

This fixes automatic discovery of Sunshine hosts by Moonlight clients on Apple devices that use the native mDNS implementation (iOS/tvOS).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
