### PR TITLE
Cross compiling

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -223,6 +223,11 @@ if (${SUNSHINE_TRAY} EQUAL 0 AND SUNSHINE_REQUIRE_TRAY)
     message(FATAL_ERROR "Tray icon is required")
 endif()
 
+pkg_check_modules(EVDEV libevdev REQUIRED)
+include_directories(SYSTEM ${EVDEV_INCLUDE_DIRS})
+link_directories(${EVDEV_LIBRARY_DIRS})
+list(APPEND SUNSHINE_EXTERNAL_LIBRARIES ${EVDEV_LIBRARIES})
+
 list(APPEND PLATFORM_TARGET_FILES
         src/platform/linux/publish.cpp
         src/platform/linux/graphics.h
@@ -241,13 +246,11 @@ list(APPEND PLATFORM_TARGET_FILES
 list(APPEND PLATFORM_LIBRARIES
         Boost::dynamic_linking
         dl
-        evdev
         numa
         pulse
         pulse-simple)
 
 include_directories(
         SYSTEM
-        /usr/include/libevdev-1.0
         third-party/nv-codec-headers/include
         third-party/glad/include)

--- a/docker/fedora-39-cross.dockerfile
+++ b/docker/fedora-39-cross.dockerfile
@@ -1,0 +1,164 @@
+# syntax=docker/dockerfile:1.4
+# artifacts: true
+# platforms: linux/amd64,linux/arm64/v8
+# platforms_pr: linux/amd64
+# no-cache-filters: sunshine-base,artifacts,sunshine
+ARG BASE=fedora
+ARG TAG=39
+FROM ${BASE}:${TAG} AS sunshine-base
+
+FROM sunshine-base as sunshine-build
+
+ARG TAG
+ARG TARGETARCH=aarch64
+ARG TUPLE=${TARGETARCH}-linux-gnu
+
+ENV TAG=${TAG}
+ENV TARGETARCH=${TARGETARCH}
+ENV TUPLE=${TUPLE}
+
+ARG BRANCH
+ARG BUILD_VERSION
+ARG COMMIT
+# note: BUILD_VERSION may be blank
+
+ENV BRANCH=${BRANCH}
+ENV BUILD_VERSION=${BUILD_VERSION}
+ENV COMMIT=${COMMIT}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# install build dependencies
+# hadolint ignore=DL3041
+RUN <<_DEPS
+#!/bin/bash
+set -e
+dnf -y update
+dnf -y install \
+  cmake-3.27.* \
+  gcc-"${TARGETARCH}"-linux-gnu-13.2.* \
+  gcc-c++-"${TARGETARCH}"-linux-gnu-13.2.* \
+  git-core \
+  nodejs \
+  pkgconf-pkg-config \
+  rpm-build \
+  wayland-devel \
+  wget \
+  which
+dnf clean all
+_DEPS
+
+# install host dependencies
+# hadolint ignore=DL3041
+RUN <<_DEPS
+#!/bin/bash
+set -e
+DNF=( dnf -y --installroot /mnt/cross --releasever "${TAG}" --forcearch "${TARGETARCH}" )
+"${DNF[@]}" install \
+  filesystem
+"${DNF[@]}" --setopt=tsflags=noscripts install \
+  $([[ "${TARGETARCH}" == x86_64 ]] && echo intel-mediasdk-devel) \
+  boost-devel-1.81.0* \
+  glibc-devel \
+  libappindicator-gtk3-devel \
+  libcap-devel \
+  libcurl-devel \
+  libdrm-devel \
+  libevdev-devel \
+  libnotify-devel \
+  libstdc++-devel \
+  libva-devel \
+  libvdpau-devel \
+  libX11-devel \
+  libxcb-devel \
+  libXcursor-devel \
+  libXfixes-devel \
+  libXi-devel \
+  libXinerama-devel \
+  libXrandr-devel \
+  libXtst-devel \
+  mesa-libGL-devel \
+  miniupnpc-devel \
+  numactl-devel \
+  openssl-devel \
+  opus-devel \
+  pulseaudio-libs-devel \
+  wayland-devel
+"${DNF[@]}" clean all
+_DEPS
+
+# todo - enable cuda once it's supported for gcc 13 and fedora 39
+## install cuda
+#WORKDIR /build/cuda
+## versions: https://developer.nvidia.com/cuda-toolkit-archive
+#ENV CUDA_VERSION="12.0.0"
+#ENV CUDA_BUILD="525.60.13"
+## hadolint ignore=SC3010
+#RUN <<_INSTALL_CUDA
+##!/bin/bash
+#set -e
+#cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
+#cuda_suffix=""
+#if [[ "${TARGETARCH}" == aarch64 ]]; then
+#  cuda_suffix="_sbsa"
+#fi
+#url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
+#echo "cuda url: ${url}"
+#wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
+#chmod a+x ./cuda.run
+#./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
+#rm ./cuda.run
+#_INSTALL_CUDA
+
+# copy repository
+WORKDIR /build/sunshine/
+COPY --link .. .
+
+# setup build directory
+WORKDIR /build/sunshine/build
+
+# cmake and cpack
+# todo - add cmake argument back in for cuda support "-DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \"
+# todo - re-enable "DSUNSHINE_ENABLE_CUDA"
+RUN <<_MAKE
+#!/bin/bash
+set -e
+
+cat > toolchain.cmake <<_TOOLCHAIN
+set(CMAKE_ASM_COMPILER "${TUPLE}-gcc")
+set(CMAKE_ASM-ATT_COMPILER "${TUPLE}-gcc")
+set(CMAKE_C_COMPILER "${TUPLE}-gcc")
+set(CMAKE_CXX_COMPILER "${TUPLE}-g++")
+set(CMAKE_AR "${TUPLE}-gcc-ar" CACHE FILEPATH "Archive manager" FORCE)
+set(CMAKE_RANLIB "${TUPLE}-gcc-ranlib" CACHE FILEPATH "Archive index generator" FORCE)
+set(CMAKE_SYSTEM_PROCESSOR "${TARGETARCH}")
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_SYSROOT "/mnt/cross")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+_TOOLCHAIN
+
+export \
+    CXXFLAGS="-isystem $(echo /mnt/cross/usr/include/c++/[0-9]*/) -isystem $(echo /mnt/cross/usr/include/c++/[0-9]*/${TUPLE%%-*}-*/)" \
+    LDFLAGS="-L$(echo /mnt/cross/usr/lib/gcc/${TUPLE%%-*}-*/[0-9]*/)" \
+    PKG_CONFIG_LIBDIR=/mnt/cross/usr/lib64/pkgconfig:/mnt/cross/usr/share/pkgconfig \
+    PKG_CONFIG_SYSROOT_DIR=/mnt/cross \
+    PKG_CONFIG_SYSTEM_INCLUDE_PATH=/mnt/cross/usr/include \
+    PKG_CONFIG_SYSTEM_LIBRARY_PATH=/mnt/cross/usr/lib64
+
+cmake \
+  -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCPACK_RPM_PACKAGE_ARCHITECTURE="${TARGETARCH}" \
+  -DSUNSHINE_ASSETS_DIR=share/sunshine \
+  -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
+  -DSUNSHINE_ENABLE_WAYLAND=ON \
+  -DSUNSHINE_ENABLE_X11=ON \
+  -DSUNSHINE_ENABLE_DRM=ON \
+  -DSUNSHINE_ENABLE_CUDA=OFF \
+  /build/sunshine
+make -j "$(nproc)"
+cpack -G RPM
+_MAKE

--- a/docker/ubuntu-22.04-cross.dockerfile
+++ b/docker/ubuntu-22.04-cross.dockerfile
@@ -1,0 +1,174 @@
+# syntax=docker/dockerfile:1.4
+# artifacts: true
+# platforms: linux/amd64,linux/arm64/v8
+# platforms_pr: linux/amd64
+# no-cache-filters: sunshine-base,artifacts,sunshine
+ARG BASE=ubuntu
+ARG TAG=22.04
+FROM ${BASE}:${TAG} AS sunshine-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+FROM sunshine-base as sunshine-build
+
+ARG TAG
+ARG TARGETARCH=arm64
+ARG TUPLE=aarch64-linux-gnu
+
+ENV TAG=${TAG}
+ENV TARGETARCH=${TARGETARCH}
+ENV TUPLE=${TUPLE}
+
+ARG BRANCH
+ARG BUILD_VERSION
+ARG COMMIT
+# note: BUILD_VERSION may be blank
+
+ENV BRANCH=${BRANCH}
+ENV BUILD_VERSION=${BUILD_VERSION}
+ENV COMMIT=${COMMIT}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# install dependencies
+RUN --mount=type=cache,target=/var/cache/apt/archives,mode=0755,id=ubuntu-22.04-apt <<_DEPS
+#!/bin/bash
+set -e
+
+# Keep downloaded archives in the cache.
+rm /etc/apt/apt.conf.d/docker-clean
+
+source /etc/lsb-release
+dpkg --add-architecture "${TARGETARCH}"
+sed -i "s/^deb /deb [arch=$(dpkg --print-architecture)] /" /etc/apt/sources.list
+
+cat > /etc/apt/sources.list.d/ports.list <<_SOURCES
+deb [arch=${TARGETARCH}] http://ports.ubuntu.com/ ${DISTRIB_CODENAME} main restricted universe
+deb [arch=${TARGETARCH}] http://ports.ubuntu.com/ ${DISTRIB_CODENAME}-updates main restricted universe
+_SOURCES
+apt-get update -y
+
+apt-get install -y --no-install-recommends \
+  apt-transport-https \
+  ca-certificates \
+  gnupg \
+  wget
+
+if [[ "${TARGETARCH}" == arm64 ]]; then
+  CUDA_REPO="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${DISTRIB_RELEASE//.}"
+  wget -O - "${CUDA_REPO}/x86_64/3bf863cc.pub" | apt-key add -
+  cat > /etc/apt/sources.list.d/cuda.list <<_SOURCES
+  deb [arch=$(dpkg --print-architecture)] ${CUDA_REPO}/cross-linux-sbsa/ /
+  deb [arch=$(dpkg --print-architecture)] ${CUDA_REPO}/$(uname -m)/ /
+_SOURCES
+  apt-get update -y
+fi
+
+apt-get install -y --no-install-recommends \
+  $([[ "${TARGETARCH}" == arm64 ]] && echo cuda-{cudart-cross-sbsa,nvcc-cross-sbsa,nvcc}-12-3) \
+  cmake=3.22.* \
+  gcc-"${TUPLE}" \
+  g++-"${TUPLE}" \
+  git \
+  libwayland-bin \
+  pkgconf \
+  $([[ "${TARGETARCH}" == amd64 ]] && echo libmfx-dev:"${TARGETARCH}") \
+  libayatana-appindicator3-dev:"${TARGETARCH}" \
+  libavdevice-dev:"${TARGETARCH}" \
+  libboost-filesystem-dev:"${TARGETARCH}"=1.74.* \
+  libboost-locale-dev:"${TARGETARCH}"=1.74.* \
+  libboost-log-dev:"${TARGETARCH}"=1.74.* \
+  libboost-program-options-dev:"${TARGETARCH}"=1.74.* \
+  libcap-dev:"${TARGETARCH}" \
+  libcurl4-openssl-dev:"${TARGETARCH}" \
+  libdrm-dev:"${TARGETARCH}" \
+  libevdev-dev:"${TARGETARCH}" \
+  libminiupnpc-dev:"${TARGETARCH}" \
+  libnotify-dev:"${TARGETARCH}" \
+  libnuma-dev:"${TARGETARCH}" \
+  libopus-dev:"${TARGETARCH}" \
+  libpulse-dev:"${TARGETARCH}" \
+  libssl-dev:"${TARGETARCH}" \
+  libva-dev:"${TARGETARCH}" \
+  libvdpau-dev:"${TARGETARCH}" \
+  libwayland-dev:"${TARGETARCH}" \
+  libx11-dev:"${TARGETARCH}" \
+  libxcb-shm0-dev:"${TARGETARCH}" \
+  libxcb-xfixes0-dev:"${TARGETARCH}" \
+  libxcb1-dev:"${TARGETARCH}" \
+  libxfixes-dev:"${TARGETARCH}" \
+  libxrandr-dev:"${TARGETARCH}" \
+  libxtst-dev:"${TARGETARCH}"
+
+rm -rf /var/lib/apt/lists/*
+_DEPS
+
+#Install Node
+# hadolint ignore=SC1091
+RUN <<_INSTALL_NODE
+#!/bin/bash
+set -e
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
+source "$HOME/.nvm/nvm.sh"
+nvm install 20.9.0
+nvm use 20.9.0
+_INSTALL_NODE
+
+# copy repository
+WORKDIR /build/sunshine/
+COPY --link .. .
+
+# setup build directory
+WORKDIR /build/sunshine/build
+
+# cmake and cpack
+# hadolint ignore=SC1091
+RUN <<_MAKE
+#!/bin/bash
+set -e
+
+# Set Node version
+source "$HOME/.nvm/nvm.sh"
+nvm use 20.9.0
+
+# Configure build
+cat > toolchain.cmake <<_TOOLCHAIN
+set(CMAKE_ASM_COMPILER "${TUPLE}-gcc")
+set(CMAKE_ASM-ATT_COMPILER "${TUPLE}-gcc")
+set(CMAKE_C_COMPILER "${TUPLE}-gcc")
+set(CMAKE_CXX_COMPILER "${TUPLE}-g++")
+set(CMAKE_AR "${TUPLE}-gcc-ar" CACHE FILEPATH "Archive manager" FORCE)
+set(CMAKE_RANLIB "${TUPLE}-gcc-ranlib" CACHE FILEPATH "Archive index generator" FORCE)
+set(CMAKE_SYSTEM_PROCESSOR "$(case ${TARGETARCH} in
+    armhf) echo armv7l ;;
+    arm64) echo aarch64 ;;
+    ppc64el) echo ppc64le ;;
+    x86_64) echo amd64 ;;
+    *) echo ${TARGETARCH} ;;
+esac)")
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+_TOOLCHAIN
+
+export \
+    PKG_CONFIG_LIBDIR=/usr/lib/"${TUPLE}"/pkgconfig:/usr/share/pkgconfig
+
+# Actually build
+cmake \
+  -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake \
+  -DCMAKE_CUDA_COMPILER:PATH=/usr/local/cuda/bin/nvcc \
+  -DCMAKE_CUDA_HOST_COMPILER:PATH="${TUPLE}-g++" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE="${TARGETARCH}" \
+  -DSUNSHINE_ASSETS_DIR=share/sunshine \
+  -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
+  -DSUNSHINE_ENABLE_WAYLAND=ON \
+  -DSUNSHINE_ENABLE_X11=ON \
+  -DSUNSHINE_ENABLE_DRM=ON \
+  -DSUNSHINE_ENABLE_CUDA=$([[ "${TARGETARCH}" == arm64 ]] && echo ON || echo OFF) \
+  /build/sunshine
+make -j "$(nproc)"
+cpack -G DEB
+_MAKE


### PR DESCRIPTION
You wanted to know how to cross-compile for faster CI builds. I have prepared this as a Dockerfile for Fedora 39. This can be run with `TARGETARCH=aarch64` or `TARGETARCH=ppc64le`. It produces an RPM. On my own machine, it takes less than 5 minutes.

I'm not suggesting you take this as-is but work it into your CI somehow. This was just an easy way for me to experiment and for you to try it out.

The `CXXFLAGS` and `LDFLAGS` variables work around some difficulty Fedora has in locating the C++ headers and libraries. Other than that though, it feels very clean, with it basically using what Fedora already provides.

Debian and Ubuntu could use a similar approach, but I think their "multiarch" support means you would normally do it differently.