### PR TITLE
package/linux: Provide launchable tags in appstream metainfo file

### DIFF
--- a/packaging/linux/sunshine.appdata.xml
+++ b/packaging/linux/sunshine.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-    <id>@PROJECT_NAME@.desktop</id>
+    <id>@PROJECT_NAME@</id>
     <metadata_license>@PROJECT_LICENSE@</metadata_license>
     <project_license>@PROJECT_LICENSE@</project_license>
     <name>@PROJECT_NAME@</name>
@@ -11,6 +11,8 @@
             @PROJECT_LONG_DESCRIPTION@
         </p>
     </description>
+    <launchable type="desktop-id">sunshine.desktop</launchable>
+    <launchable type="url">https://localhost:47990</launchable>
     <screenshots>
         <screenshot type="default">
             <image>https://app.lizardbyte.dev/Sunshine/assets/images/AdobeStock_305732536_1920x1280.jpg</image>


### PR DESCRIPTION
## Description
By default the .desktop file gets installed to sunshine.desktop, as such provide the launchable tag for it to help `appstream-builder` "find" the .desktop file due to the id (Sunshine.desktop) not matching.

Rename the id to just @PRODUCT_NAME@ as well since the .desktop suffix is no longer required.

Provide URL as well.

Spec: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable

Fixes appstream-builder generation for this package in Solus.


### Screenshot
N/A


### Issues Fixed or Closed
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
