### PR TITLE
Implement pen and touch support for Linux

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -423,8 +423,6 @@ editing the `conf` file in a text editor. Use the examples as reference.
 
    This can be useful to disable for older applications without native pen/touch support.
 
-   .. caution:: Applies to Windows only.
-
 **Default**
    ``enabled``
 

--- a/src/input.h
+++ b/src/input.h
@@ -33,4 +33,7 @@ namespace input {
 
     float scalar_inv;
   };
+
+  std::pair<float, float>
+  scale_client_contact_area(const std::pair<float, float> &val, uint16_t rotation, const std::pair<float, float> &scalar);
 }  // namespace input

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -358,7 +358,7 @@
         </div>
 
         <!-- Native pen/touch support -->
-        <div class="mb-3" v-if="config.mouse === 'enabled' && platform === 'windows'">
+        <div class="mb-3" v-if="config.mouse === 'enabled'">
           <label for="native_pen_touch" class="form-label">Native Pen/Touch Support</label>
           <select id="native_pen_touch" class="form-select" v-model="config.native_pen_touch">
             <option value="disabled">Disabled</option>


### PR DESCRIPTION
## Description
The first commit resolves a longstanding issue with how Linux input was treating absolute mouse input. Rather than emulating an absolute pointing device, Sunshine was actually emulating a single-touch touchscreen. This lead to all sorts of strange things depending on how the desktop environment treats touch input. Most commonly, it caused the cursor to disappear when not moving or mouse clicks to go to the wrong window. Now we behave like the Linux [vmmouse](https://elixir.bootlin.com/linux/v6.7/source/drivers/input/mouse/vmmouse.c) driver with separate absolute and relative mouse devices.

The second commit implements native support for pen and touch on Linux. I've tested with a few apps under a GNOME Wayland session plus `evtest` and the events look sane to me.

Testing checklist:
- [x] GNOME Wayland
- [x] GNOME X11
- [x] KDE Wayland
- [x] Sway

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #1828
Closes #1706 (superseded)

<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
