### PR TITLE
Use dl handle for libva's vaTerminate rather than actual function

### DIFF
--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -520,7 +520,7 @@ namespace va {
     auto hwctx = (AVVAAPIDeviceContext *) ctx->hwctx;
     auto priv = (VAAPIDevicePriv *) ctx->user_opaque;
 
-    vaTerminate(hwctx->display);
+    terminate(hwctx->display);
     close(priv->drm_fd);
     av_freep(&priv);
   }


### PR DESCRIPTION
## Description
libva is supposed to be optional. Building currently fails with an unresolved symbol if it is missing.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
