### PR TITLE
build(linux): make vaapi optional

### DIFF
--- a/cmake/FindLibva.cmake
+++ b/cmake/FindLibva.cmake
@@ -1,0 +1,70 @@
+# - Try to find Libva
+# This module defines the following variables:
+#
+# * LIBVA_FOUND - The component was found
+# * LIBVA_INCLUDE_DIRS - The component include directory
+# * LIBVA_LIBRARIES - The component library Libva
+# * LIBVA_DRM_LIBRARIES - The component library Libva DRM
+
+# Use pkg-config to get the directories and then use these values in the
+# find_path() and find_library() calls
+# cmake-format: on
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(_LIBVA libva)
+    pkg_check_modules(_LIBVA_DRM libva-drm)
+endif()
+
+find_path(
+        LIBVA_INCLUDE_DIR
+        NAMES va/va.h va/va_drm.h
+        HINTS ${_LIBVA_INCLUDE_DIRS}
+        PATHS /usr/include /usr/local/include /opt/local/include)
+
+find_library(
+        LIBVA_LIB
+        NAMES ${_LIBVA_LIBRARIES} libva
+        HINTS ${_LIBVA_LIBRARY_DIRS}
+        PATHS /usr/lib /usr/local/lib /opt/local/lib)
+
+find_library(
+        LIBVA_DRM_LIB
+        NAMES ${_LIBVA_DRM_LIBRARIES} libva-drm
+        HINTS ${_LIBVA_DRM_LIBRARY_DIRS}
+        PATHS /usr/lib /usr/local/lib /opt/local/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libva REQUIRED_VARS LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB)
+mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB)
+
+if(LIBVA_FOUND)
+    set(LIBVA_INCLUDE_DIRS ${LIBVA_INCLUDE_DIR})
+    set(LIBVA_LIBRARIES ${LIBVA_LIB})
+    set(LIBVA_DRM_LIBRARIES ${LIBVA_DRM_LIB})
+
+    if(NOT TARGET Libva::va)
+        if(IS_ABSOLUTE "${LIBVA_LIBRARIES}")
+            add_library(Libva::va UNKNOWN IMPORTED)
+            set_target_properties(Libva::va PROPERTIES IMPORTED_LOCATION "${LIBVA_LIBRARIES}")
+        else()
+            add_library(Libva::va INTERFACE IMPORTED)
+            set_target_properties(Libva::va PROPERTIES IMPORTED_LIBNAME "${LIBVA_LIBRARIES}")
+        endif()
+
+        set_target_properties(Libva::va PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
+    endif()
+
+    if(NOT TARGET Libva::drm)
+        if(IS_ABSOLUTE "${LIBVA_DRM_LIBRARIES}")
+            add_library(Libva::drm UNKNOWN IMPORTED)
+            set_target_properties(Libva::drm PROPERTIES IMPORTED_LOCATION "${LIBVA_DRM_LIBRARIES}")
+        else()
+            add_library(Libva::drm INTERFACE IMPORTED)
+            set_target_properties(Libva::drm PROPERTIES IMPORTED_LIBNAME "${LIBVA_DRM_LIBRARIES}")
+        endif()
+
+        set_target_properties(Libva::drm PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
+    endif()
+
+endif()

--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -120,6 +120,25 @@ elseif(NOT LIBDRM_FOUND)
     message(WARNING "Missing libcap")
 endif()
 
+# vaapi
+if(${SUNSHINE_ENABLE_VAAPI})
+    find_package(Libva)
+else()
+    set(LIBVA_FOUND OFF)
+endif()
+if(LIBVA_FOUND)
+    add_compile_definitions(SUNSHINE_BUILD_VAAPI)
+    include_directories(SYSTEM ${LIBVA_INCLUDE_DIR})
+    list(APPEND PLATFORM_LIBRARIES ${LIBVA_LIBRARIES})
+    if(${SUNSHINE_ENABLE_DRM})
+        list(APPEND PLATFORM_LIBRARIES
+                ${LIBVA_DRM_LIBRARIES})
+    endif()
+    list(APPEND PLATFORM_TARGET_FILES
+            src/platform/linux/vaapi.h
+            src/platform/linux/vaapi.cpp)
+endif()
+
 # wayland
 if(${SUNSHINE_ENABLE_WAYLAND})
     find_package(Wayland)
@@ -167,8 +186,12 @@ if(X11_FOUND)
             src/platform/linux/x11grab.cpp)
 endif()
 
-if(NOT ${CUDA_FOUND} AND NOT ${WAYLAND_FOUND} AND NOT ${X11_FOUND} AND NOT (${LIBDRM_FOUND} AND ${LIBCAP_FOUND}))
-    message(FATAL_ERROR "Couldn't find either x11, wayland, cuda or (libdrm and libcap)")
+if(NOT ${CUDA_FOUND}
+        AND NOT ${WAYLAND_FOUND}
+        AND NOT ${X11_FOUND}
+        AND NOT (${LIBDRM_FOUND} AND ${LIBCAP_FOUND})
+        AND NOT ${LIBVA_FOUND})
+    message(FATAL_ERROR "Couldn't find either cuda, wayland, x11, (libdrm and libcap), or libva")
 endif()
 
 # tray icon
@@ -206,8 +229,6 @@ endif()
 
 list(APPEND PLATFORM_TARGET_FILES
         src/platform/linux/publish.cpp
-        src/platform/linux/vaapi.h
-        src/platform/linux/vaapi.cpp
         src/platform/linux/graphics.h
         src/platform/linux/graphics.cpp
         src/platform/linux/misc.h

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -26,6 +26,8 @@ elseif(UNIX)  # Linux
             "Enable cuda specific code." ON)
     option(SUNSHINE_ENABLE_DRM
             "Enable KMS grab if available." ON)
+    option(SUNSHINE_ENABLE_VAAPI
+            "Enable building vaapi specific code." ON)
     option(SUNSHINE_ENABLE_WAYLAND
             "Enable building wayland specific code." ON)
     option(SUNSHINE_ENABLE_X11

--- a/docs/source/building/linux.rst
+++ b/docs/source/building/linux.rst
@@ -32,7 +32,7 @@ Install Requirements
           libopus-dev \
           libpulse-dev \
           libssl-dev \
-          libva-dev \
+          libva-dev \  # VA-API
           libvdpau-dev \
           libwayland-dev \  # Wayland
           libx11-dev \  # X11
@@ -67,7 +67,7 @@ Install Requirements
           libdrm-devel \
           libevdev-devel \
           libnotify-devel \
-          libva-devel \
+          libva-devel \  # VA-API
           libvdpau-devel \
           libX11-devel \  # X11
           libxcb-devel \  # X11
@@ -115,7 +115,7 @@ Install Requirements
           libopus-dev \
           libpulse-dev \
           libssl-dev \
-          libva-dev \
+          libva-dev \  # VA-API
           libvdpau-dev \
           libwayland-dev \  # Wayland
           libx11-dev \  # X11
@@ -165,6 +165,7 @@ Install Requirements
           libopus-dev \
           libpulse-dev \
           libssl-dev \
+          libva-dev \  # VA-API
           libwayland-dev \  # Wayland
           libx11-dev \  # X11
           libxcb-shm0-dev \  # X11


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
As discovered by #1955, there is at least one package of Sunshine built without vaapi support. This PR adds a cmake option to disable it.

The FindLibva.cmake file was borrowed from OBS.

Todo:
- [x] Is the `find_package` defined correctly?


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
