### PR TITLE
Optionally allow the system installation of wayland-protocols to be used

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -129,8 +129,15 @@ endif()
 if(WAYLAND_FOUND)
     add_compile_definitions(SUNSHINE_BUILD_WAYLAND)
 
-    GEN_WAYLAND("wayland-protocols" "unstable/xdg-output" xdg-output-unstable-v1)
-    GEN_WAYLAND("wlr-protocols" "unstable" wlr-export-dmabuf-unstable-v1)
+    if(NOT SUNSHINE_SYSTEM_WAYLAND_PROTOCOLS)
+        set(WAYLAND_PROTOCOLS_DIR "${CMAKE_SOURCE_DIR}/third-party/wayland-protocols")
+    else()
+        pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
+        pkg_check_modules(WAYLAND_PROTOCOLS wayland-protocols REQUIRED)
+    endif()
+
+    GEN_WAYLAND("${WAYLAND_PROTOCOLS_DIR}" "unstable/xdg-output" xdg-output-unstable-v1)
+    GEN_WAYLAND("${CMAKE_SOURCE_DIR}/third-party/wlr-protocols" "unstable" wlr-export-dmabuf-unstable-v1)
 
     include_directories(
             SYSTEM

--- a/cmake/macros/linux.cmake
+++ b/cmake/macros/linux.cmake
@@ -5,17 +5,17 @@ macro(GEN_WAYLAND wayland_directory subdirectory filename)
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/generated-src)
 
     message("wayland-scanner private-code \
-${CMAKE_SOURCE_DIR}/third-party/${wayland_directory}/${subdirectory}/${filename}.xml \
+${wayland_directory}/${subdirectory}/${filename}.xml \
 ${CMAKE_BINARY_DIR}/generated-src/${filename}.c")
     message("wayland-scanner client-header \
-${CMAKE_SOURCE_DIR}/third-party/${wayland_directory}/${subdirectory}/${filename}.xml \
+${wayland_directory}/${subdirectory}/${filename}.xml \
 ${CMAKE_BINARY_DIR}/generated-src/${filename}.h")
     execute_process(
             COMMAND wayland-scanner private-code
-            ${CMAKE_SOURCE_DIR}/third-party/${wayland_directory}/${subdirectory}/${filename}.xml
+            ${wayland_directory}/${subdirectory}/${filename}.xml
             ${CMAKE_BINARY_DIR}/generated-src/${filename}.c
             COMMAND wayland-scanner client-header
-            ${CMAKE_SOURCE_DIR}/third-party/${wayland_directory}/${subdirectory}/${filename}.xml
+            ${wayland_directory}/${subdirectory}/${filename}.xml
             ${CMAKE_BINARY_DIR}/generated-src/${filename}.h
 
             RESULT_VARIABLE EXIT_INT

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -5,6 +5,7 @@ option(SUNSHINE_ENABLE_TRAY "Enable system tray icon. This option will be ignore
 option(SUNSHINE_REQUIRE_TRAY "Require system tray icon. Fail the build if tray requirements are not met." ON)
 
 option(SUNSHINE_SYSTEM_MINIUPNP "Use system installation of MiniUPnP rather than the submodule." OFF)
+option(SUNSHINE_SYSTEM_WAYLAND_PROTOCOLS "Use system installation of wayland-protocols rather than the submodule." OFF)
 
 if(APPLE)
     option(SUNSHINE_CONFIGURE_PORTFILE


### PR DESCRIPTION
## Description
Gentoo Linux users on Wayland will almost certainly have these protocol files installed already. This makes the package a little simpler. Unfortunately, wlr-protocols does not appear to be packaged anywhere. This is the last of my unbundling requests, apart from allowing a custom build of ffmpeg.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated