### PR TITLE
fix(tray): use PROJECT_NAME definition for tooltip

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -40,11 +40,13 @@
   #include "main.h"
   #include "platform/common.h"
   #include "process.h"
+  #include "version.h"
 
 using namespace std::literals;
 
 // system_tray namespace
 namespace system_tray {
+  static char tooltipText[] = PROJECT_NAME;
 
   /**
    * @brief Callback for opening the UI from the system tray.
@@ -126,9 +128,7 @@ namespace system_tray {
   // Tray menu
   static struct tray tray = {
     .icon = TRAY_ICON,
-  #if defined(_WIN32)
-    .tooltip = const_cast<char *>("Sunshine"),  // cast the string literal to a non-const char* pointer
-  #endif
+    .tooltip = tooltipText,
     .menu =
       (struct tray_menu[]) {
         // todo - use boost/locale to translate menu strings
@@ -340,7 +340,7 @@ namespace system_tray {
     tray.notification_icon = TRAY_ICON;
     tray.notification_title = "Application Stopped";
     tray.notification_text = msg;
-    tray.tooltip = "Sunshine";
+    tray.tooltip = tooltipText;
     tray_update(&tray);
   }
 
@@ -359,7 +359,7 @@ namespace system_tray {
     tray.notification_title = "Incoming Pairing Request";
     tray.notification_text = "Click here to complete the pairing process";
     tray.notification_icon = TRAY_ICON_LOCKED;
-    tray.tooltip = "Sunshine";
+    tray.tooltip = tooltipText;
     tray.notification_cb = []() {
       launch_ui_with_path("/pin");
     };

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -46,8 +46,6 @@ using namespace std::literals;
 
 // system_tray namespace
 namespace system_tray {
-  static char tooltipText[] = PROJECT_NAME;
-
   /**
    * @brief Callback for opening the UI from the system tray.
    * @param item The tray menu item.
@@ -128,7 +126,7 @@ namespace system_tray {
   // Tray menu
   static struct tray tray = {
     .icon = TRAY_ICON,
-    .tooltip = tooltipText,
+    .tooltip = PROJECT_NAME,
     .menu =
       (struct tray_menu[]) {
         // todo - use boost/locale to translate menu strings
@@ -340,7 +338,7 @@ namespace system_tray {
     tray.notification_icon = TRAY_ICON;
     tray.notification_title = "Application Stopped";
     tray.notification_text = msg;
-    tray.tooltip = tooltipText;
+    tray.tooltip = PROJECT_NAME;
     tray_update(&tray);
   }
 
@@ -359,7 +357,7 @@ namespace system_tray {
     tray.notification_title = "Incoming Pairing Request";
     tray.notification_text = "Click here to complete the pairing process";
     tray.notification_icon = TRAY_ICON_LOCKED;
-    tray.tooltip = tooltipText;
+    tray.tooltip = PROJECT_NAME;
     tray.notification_cb = []() {
       launch_ui_with_path("/pin");
     };


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use common variable for tray tooltip assignment, using `PROJECT_NAME` definition.
- Two warnings are generated during build due to converting a string constant to `char*` fixed in https://github.com/LizardByte/tray/pull/8.

```txt
#18 57.17 /build/sunshine/src/system_tray.cpp: In function 'void system_tray::update_tray_stopped(std::string)':
#18 57.17 /build/sunshine/src/system_tray.cpp:343:20: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
#18 57.17   343 |     tray.tooltip = "Sunshine";
#18 57.17       |                    ^~~~~~~~~~
#18 57.17 /build/sunshine/src/system_tray.cpp: In function 'void system_tray::update_tray_require_pin()':
#18 57.17 /build/sunshine/src/system_tray.cpp:362:20: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
#18 57.17   362 |     tray.tooltip = "Sunshine";
#18 57.17       |                    ^~~~~~~~~~
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
