### PR TITLE
Don't install/update ViGEmBus if 1.17 or later is already installed

### DIFF
--- a/src_assets/windows/misc/gamepad/install-gamepad.bat
+++ b/src_assets/windows/misc/gamepad/install-gamepad.bat
@@ -3,7 +3,7 @@ setlocal enabledelayedexpansion
 
 rem Check if a compatible version of ViGEmBus is already installed (1.17 or later)
 set Version=
-for /f "usebackq delims=" %%a in (`"wmic product where name='ViGEm Bus Driver' get Version /format:Textvaluelist"`) do (
+for /f "usebackq delims=" %%a in (`wmic product where "name='ViGEm Bus Driver' or name='Nefarius Virtual Gamepad Emulation Bus Driver'" get Version /format:Textvaluelist`) do (
     for /f "delims=" %%# in ("%%a") do set "%%#"
 )
 

--- a/src_assets/windows/misc/gamepad/install-gamepad.bat
+++ b/src_assets/windows/misc/gamepad/install-gamepad.bat
@@ -6,8 +6,27 @@ set Version=
 for /f "usebackq delims=" %%a in (`"wmic product where name='ViGEm Bus Driver' get Version /format:Textvaluelist"`) do (
     for /f "delims=" %%# in ("%%a") do set "%%#"
 )
-if /i %Version:~2,4% geq 17 exit /b 0
 
+rem Extract Major and Minor versions
+for /f "tokens=1,2 delims=." %%a in ("%Version%") do (
+    set "MajorVersion=%%a"
+    set "MinorVersion=%%b"
+)
+
+rem Compare the version to 1.17
+if /i !MajorVersion! gtr 1 goto skip
+if /i !MajorVersion! equ 1 (
+    if /i !MinorVersion! geq 17 (
+        goto skip
+    )
+)
+goto continue
+
+:skip
+echo "The installed version is %Version%, no update needed. Exiting."
+exit /b 0
+
+:continue
 rem Get temp directory
 set temp_dir=%temp%/Sunshine
 

--- a/src_assets/windows/misc/gamepad/install-gamepad.bat
+++ b/src_assets/windows/misc/gamepad/install-gamepad.bat
@@ -1,6 +1,13 @@
 @echo off
 setlocal enabledelayedexpansion
 
+rem Check if a compatible version of ViGEmBus is already installed (1.17 or later)
+set Version=
+for /f "usebackq delims=" %%a in (`"wmic product where name='ViGEm Bus Driver' get Version /format:Textvaluelist"`) do (
+    for /f "delims=" %%# in ("%%a") do set "%%#"
+)
+if /i %Version:~2,4% geq 17 exit /b 0
+
 rem Get temp directory
 set temp_dir=%temp%/Sunshine
 


### PR DESCRIPTION
## Description
This implements the feature mentioned in https://github.com/LizardByte/Sunshine/pull/1948#discussion_r1438467072. We will no longer install or upgrade ViGEmBus if version 1.17 or later is already present. That version was released in December 2020, so this should mitigate the unexpected reboot issues during setup for the vast majority of cases. We use the extended DualShock 4 features, so we don't want to allow drivers older than 1.17.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
