### PR TITLE
Extend session timeout

### DIFF
--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -315,7 +315,7 @@ namespace rtsp_stream {
       if (raised_timeout > now && launch_event.peek()) {
         return;
       }
-      raised_timeout = now + 10s;
+      raised_timeout = now + config::stream.ping_timeout;
 
       --_slot_count;
       launch_event.raise(launch_session);

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -307,6 +307,19 @@ namespace rtsp_stream {
       _map_cmd_cb.emplace(type, std::move(cb));
     }
 
+    /**
+     * @brief Launch a new streaming session.
+     * @note If the client does not begin streaming within the ping_timeout,
+     *       the session will be discarded.
+     * @param launch_session Streaming session information.
+     *
+     * EXAMPLES:
+     * ```cpp
+     * launch_session_t launch_session;
+     * rtsp_server_t server {};
+     * server.session_raise(launch_session);
+     * ```
+     */
     void
     session_raise(rtsp_stream::launch_session_t launch_session) {
       auto now = std::chrono::steady_clock::now();
@@ -328,6 +341,15 @@ namespace rtsp_stream {
 
     safe::event_t<rtsp_stream::launch_session_t> launch_event;
 
+    /**
+     * @brief Clear launch sessions.
+     * @param all If true, clear all sessions. Otherwise, only clear timed out and stopped sessions.
+     *
+     * EXAMPLES:
+     * ```cpp
+     * clear(false);
+     * ```
+     */
     void
     clear(bool all = true) {
       // if a launch event timed out --> Remove it.

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -334,6 +334,7 @@ namespace rtsp_stream {
       if (raised_timeout < std::chrono::steady_clock::now()) {
         auto discarded = launch_event.pop(0s);
         if (discarded) {
+          BOOST_LOG(debug) << "Event timeout: "sv << discarded->unique_id;
           ++_slot_count;
         }
       }


### PR DESCRIPTION
## Description
Use the ping timeout for the launch event's timeout value, to allow users of slower clients more time to connect.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
