### PR TITLE
Workaround "Assertion '!(__hi < __lo)' failed" crash

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -471,14 +471,14 @@ namespace input {
     auto scalarX = touch_port.width / size.first;
     auto scalarY = touch_port.height / size.second;
 
-    float x = std::clamp(val.first, 0.0f, size.first) * scalarX;
-    float y = std::clamp(val.second, 0.0f, size.second) * scalarY;
+    float x = std::min(std::max(val.first, 0.0f), size.first) * scalarX;
+    float y = std::min(std::max(val.second, 0.0f), size.second) * scalarY;
 
     auto offsetX = touch_port.client_offsetX;
     auto offsetY = touch_port.client_offsetY;
 
-    x = std::clamp(x, offsetX, (size.first * scalarX) - offsetX);
-    y = std::clamp(y, offsetY, (size.second * scalarY) - offsetY);
+    x = std::min(std::max(x, offsetX), (size.first * scalarX) - offsetX);
+    y = std::min(std::max(y, offsetY), (size.second * scalarY) - offsetY);
 
     return { (x - offsetX) * touch_port.scalar_inv, (y - offsetY) * touch_port.scalar_inv };
   }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Replace std::clamp with std::min/max equivalent in input::client_to_touchport().

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
None

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

None, but:

I'm running sunshine on Manjaro Linux.
Although don't know why, sunshine crashes on client (in my case,moonlight) connect.
Tried nightly version and got the same crash.

```log
12月 09 19:57:31 zt-ms7d48 systemd[996]: Started Sunshine is a self-hosted game stream host for Moonlight..
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [nvenc_preset] -- [3]
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [address_family] -- [both]
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Sunshine version: 0.21.0
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: System tray created
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Error: Environment variable WAYLAND_DISPLAY has not been defined
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detecting monitors
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detected monitor 0: DP-0, connected: false
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detected monitor 1: DP-1, connected: false
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detected monitor 2: DP-2, connected: false
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detected monitor 3: DP-3, connected: true
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detected monitor 4: HDMI-0, connected: false
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detected monitor 5: DP-4, connected: false
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Detected monitor 6: DP-5, connected: false
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: // Testing for available encoders, this may generate errors. You can safely ignore those errors. //
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Trying encoder [nvenc]
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Screencasting with X11
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Screencasting with X11
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: SDR color coding [Rec. 601]
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Color depth: 8-bit
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Color range: [JPEG]
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Screencasting with X11
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: SDR color coding [Rec. 601]
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Color depth: 8-bit
12月 09 19:57:31 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:31]: Info: Color range: [JPEG]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Screencasting with X11
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: SDR color coding [Rec. 601]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Color depth: 8-bit
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Color range: [JPEG]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Warning: [av1_nvenc @ 0x55f3de824000] Codec not supported
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Fatal: [av1_nvenc @ 0x55f3de824000] Provided device doesn't support required NVENC features
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Error: Could not open codec [av1_nvenc]: 函数未实现
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Screencasting with X11
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: SDR color coding [Rec. 601]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Color depth: 8-bit
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Color range: [JPEG]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Warning: [av1_nvenc @ 0x55f3de824000] Codec not supported
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Fatal: [av1_nvenc @ 0x55f3de824000] Provided device doesn't support required NVENC features
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Error: Could not open codec [av1_nvenc]: 函数未实现
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Screencasting with X11
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: SDR color coding [Rec. 709]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Color depth: 10-bit
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Color range: [JPEG]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info:
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: // Ignore any errors mentioned above, they are not relevant. //
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info:
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Found H.264 encoder: h264_nvenc [nvenc]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Found HEVC encoder: hevc_nvenc [nvenc]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Configuration UI available at [https://localhost:47990]
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Adding avahi service Sunshine
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Avahi service Sunshine successfully established.
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Avahi service name collision, renaming service to Sunshine #2
12月 09 19:57:32 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:32]: Info: Adding avahi service Sunshine #2
12月 09 19:57:33 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:33]: Info: Avahi service Sunshine #2 successfully established.
12月 09 19:57:33 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:33]: Info: Avahi service name collision, renaming service to Sunshine #3
12月 09 19:57:33 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:33]: Info: Adding avahi service Sunshine #3
12月 09 19:57:35 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:35]: Info: Avahi service Sunshine #3 successfully established.
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: // Testing for available encoders, this may generate errors. You can safely ignore those errors. //
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Trying encoder [nvenc]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Screencasting with X11
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Screencasting with X11
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: SDR color coding [Rec. 601]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color depth: 8-bit
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color range: [JPEG]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Screencasting with X11
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: SDR color coding [Rec. 601]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color depth: 8-bit
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color range: [JPEG]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Screencasting with X11
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: SDR color coding [Rec. 601]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color depth: 8-bit
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color range: [JPEG]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Warning: [av1_nvenc @ 0x7f4b7c059740] Codec not supported
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Fatal: [av1_nvenc @ 0x7f4b7c059740] Provided device doesn't support required NVENC features
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Error: Could not open codec [av1_nvenc]: 函数未实现
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Screencasting with X11
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: SDR color coding [Rec. 601]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color depth: 8-bit
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color range: [JPEG]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Warning: [av1_nvenc @ 0x7f4b7c059740] Codec not supported
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Fatal: [av1_nvenc @ 0x7f4b7c059740] Provided device doesn't support required NVENC features
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Error: Could not open codec [av1_nvenc]: 函数未实现
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Screencasting with X11
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: SDR color coding [Rec. 709]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color depth: 10-bit
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Color range: [JPEG]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info:
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: // Ignore any errors mentioned above, they are not relevant. //
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info:
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Found H.264 encoder: h264_nvenc [nvenc]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Found HEVC encoder: hevc_nvenc [nvenc]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Executing [Desktop]
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: CLIENT CONNECTED
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detecting monitors
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detected monitor 0: DP-0, connected: false
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detected monitor 1: DP-1, connected: false
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detected monitor 2: DP-2, connected: false
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detected monitor 3: DP-3, connected: true
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detected monitor 4: HDMI-0, connected: false
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detected monitor 5: DP-4, connected: false
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Detected monitor 6: DP-5, connected: false
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Screencasting with X11
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: [2023:12:09:19:57:47]: Info: Configuring selected monitor (0) to stream
12月 09 19:57:47 zt-ms7d48 sunshine[1233955]: /usr/include/c++/13.2.1/bits/stl_algo.h:3669: constexpr const _Tp& std::clamp(const _Tp&, const _Tp&, const _Tp&) [with _Tp = float]: Assertion '!(__hi < __lo)' failed.
12月 09 19:57:48 zt-ms7d48 systemd-coredump[1234131]: Process 1233955 (sunshine) of user 1000 dumped core.
                                                       
                                                       Stack trace of thread 1233962:
                                                       #0  0x00007f4bdccc683c n/a (libc.so.6 + 0x8e83c)
                                                       #1  0x00007f4bdcc76668 raise (libc.so.6 + 0x3e668)
                                                       #2  0x00007f4bdcc5e4b8 abort (libc.so.6 + 0x264b8)
                                                       #3  0x00007f4bdd0dd3b2 _ZSt21__glibcxx_assert_failPKciS0_S0_ (libstdc++.so.6 + 0xdd3b2)
                                                       #4  0x000055f3dd172a40 _ZSt5clampIfERKT_S2_S2_S2_ (sunshine-0.21.0 + 0x1b9a40)
                                                       #5  0x000055f3dd17617a _ZN5input11passthroughERSt10shared_ptrINS_7input_tEEP25_NV_ABS_MOUSE_MOVE_PACKET (sunshine-0.21.0 + 0x1bd17a)
                                                       #6  0x000055f3dd17b778 _ZN5input24passthrough_next_messageESt10shared_ptrINS_7input_tEE (sunshine-0.21.0 + 0x1c2778)
                                                       #7  0x000055f3dd17d6d8 _ZSt13__invoke_implIvRPFvSt10shared_ptrIN5input7input_tEEEJS3_EET_St14__invoke_otherOT0_DpOT1_ (sunshine-0.21.0 + 0x1c46d8)
                                                       #8  0x000055f3dd09777d _ZNKSt8functionIFSt10unique_ptrINSt13__future_base12_Result_baseENS2_8_DeleterEEvEEclEv (sunshine-0.21.0 + 0xde77d)
                                                       #9  0x00007f4bdccc9bbf n/a (libc.so.6 + 0x91bbf)
                                                       #10 0x000055f3dd17ca92 __gthread_once (sunshine-0.21.0 + 0x1c3a92)
                                                       #11 0x000055f3dd098808 _ZNSt13packaged_taskIFvvEEclEv (sunshine-0.21.0 + 0xdf808)
                                                       #12 0x00007f4bdd0e1943 execute_native_thread_routine (libstdc++.so.6 + 0xe1943)
                                                       #13 0x00007f4bdccc49eb n/a (libc.so.6 + 0x8c9eb)
                                                       #14 0x00007f4bdcd487cc n/a (libc.so.6 + 0x1107cc)
                                                       
                                                       Stack trace of thread 1233955:
                                                       #0  0x00007f4bdcd48bf6 epoll_wait (libc.so.6 + 0x110bf6)
                                                       #1  0x000055f3dd0b383b _ZN5boost4asio6detail13epoll_reactor3runElRNS1_8op_queueINS1_19scheduler_operationEEE (sunshine-0.21.0 + 0xfa83b)
                                                       #2  0x000055f3dd13da87 _ZN5boost4asio6detail9scheduler11do_wait_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoElRKNS_6system10error_codeE (sunshine-0.21.0 + 0x184a87)
                                                       #3  0x000055f3dd13cdd4 _ZN5boost4asio6detail9scheduler8wait_oneElRNS_6system10error_codeE (sunshine-0.21.0 + 0x183dd4)
                                                       #4  0x000055f3dd06741d main (sunshine-0.21.0 + 0xae41d)
                                                       #5  0x00007f4bdcc5fcd0 n/a (libc.so.6 + 0x27cd0)
                                                       #6  0x00007f4bdcc5fd8a __libc_start_main (libc.so.6 + 0x27d8a)
                                                       #7  0x000055f3dd06dba5 _start (sunshine-0.21.0 + 0xb4ba5)
```
From the backtrace (I manually rebuilt sunshine for it), it seems that the code is crashing in `std::clamp` call inside `input::passthrough(std::shared_ptr<input::input_t>&, _NV_ABS_MOUSE_MOVE_PACKET*)`.
I tried `sudo coredumpctl debug` later, but didn't figure out what is really going wrong. 
Nonetheless, after replaceing the `std::clamp`s, the code is no longer crashing in my case.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
