### PR TITLE
Fatal warning improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -517,10 +517,9 @@ main(int argc, char *argv[]) {
     char buffer[1024];
 
     av_log_format_line(ptr, level, fmt, vl, buffer, sizeof(buffer), &print_prefix);
-    if (level <= AV_LOG_FATAL) {
-      BOOST_LOG(fatal) << buffer;
-    }
-    else if (level <= AV_LOG_ERROR) {
+    if (level <= AV_LOG_ERROR) {
+      // We print AV_LOG_FATAL at the error level. FFmpeg prints things as fatal that
+      // are expected in some cases, such as lack of codec support or similar things.
       BOOST_LOG(error) << buffer;
     }
     else if (level <= AV_LOG_WARNING) {

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -200,6 +200,8 @@ namespace platf {
       if (!VIGEM_SUCCESS(status)) {
         BOOST_LOG(warning) << "Couldn't setup connection to ViGEm for gamepad support ["sv << util::hex(status).to_string_view() << ']';
 
+        // Log a special fatal message for this case to show the error in the web UI
+        BOOST_LOG(fatal) << "ViGEmBus is not installed or running. You must install ViGEmBus for gamepad support!"sv;
         return -1;
       }
 

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -13,8 +13,8 @@
     <div class="alert alert-danger" v-if="fancyLogs.find(x => x.level === 'Fatal')">
       <div style="line-height: 32px;">
         <i class="fas fa-circle-exclamation" style="font-size: 32px;margin-right: 0.25em;"></i>
-        <b>Attention!</b> Sunshine detected these errors during startup. These errors <b>MUST</b> be fixed before using
-        Sunshine.<br>
+        <b>Attention!</b> Sunshine detected these errors during startup. We <b>STRONGLY RECOMMEND</b> fixing them
+        before streaming.<br>
       </div>
       <ul>
         <li v-for="v in fancyLogs.filter(x => x.level === 'Fatal')">{{v.value}}</li>


### PR DESCRIPTION
## Description
This PR has a few changes to improve the UX for "fatal" errors in the web UI.

- It demotes FFmpeg's `AV_LOG_FATAL` log level down to our `error` level to avoid things like #1849
- It adds an error for ViGEmBus initialization failure since it's common for portable users to fail to install it and wonder why their gamepad doesn't work
- Tweaked wording to be less strong regarding configuration errors, since some may be expected in esoteric configurations

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/1886e11e-6a89-497f-af3f-84844453ed0c)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
