### PR TITLE
docs: use doxygenindex directive for source code

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1047,7 +1047,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS = KITTY_USING_MOVE_T
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -2373,7 +2373,12 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED = \
+  DOXYGEN= \
+  KITTY_USING_MOVE_T(move_t, t, init_val, z)= \
+  NSTATUS=long \
+  STDMETHODCALLTYPE= \
+  WINAPI=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/source/source_code/source_code.rst
+++ b/docs/source/source_code/source_code.rst
@@ -55,37 +55,42 @@ Example Documentation Blocks
 Source
 ------
 
-.. toctree::
-   :caption: src
-   :maxdepth: 1
-   :glob:
+.. doxygenindex::
+   :allow-dot-graphs:
 
-   src/*
-
-.. toctree::
-   :caption: src/platform
-   :maxdepth: 1
-   :glob:
-
-   src/platform/*
-
-.. toctree::
-   :caption: src/platform/linux
-   :maxdepth: 1
-   :glob:
-
-   src/platform/linux/*
-
-.. toctree::
-   :caption: src/platform/macos
-   :maxdepth: 1
-   :glob:
-
-   src/platform/macos/*
-
-.. toctree::
-   :caption: src/platform/windows
-   :maxdepth: 1
-   :glob:
-
-   src/platform/windows/*
+.. Ideally, we would use `doxygenfile` with `:allow-dot-graphs:`, but sphinx complains about duplicated namespaces...
+..
+.. .. toctree::
+..    :caption: src
+..    :maxdepth: 1
+..    :glob:
+..
+..    src/*
+..
+.... toctree::
+..    :caption: src/platform
+..    :maxdepth: 1
+..    :glob:
+..
+..    src/platform/*
+..
+.. .. toctree::
+..    :caption: src/platform/linux
+..    :maxdepth: 1
+..    :glob:
+..
+..    src/platform/linux/*
+..
+.. .. toctree::
+..    :caption: src/platform/macos
+..    :maxdepth: 1
+..    :glob:
+..
+..    src/platform/macos/*
+..
+.. .. toctree::
+..    :caption: src/platform/windows
+..    :maxdepth: 1
+..    :glob:
+..
+..    src/platform/windows/*

--- a/docs/source/source_code/src/audio.rst
+++ b/docs/source/source_code/src/audio.rst
@@ -1,5 +1,0 @@
-audio
-=====
-
-.. doxygenfile:: audio.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/cbs.rst
+++ b/docs/source/source_code/src/cbs.rst
@@ -1,5 +1,0 @@
-cbs
-===
-
-.. doxygenfile:: cbs.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/config.rst
+++ b/docs/source/source_code/src/config.rst
@@ -1,5 +1,0 @@
-config
-======
-
-.. doxygenfile:: config.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/confighttp.rst
+++ b/docs/source/source_code/src/confighttp.rst
@@ -1,5 +1,0 @@
-confighttp
-==========
-
-.. doxygenfile:: confighttp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/crypto.rst
+++ b/docs/source/source_code/src/crypto.rst
@@ -1,5 +1,0 @@
-crypto
-======
-
-.. doxygenfile:: crypto.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/httpcommon.rst
+++ b/docs/source/source_code/src/httpcommon.rst
@@ -1,5 +1,0 @@
-httpcommon
-==========
-
-.. doxygenfile:: httpcommon.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/input.rst
+++ b/docs/source/source_code/src/input.rst
@@ -1,5 +1,0 @@
-input
-=====
-
-.. doxygenfile:: input.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/main.rst
+++ b/docs/source/source_code/src/main.rst
@@ -1,5 +1,0 @@
-main
-====
-
-.. doxygenfile:: main.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/move_by_copy.rst
+++ b/docs/source/source_code/src/move_by_copy.rst
@@ -1,5 +1,0 @@
-move_by_copy
-============
-
-.. doxygenfile:: move_by_copy.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/network.rst
+++ b/docs/source/source_code/src/network.rst
@@ -1,5 +1,0 @@
-network
-=======
-
-.. doxygenfile:: network.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/nvhttp.rst
+++ b/docs/source/source_code/src/nvhttp.rst
@@ -1,5 +1,0 @@
-nvhttp
-======
-
-.. doxygenfile:: nvhttp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/common.rst
+++ b/docs/source/source_code/src/platform/common.rst
@@ -1,4 +1,0 @@
-common
-======
-
-.. Todo:: Add common.h

--- a/docs/source/source_code/src/platform/linux/cuda.rst
+++ b/docs/source/source_code/src/platform/linux/cuda.rst
@@ -1,5 +1,0 @@
-cuda
-====
-
-.. doxygenfile:: platform/linux/cuda.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/linux/graphics.rst
+++ b/docs/source/source_code/src/platform/linux/graphics.rst
@@ -1,4 +1,0 @@
-graphics
-========
-
-.. Todo:: Add graphics.h

--- a/docs/source/source_code/src/platform/linux/misc.rst
+++ b/docs/source/source_code/src/platform/linux/misc.rst
@@ -1,4 +1,0 @@
-misc
-====
-
-.. Todo:: Add misc.h

--- a/docs/source/source_code/src/platform/linux/vaapi.rst
+++ b/docs/source/source_code/src/platform/linux/vaapi.rst
@@ -1,5 +1,0 @@
-vaapi
-=====
-
-.. doxygenfile:: platform/linux/vaapi.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/linux/wayland.rst
+++ b/docs/source/source_code/src/platform/linux/wayland.rst
@@ -1,5 +1,0 @@
-wayland
-=======
-
-.. doxygenfile:: platform/linux/wayland.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/linux/x11grab.rst
+++ b/docs/source/source_code/src/platform/linux/x11grab.rst
@@ -1,4 +1,0 @@
-x11grab
-=======
-
-.. Todo:: Add x11grab.h

--- a/docs/source/source_code/src/platform/macos/av_audio.rst
+++ b/docs/source/source_code/src/platform/macos/av_audio.rst
@@ -1,4 +1,0 @@
-av_audio
-========
-
-.. Todo:: Add av_audio.h

--- a/docs/source/source_code/src/platform/macos/av_img_t.rst
+++ b/docs/source/source_code/src/platform/macos/av_img_t.rst
@@ -1,4 +1,0 @@
-av_img_t
-========
-
-.. Todo:: Add av_img_t.h

--- a/docs/source/source_code/src/platform/macos/av_video.rst
+++ b/docs/source/source_code/src/platform/macos/av_video.rst
@@ -1,4 +1,0 @@
-av_video
-========
-
-.. Todo:: Add av_video.h

--- a/docs/source/source_code/src/platform/macos/misc.rst
+++ b/docs/source/source_code/src/platform/macos/misc.rst
@@ -1,5 +1,0 @@
-misc
-====
-
-.. doxygenfile:: platform/macos/misc.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/macos/nv12_zero_device.rst
+++ b/docs/source/source_code/src/platform/macos/nv12_zero_device.rst
@@ -1,4 +1,0 @@
-nv12_zero_device
-================
-
-.. Todo:: Add nv12_zero_device.h

--- a/docs/source/source_code/src/platform/windows/PolicyConfig.rst
+++ b/docs/source/source_code/src/platform/windows/PolicyConfig.rst
@@ -1,4 +1,0 @@
-PolicyConfig
-============
-
-.. Todo:: Add PolicyConfig.h

--- a/docs/source/source_code/src/platform/windows/display.rst
+++ b/docs/source/source_code/src/platform/windows/display.rst
@@ -1,4 +1,0 @@
-display
-=======
-
-.. Todo:: Add display.h

--- a/docs/source/source_code/src/platform/windows/misc.rst
+++ b/docs/source/source_code/src/platform/windows/misc.rst
@@ -1,5 +1,0 @@
-misc
-====
-
-.. doxygenfile:: platform/windows/misc.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/process.rst
+++ b/docs/source/source_code/src/process.rst
@@ -1,5 +1,0 @@
-process
-=======
-
-.. doxygenfile:: process.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/round_robin.rst
+++ b/docs/source/source_code/src/round_robin.rst
@@ -1,5 +1,0 @@
-round_robin
-===========
-
-.. doxygenfile:: round_robin.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/rtsp.rst
+++ b/docs/source/source_code/src/rtsp.rst
@@ -1,5 +1,0 @@
-rtsp
-====
-
-.. doxygenfile:: rtsp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/stream.rst
+++ b/docs/source/source_code/src/stream.rst
@@ -1,5 +1,0 @@
-stream
-======
-
-.. doxygenfile:: stream.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/sync.rst
+++ b/docs/source/source_code/src/sync.rst
@@ -1,5 +1,0 @@
-sync
-====
-
-.. doxygenfile:: sync.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/system_tray.rst
+++ b/docs/source/source_code/src/system_tray.rst
@@ -1,5 +1,0 @@
-system_tray
-===========
-
-.. doxygenfile:: system_tray.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/task_pool.rst
+++ b/docs/source/source_code/src/task_pool.rst
@@ -1,5 +1,0 @@
-task_pool
-=========
-
-.. doxygenfile:: task_pool.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/thread_pool.rst
+++ b/docs/source/source_code/src/thread_pool.rst
@@ -1,5 +1,0 @@
-thread_pool
-===========
-
-.. doxygenfile:: thread_pool.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/thread_safe.rst
+++ b/docs/source/source_code/src/thread_safe.rst
@@ -1,5 +1,0 @@
-thread_safe
-===========
-
-.. doxygenfile:: thread_safe.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/upnp.rst
+++ b/docs/source/source_code/src/upnp.rst
@@ -1,5 +1,0 @@
-upnp
-====
-
-.. doxygenfile:: upnp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/utility.rst
+++ b/docs/source/source_code/src/utility.rst
@@ -1,4 +1,0 @@
-utility
-=======
-
-.. Todo:: Add utility.h

--- a/docs/source/source_code/src/uuid.rst
+++ b/docs/source/source_code/src/uuid.rst
@@ -1,5 +1,0 @@
-uuid
-====
-
-.. doxygenfile:: uuid.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/video.rst
+++ b/docs/source/source_code/src/video.rst
@@ -1,5 +1,0 @@
-video
-=====
-
-.. doxygenfile:: video.h
-   :allow-dot-graphs:

--- a/src/platform/macos/av_audio.h
+++ b/src/platform/macos/av_audio.h
@@ -10,10 +10,12 @@
 
 #define kBufferLength 2048
 
+#ifndef DOXYGEN // Doxygen throws an error
 @interface AVAudio: NSObject <AVCaptureAudioDataOutputSampleBufferDelegate> {
 @public
   TPCircularBuffer audioSampleBuffer;
 }
+#endif
 
 @property (nonatomic, assign) AVCaptureSession *audioCaptureSession;
 @property (nonatomic, assign) AVCaptureConnection *audioConnection;

--- a/src/platform/macos/av_video.h
+++ b/src/platform/macos/av_video.h
@@ -11,7 +11,9 @@ struct CaptureSession {
   NSCondition *captureStopped;
 };
 
+#ifndef DOXYGEN // Doxygen throws an error
 @interface AVVideo: NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+#endif
 
 #define kMaxDisplays 32
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Change to doxygenindex directive to avoid duplicate C++ declaration errors.

The disadvantage is that all of the code will be held on a single rst page, but the advantage is that the code documentation will be fully complete.

Todo:
- [ ] Solve Sphinx/C++ errors/warnings.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
