### PR TITLE
Wlgrab fixes

### DIFF
--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -558,6 +558,36 @@ namespace egl {
     return rgb;
   }
 
+  /**
+   * @brief Creates a black RGB texture of the specified image size.
+   * @param img The image to use for texture sizing.
+   * @return The new RGB texture.
+   */
+  rgb_t
+  create_blank(platf::img_t &img) {
+    rgb_t rgb {
+      EGL_NO_DISPLAY,
+      EGL_NO_IMAGE,
+      gl::tex_t::make(1)
+    };
+
+    gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
+    gl::ctx.TexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, img.width, img.height);
+    gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
+
+    auto framebuf = gl::frame_buf_t::make(1);
+    framebuf.bind(&rgb->tex[0], &rgb->tex[0] + 1);
+
+    GLenum attachment = GL_COLOR_ATTACHMENT0;
+    gl::ctx.DrawBuffers(1, &attachment);
+    const GLuint rgb_black[] = { 0, 0, 0, 0 };
+    gl::ctx.ClearBufferuiv(GL_COLOR, 0, rgb_black);
+
+    gl_drain_errors;
+
+    return rgb;
+  }
+
   std::optional<nv12_t>
   import_target(display_t::pointer egl_display, std::array<file_t, nv12_img_t::num_fds> &&fds, const surface_descriptor_t &r8, const surface_descriptor_t &gr88) {
     EGLAttrib img_attr_planes[2][17] {

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -268,6 +268,9 @@ namespace egl {
     display_t::pointer egl_display,
     const surface_descriptor_t &xrgb);
 
+  rgb_t
+  create_blank(platf::img_t &img);
+
   std::optional<nv12_t>
   import_target(
     display_t::pointer egl_display,

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -819,17 +819,11 @@ namespace platf {
 
         auto &rgb = *rgb_opt;
 
-        gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
-
-        int w, h;
-        gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
-        gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
-        BOOST_LOG(debug) << "width and height: w "sv << w << " h "sv << h;
-
         if (!pull_free_image_cb(img_out)) {
           return platf::capture_e::interrupted;
         }
 
+        gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
         gl::ctx.GetTextureSubImage(rgb->tex[0], 0, img_offset_x, img_offset_y, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
 
         if (cursor_opt && cursor) {

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -874,6 +874,8 @@ namespace platf {
       alloc_img() override {
         auto img = std::make_shared<egl::img_descriptor_t>();
 
+        img->width = width;
+        img->height = height;
         img->serial = std::numeric_limits<decltype(img->serial)>::max();
         img->data = nullptr;
         img->pixel_pitch = 4;
@@ -886,16 +888,8 @@ namespace platf {
 
       int
       dummy_img(platf::img_t *img) override {
-        // TODO: stop cheating and give black image
-        if (!img) {
-          return -1;
-        };
-        auto pull_dummy_img_callback = [&img](std::shared_ptr<platf::img_t> &img_out) -> bool {
-          img_out = img->shared_from_this();
-          return true;
-        };
-        std::shared_ptr<platf::img_t> img_out;
-        return snapshot(pull_dummy_img_callback, img_out, 1s, false) != platf::capture_e::ok;
+        // Empty images are recognized as dummies by the zero sequence number
+        return 0;
       }
 
       capture_e
@@ -988,12 +982,10 @@ namespace platf {
           return -1;
         }
 
-        sequence = 0;
-
         return 0;
       }
 
-      std::uint64_t sequence;
+      std::uint64_t sequence {};
     };
 
   }  // namespace kms

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -436,7 +436,11 @@ namespace va {
     convert(platf::img_t &img) override {
       auto &descriptor = (egl::img_descriptor_t &) img;
 
-      if (descriptor.sequence > sequence) {
+      if (descriptor.sequence == 0) {
+        // For dummy images, use a blank RGB texture instead of importing a DMA-BUF
+        rgb = egl::create_blank(img);
+      }
+      else if (descriptor.sequence > sequence) {
         sequence = descriptor.sequence;
 
         rgb = egl::rgb_t {};

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -118,7 +118,19 @@ namespace wl {
     void
     xdg_size(zxdg_output_v1 *, std::int32_t width, std::int32_t height);
     void
-    xdg_done(zxdg_output_v1 *);
+    xdg_done(zxdg_output_v1 *) {}
+
+    void
+    wl_geometry(wl_output *wl_output, std::int32_t x, std::int32_t y,
+      std::int32_t physical_width, std::int32_t physical_height, std::int32_t subpixel,
+      const char *make, const char *model, std::int32_t transform) {}
+    void
+    wl_mode(wl_output *wl_output, std::uint32_t flags,
+      std::int32_t width, std::int32_t height, std::int32_t refresh);
+    void
+    wl_done(wl_output *wl_output) {}
+    void
+    wl_scale(wl_output *wl_output, std::int32_t factor) {}
 
     void
     listen(zxdg_output_manager_v1 *output_manager);
@@ -130,7 +142,8 @@ namespace wl {
 
     platf::touch_port_t viewport;
 
-    zxdg_output_v1_listener listener;
+    wl_output_listener wl_listener;
+    zxdg_output_v1_listener xdg_listener;
   };
 
   class interface_t {

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -206,6 +206,10 @@ namespace wl {
     void
     roundtrip();
 
+    // Wait up to the timeout to read and dispatch new events
+    bool
+    dispatch(std::chrono::milliseconds timeout);
+
     // Get the registry associated with the display
     // No need to manually free the registry
     wl_registry *

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -313,6 +313,8 @@ namespace wl {
     alloc_img() override {
       auto img = std::make_shared<egl::img_descriptor_t>();
 
+      img->width = width;
+      img->height = height;
       img->sequence = 0;
       img->serial = std::numeric_limits<decltype(img->serial)>::max();
       img->data = nullptr;
@@ -334,16 +336,8 @@ namespace wl {
 
     int
     dummy_img(platf::img_t *img) override {
-      // TODO: stop cheating and give black image
-      if (!img) {
-        return -1;
-      };
-      auto pull_dummy_img_callback = [&img](std::shared_ptr<platf::img_t> &img_out) -> bool {
-        img_out = img->shared_from_this();
-        return true;
-      };
-      std::shared_ptr<platf::img_t> img_out;
-      return snapshot(pull_dummy_img_callback, img_out, 1000ms, false) != platf::capture_e::ok;
+      // Empty images are recognized as dummies by the zero sequence number
+      return 0;
     }
 
     std::uint64_t sequence {};

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -87,11 +87,11 @@ namespace wl {
     snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor) {
       auto to = std::chrono::steady_clock::now() + timeout;
 
+      // Dispatch events until we get a new frame or the timeout expires
       dmabuf.listen(interface.dmabuf_manager, output, cursor);
       do {
-        display.roundtrip();
-
-        if (to < std::chrono::steady_clock::now()) {
+        auto remaining_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(to - std::chrono::steady_clock::now());
+        if (remaining_time_ms.count() < 0 || !display.dispatch(remaining_time_ms)) {
           return platf::capture_e::timeout;
         }
       } while (dmabuf.status == dmabuf_t::WAITING);

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -182,12 +182,6 @@ namespace wl {
       }
 
       gl::ctx.BindTexture(GL_TEXTURE_2D, (*rgb_opt)->tex[0]);
-
-      int w, h;
-      gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
-      gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
-      BOOST_LOG(debug) << "width and height: w "sv << w << " h "sv << h;
-
       gl::ctx.GetTextureSubImage((*rgb_opt)->tex[0], 0, 0, 0, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
       gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
 


### PR DESCRIPTION
## Description
This PR fixes several bugs in the wlgrab capture code used for wlroots-derived compositors.

- wlgrab was using the logical size instead of the physical size for capture buffers, which caused problems for environments with a scaling factor != 1.0 (#238)

- wlgrab's `dummy_img()` was not safe to call on a separate thread (as required by `PARALLEL_ENCODING`), because it called `wl_display_dispatch()` which can block indefinitely when racing with another thread. When these races didn't lead to hangs, they would randomly lead to corrupt frames being captured that contained an amalgamation of metadata and buffers from partial frames that resulted in the `Couldn't import RGB Image: 0000300C` errors. This is fixed by updating VAAPI code to understand dummy images and sampling from a blank RGB texture instead of an imported DMA-BUF.  #1442

- wlgrab was calling `wl_display_roundtrip()` in a tight loop when waiting for a new frame. This function is nominally blocking but it just pings the compositor, so this was leading to high CPU usage while waiting for new frames. I've replaced this with a solution that uses the thread-safe event dispatching APIs and `poll()` to let us sleep until the compositor has new data for us.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #238
Fixes #1442


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
