### PR TITLE
Implement graceful termination and group-based app lifetime tracking

### DIFF
--- a/docs/source/about/setup.rst
+++ b/docs/source/about/setup.rst
@@ -550,6 +550,8 @@ Application List
    - ``name`` - The name of the application/game
    - ``output`` - The file where the output of the command is stored
    - ``auto-detach`` - Specifies whether the app should be treated as detached if it exits quickly
+   - ``wait-all`` - Specifies whether to wait for all processes to terminate rather than just the initial process
+   - ``exit-timeout`` - Specifies how long to wait in seconds for the process to gracefully exit (default: 5 seconds)
    - ``prep-cmd`` - A list of commands to be run before/after the application
 
      - If any of the prep-commands fail, starting the application is aborted

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -618,6 +618,22 @@ namespace platf {
   void
   open_url(const std::string &url);
 
+  /**
+   * @brief Attempt to gracefully terminate a process group.
+   * @param native_handle The native handle of the process group.
+   * @return true if termination was successfully requested.
+   */
+  bool
+  request_process_group_exit(std::uintptr_t native_handle);
+
+  /**
+   * @brief Checks if a process group still has running children.
+   * @param native_handle The native handle of the process group.
+   * @return true if processes are still running.
+   */
+  bool
+  process_group_running(std::uintptr_t native_handle);
+
   input_t
   input();
   void

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -249,6 +249,33 @@ namespace platf {
     lifetime::exit_sunshine(0, true);
   }
 
+  /**
+   * @brief Attempt to gracefully terminate a process group.
+   * @param native_handle The process group ID.
+   * @return true if termination was successfully requested.
+   */
+  bool
+  request_process_group_exit(std::uintptr_t native_handle) {
+    if (kill(-((pid_t) native_handle), SIGTERM) == 0 || errno == ESRCH) {
+      BOOST_LOG(debug) << "Successfully sent SIGTERM to process group: "sv << native_handle;
+      return true;
+    }
+    else {
+      BOOST_LOG(warning) << "Unable to send SIGTERM to process group ["sv << native_handle << "]: "sv << errno;
+      return false;
+    }
+  }
+
+  /**
+   * @brief Checks if a process group still has running children.
+   * @param native_handle The process group ID.
+   * @return true if processes are still running.
+   */
+  bool
+  process_group_running(std::uintptr_t native_handle) {
+    return waitpid(-((pid_t) native_handle), nullptr, WNOHANG) >= 0;
+  }
+
   struct sockaddr_in
   to_sockaddr(boost::asio::ip::address_v4 address, uint16_t port) {
     struct sockaddr_in saddr_v4 = {};

--- a/src/process.h
+++ b/src/process.h
@@ -38,10 +38,16 @@ namespace proc {
     std::vector<cmd_t> prep_cmds;
 
     /**
-     * Some applications, such as Steam,
-     * either exit quickly, or keep running indefinitely.
-     * Steam.exe is one such application.
-     * That is why some applications need be run and forgotten about
+     * Some applications, such as Steam, either exit quickly, or keep running indefinitely.
+     *
+     * Apps that launch normal child processes and terminate will be handled by the process
+     * grouping logic (wait_all). However, apps that launch child processes indirectly or
+     * into another process group (such as UWP apps) can only be handled by the auto-detach
+     * heuristic which catches processes that exit 0 very quickly, but we won't have proper
+     * process tracking for those.
+     *
+     * For cases where users just want to kick off a background process and never manage the
+     * lifetime of that process, they can use detached commands for that.
      */
     std::vector<std::string> detached;
 
@@ -53,6 +59,8 @@ namespace proc {
     std::string id;
     bool elevated;
     bool auto_detach;
+    bool wait_all;
+    std::chrono::seconds exit_timeout;
   };
 
   class proc_t {

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -243,6 +243,28 @@
             a launcher-type app is detected, it is treated as a detached app.
           </div>
         </div>
+        <!-- wait for all processes -->
+        <div class="mb-3 form-check">
+          <label for="waitAll" class="form-check-label">Continue streaming until all app processes exit</label>
+          <input type="checkbox" class="form-check-input" id="waitAll" v-model="editForm['wait-all']"
+            true-value="true" false-value="false" />
+          <div class="form-text">
+            This will continue streaming until all processes started by the app have terminated.
+            When unchecked, streaming will stop when the initial app process exits, even if other
+            app processes are still running.
+          </div>
+        </div>
+        <!-- exit timeout -->
+        <div class="mb-3">
+          <label for="exitTimeout" class="form-label">Exit Timeout</label>
+          <input type="text" class="form-control monospace" id="exitTimeout" aria-describedby="exitTimeoutHelp"
+            v-model="editForm['exit-timeout']" />
+          <div id="exitTimeoutHelp" class="form-text">
+            Number of seconds to wait for all app processes to gracefully exit when requested to quit.<br>
+            If unset, the default is to wait up to 5 seconds. If set to zero or a negative value,
+            the app will be immediately terminated.
+          </div>
+        </div>
         <div class="mb-3">
           <label for="appImagePath" class="form-label">Image</label>
           <div class="input-group dropup">
@@ -412,6 +434,8 @@
           "exclude-global-prep-cmd": false,
           elevated: false,
           "auto-detach": true,
+          "wait-all": true,
+          "exit-timeout": 5,
           "prep-cmd": [],
           detached: [],
           "image-path": ""
@@ -433,6 +457,12 @@
         }
         if (this.editForm["auto-detach"] === undefined) {
           this.editForm["auto-detach"] = true;
+        }
+        if (this.editForm["wait-all"] === undefined) {
+          this.editForm["wait-all"] = true;
+        }
+        if (this.editForm["exit-timeout"] === undefined) {
+          this.editForm["exit-timeout"] = 5;
         }
         this.showEditForm = true;
       },


### PR DESCRIPTION
## Description
This PR introduces OS-specific graceful termination logic to allow apps to terminate normally rather than be abruptly killed when the client requests them to be stopped. On Windows, we send `WM_CLOSE` to all windows that are owned by processes in the app's process group. On Mac and Linux, we send `SIGTERM` to the process group.

This PR also introduces group-based app lifetime tracking which uses the process group to determine if the "app" is still running rather than just looking at the status of the first process we launched. This group-based tracking takes precedence over auto-detach if both are enabled and the initial process terminates after launching a child, since group-based tracking still allows full functionality of the running/not-running state and the Quit App button in Moonlight, unlike auto-detach. This feature should largely eliminate the need for using detached commands for "normal" apps.

I'm still keeping auto-detach around because there are some cases where a process may spawn a child into another process group or indirectly via another running process, which will still fool our group-based process tracking.

This PR also contains a fix to address a regression in #1974 that would cause abnormal termination of Sunshine if a process exited before the user quit it in Moonlight.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/e6dd6e03-9b21-4458-b122-d79cc2a6d7e9)

### Issues Fixed or Closed
Fixes #1997
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
