### PR TITLE
refactor(process): re-order variables to avoid unused variable when tray is disabled

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -258,13 +258,11 @@ namespace proc {
 
   void
   proc_t::terminate() {
-    bool has_run = _app_id > 0;
     std::error_code ec;
     placebo = false;
     process_end(_process, _process_handle);
     _process = bp::child();
     _process_handle = bp::group();
-    _app_id = -1;
 
     for (; _app_prep_it != _app_prep_begin; --_app_prep_it) {
       auto &cmd = *(_app_prep_it - 1);
@@ -293,12 +291,16 @@ namespace proc {
 
     _pipe.reset();
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
+    bool has_run = _app_id > 0;
+
     // Only show the Stopped notification if we actually have an app to stop
     // Since terminate() is always run when a new app has started
     if (proc::proc.get_last_run_app_name().length() > 0 && has_run) {
       system_tray::update_tray_stopped(proc::proc.get_last_run_app_name());
     }
 #endif
+
+    _app_id = -1;
   }
 
   const std::vector<ctx_t> &


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR fixes an issue when the tray is disabled and a build warning was produced because of unused variable `has_bool`.

```
/Users/runner/work/Sunshine/Sunshine/src/process.cpp:261:10: warning: unused variable 'has_run' [-Wunused-variable]
    bool has_run = _app_id > 0;
         ^
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
