### PR TITLE
Fix EGL import of YUV buffers with aux planes

### DIFF
--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -275,7 +275,7 @@ namespace egl {
   import_target(
     display_t::pointer egl_display,
     std::array<file_t, nv12_img_t::num_fds> &&fds,
-    const surface_descriptor_t &r8, const surface_descriptor_t &gr88);
+    const surface_descriptor_t &y, const surface_descriptor_t &uv);
 
   class cursor_t: public platf::img_t {
   public:


### PR DESCRIPTION
## Description
This is a follow up to beb51cc9255c9b0d9d316c4f461f16d415caf620, which fixed issues with EGL import for tiled formats but didn't fix aux planes. Aux planes are used for color compression in some modern Intel hardware.

It refactors the `EGLAttrib` array creation into a single function that is shared between RGB and YUV import functions and fully populates that `surface_descriptor_t` with _all_ provided planes in the YUV import codepath to resolve the aux plane issue.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #1041
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
