### PR TITLE
Video encryption

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -838,6 +838,64 @@ keybindings
 
       external_ip = 123.456.789.12
 
+`lan_encryption_mode <https://localhost:47990/config/#lan_encryption_mode>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   This determines when encryption will be used when streaming over your local network.
+
+   .. warning:: Encryption can reduce streaming performance, particularly on less powerful hosts and clients.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   =====     ===========
+   Value     Description
+   =====     ===========
+   0         encryption will not be used
+   1         encryption will be used if the client supports it
+   2         encryption is mandatory and unencrypted connections are rejected
+   =====     ===========
+
+**Default**
+   ``0``
+
+**Example**
+   .. code-block:: text
+
+      lan_encryption_mode = 0
+
+`wan_encryption_mode <https://localhost:47990/config/#wan_encryption_mode>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   This determines when encryption will be used when streaming over the Internet.
+
+   .. warning:: Encryption can reduce streaming performance, particularly on less powerful hosts and clients.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   =====     ===========
+   Value     Description
+   =====     ===========
+   0         encryption will not be used
+   1         encryption will be used if the client supports it
+   2         encryption is mandatory and unencrypted connections are rejected
+   =====     ===========
+
+**Default**
+   ``1``
+
+**Example**
+   .. code-block:: text
+
+      wan_encryption_mode = 1
+
 `ping_timeout <https://localhost:47990/config/#ping_timeout>`__
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -376,7 +376,10 @@ namespace config {
     APPS_JSON_PATH,
 
     20,  // fecPercentage
-    1  // channels
+    1,  // channels
+
+    ENCRYPTION_MODE_NEVER,  // lan_encryption_mode
+    ENCRYPTION_MODE_OPPORTUNISTIC,  // wan_encryption_mode
   };
 
   nvhttp_t nvhttp {
@@ -1015,6 +1018,9 @@ namespace config {
     }
 
     int_between_f(vars, "channels", stream.channels, { 1, std::numeric_limits<int>::max() });
+
+    int_between_f(vars, "lan_encryption_mode", stream.lan_encryption_mode, { 0, 2 });
+    int_between_f(vars, "wan_encryption_mode", stream.wan_encryption_mode, { 0, 2 });
 
     path_f(vars, "file_apps", stream.file_apps);
     int_between_f(vars, "fec_percentage", stream.fec_percentage, { 1, 255 });

--- a/src/config.h
+++ b/src/config.h
@@ -76,6 +76,10 @@ namespace config {
     bool install_steam_drivers;
   };
 
+  constexpr int ENCRYPTION_MODE_NEVER = 0;  // Never use video encryption, even if the client supports it
+  constexpr int ENCRYPTION_MODE_OPPORTUNISTIC = 1;  // Use video encryption if available, but stream without it if not supported
+  constexpr int ENCRYPTION_MODE_MANDATORY = 2;  // Always use video encryption and refuse clients that can't encrypt
+
   struct stream_t {
     std::chrono::milliseconds ping_timeout;
 
@@ -85,6 +89,10 @@ namespace config {
 
     // max unique instances of video and audio streams
     int channels;
+
+    // Video encryption settings for LAN and WAN streams
+    int lan_encryption_mode;
+    int wan_encryption_mode;
   };
 
   struct nvhttp_t {

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -23,7 +23,7 @@ namespace crypto {
 
   using sha256_t = std::array<std::uint8_t, SHA256_DIGEST_LENGTH>;
 
-  using aes_t = std::array<std::uint8_t, 16>;
+  using aes_t = std::vector<std::uint8_t>;
   using x509_t = util::safe_ptr<X509, X509_free>;
   using x509_store_t = util::safe_ptr<X509_STORE, X509_STORE_free>;
   using x509_store_ctx_t = util::safe_ptr<X509_STORE_CTX, X509_STORE_CTX_free>;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -44,7 +44,7 @@ namespace net {
 
   net_e
   from_address(const std::string_view &view) {
-    auto addr = ip::make_address(view);
+    auto addr = normalize_address(ip::make_address(view));
 
     if (addr.is_v6()) {
       for (auto &range : pc_ips_v6) {

--- a/src/network.h
+++ b/src/network.h
@@ -59,6 +59,15 @@ namespace net {
   af_to_any_address_string(af_e af);
 
   /**
+   * @brief Converts an address to a normalized form.
+   * @details Normalization converts IPv4-mapped IPv6 addresses into IPv4 addresses.
+   * @param address The address to normalize.
+   * @return Normalized address.
+   */
+  boost::asio::ip::address
+  normalize_address(boost::asio::ip::address address);
+
+  /**
    * @brief Returns the given address in normalized string form.
    * @details Normalization converts IPv4-mapped IPv6 addresses into IPv4 addresses.
    * @param address The address to normalize.

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -796,7 +796,7 @@ namespace rtsp_stream {
       return;
     }
 
-    auto session = stream::session::alloc(config, launch_session->gcm_key, launch_session->iv, launch_session->av_ping_payload, launch_session->control_connect_data);
+    auto session = stream::session::alloc(config, *launch_session);
 
     auto slot = server->accept(session);
     if (!slot) {

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -5,6 +5,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 
 extern "C" {
+#include <moonlight-common-c/src/Limelight-internal.h>
 #include <moonlight-common-c/src/Rtsp.h>
 }
 
@@ -705,6 +706,7 @@ namespace rtsp_stream {
     args.try_emplace("x-nv-vqos[0].qosTrafficType"sv, "5"sv);
     args.try_emplace("x-nv-aqos.qosTrafficType"sv, "4"sv);
     args.try_emplace("x-ml-video.configuredBitrateKbps"sv, "0"sv);
+    args.try_emplace("x-ss-general.encryptionEnabled"sv, "0"sv);
 
     stream::config_t config;
 
@@ -721,10 +723,15 @@ namespace rtsp_stream {
       config.controlProtocolType = util::from_view(args.at("x-nv-general.useReliableUdp"sv));
       config.packetsize = util::from_view(args.at("x-nv-video[0].packetSize"sv));
       config.minRequiredFecPackets = util::from_view(args.at("x-nv-vqos[0].fec.minRequiredFecPackets"sv));
-      config.nvFeatureFlags = util::from_view(args.at("x-nv-general.featureFlags"sv));
       config.mlFeatureFlags = util::from_view(args.at("x-ml-general.featureFlags"sv));
       config.audioQosType = util::from_view(args.at("x-nv-aqos.qosTrafficType"sv));
       config.videoQosType = util::from_view(args.at("x-nv-vqos[0].qosTrafficType"sv));
+      config.encryptionFlagsEnabled = util::from_view(args.at("x-ss-general.encryptionEnabled"sv));
+
+      // Legacy clients use nvFeatureFlags to indicate support for audio encryption
+      if (util::from_view(args.at("x-nv-general.featureFlags"sv)) & 0x20) {
+        config.encryptionFlagsEnabled |= SS_ENC_AUDIO;
+      }
 
       config.monitor.height = util::from_view(args.at("x-nv-video[0].clientViewportHt"sv));
       config.monitor.width = util::from_view(args.at("x-nv-video[0].clientViewportWd"sv));

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -518,14 +518,22 @@ namespace rtsp_stream {
     std::stringstream ss;
 
     // Tell the client about our supported features
-    ss << "a=x-ss-general.featureFlags: " << (uint32_t) platf::get_capabilities() << std::endl;
+    ss << "a=x-ss-general.featureFlags:" << (uint32_t) platf::get_capabilities() << std::endl;
+
+    // Always request new control stream encryption if the client supports it
+    uint32_t encryption_flags_supported = SS_ENC_CONTROL_V2 | SS_ENC_AUDIO;
+    uint32_t encryption_flags_requested = SS_ENC_CONTROL_V2;
+
+    // Report supported and required encryption flags
+    ss << "a=x-ss-general.encryptionSupported:" << encryption_flags_supported << std::endl;
+    ss << "a=x-ss-general.encryptionRequested:" << encryption_flags_requested << std::endl;
+
+    if (video::last_encoder_probe_supported_ref_frames_invalidation) {
+      ss << "a=x-nv-video[0].refPicInvalidation:1"sv << std::endl;
+    }
 
     if (video::active_hevc_mode != 1) {
       ss << "sprop-parameter-sets=AAAAAU"sv << std::endl;
-    }
-
-    if (video::last_encoder_probe_supported_ref_frames_invalidation) {
-      ss << "x-nv-video[0].refPicInvalidation=1"sv << std::endl;
     }
 
     if (video::active_av1_mode != 1) {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -235,9 +235,9 @@ namespace stream {
   // return bytes written on success
   // return -1 on error
   static inline int
-  encode_audio(int featureSet, const audio::buffer_t &plaintext, audio_packet_t &destination, std::uint32_t avRiKeyIv, crypto::cipher::cbc_t &cbc) {
+  encode_audio(bool encrypted, const audio::buffer_t &plaintext, audio_packet_t &destination, std::uint32_t avRiKeyIv, crypto::cipher::cbc_t &cbc) {
     // If encryption isn't enabled
-    if (!(featureSet & 0x20)) {
+    if (!encrypted) {
       std::copy(std::begin(plaintext), std::end(plaintext), destination->payload());
       return plaintext.size();
     }
@@ -1415,7 +1415,7 @@ namespace stream {
       // For now, encode_audio needs it to be the proper sequenceNumber
       audio_packet->rtp.sequenceNumber = sequenceNumber;
 
-      auto bytes = encode_audio(session->config.nvFeatureFlags, packet_data, audio_packet, session->audio.avRiKeyId, session->audio.cipher);
+      auto bytes = encode_audio(session->config.encryptionFlagsEnabled & SS_ENC_AUDIO, packet_data, audio_packet, session->audio.avRiKeyId, session->audio.cipher);
       if (bytes < 0) {
         BOOST_LOG(error) << "Couldn't encode audio packet"sv;
         break;

--- a/src/stream.h
+++ b/src/stream.h
@@ -22,11 +22,12 @@ namespace stream {
 
     int packetsize;
     int minRequiredFecPackets;
-    int nvFeatureFlags;
     int mlFeatureFlags;
     int controlProtocolType;
     int audioQosType;
     int videoQosType;
+
+    uint32_t encryptionFlagsEnabled;
 
     std::optional<int> gcmap;
   };

--- a/src/stream.h
+++ b/src/stream.h
@@ -40,7 +40,7 @@ namespace stream {
     };
 
     std::shared_ptr<session_t>
-    alloc(config_t &config, crypto::aes_t &gcm_key, crypto::aes_t &iv, std::string_view av_ping_payload, uint32_t control_connect_data);
+    alloc(config_t &config, rtsp_stream::launch_session_t &launch_session);
     int
     start(session_t &session, const std::string &addr_string);
     void

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -668,6 +668,46 @@
           </div>
         </div>
 
+        <!-- LAN Encryption Mode -->
+        <div class="mb-3">
+          <label for="lan_encryption_mode" class="form-label">LAN Encryption Mode</label>
+          <select id="lan_encryption_mode" class="form-select" v-model="config.lan_encryption_mode">
+            <option value="0">
+              Disabled (default)
+            </option>
+            <option value="1">
+              Enabled for supported clients
+            </option>
+            <option value="2">
+              Required for all clients
+            </option>
+          </select>
+          <div class="form-text">
+            This determines when encryption will be used when streaming over your local network.<br>
+            Encryption can reduce streaming performance, particularly on less powerful hosts and clients.
+          </div>
+        </div>
+
+        <!-- WAN Encryption Mode -->
+        <div class="mb-3">
+          <label for="wan_encryption_mode" class="form-label">WAN Encryption Mode</label>
+          <select id="wan_encryption_mode" class="form-select" v-model="config.wan_encryption_mode">
+            <option value="0">
+              Disabled
+            </option>
+            <option value="1">
+              Enabled for supported clients (default)
+            </option>
+            <option value="2">
+              Required for all clients
+            </option>
+          </select>
+          <div class="form-text">
+            This determines when encryption will be used when streaming over the Internet.<br>
+            Encryption can reduce streaming performance, particularly on less powerful hosts and clients.
+          </div>
+        </div>
+
         <!-- Ping Timeout -->
         <div class="mb-3">
           <label for="ping_timeout" class="form-label">Ping Timeout</label>
@@ -1155,6 +1195,8 @@
               "origin_web_ui_allowed": "lan",
               "upnp": "disabled",
               "external_ip": "",
+              "lan_encryption_mode": 0,
+              "wan_encryption_mode": 1,
               "ping_timeout": 10000,
             },
           },


### PR DESCRIPTION
## Description
This PR does some refactoring of encryption-related code and implements video encryption and newer control stream encryption scheme. The main functional changes are https://github.com/LizardByte/Sunshine/pull/2025/commits/466492ba17ef36fcf7c4449610f0990b859b0608 and https://github.com/LizardByte/Sunshine/pull/2025/commits/2ac9ab2108f2866f3cf84343ed1bb29624f66942.

From the user perspective, this PR gives the user 3 options for both WAN and LAN connections:
- `ENCRYPTION_MODE_NEVER` - Never use video encryption even if the client supports (default for LAN)
- `ENCRYPTION_MODE_OPPORTUNISTIC` - Use video encryption if the client supports it but allow unencrypted connections from older/slower clients (default for WAN)
- `ENCRYPTION_MODE_MANDATORY` - Require video encryption for all connections. Unencrypted connections from older clients are rejected.

The new scheme is negotiated using new SDP attributes and [new flags](https://github.com/moonlight-stream/moonlight-common-c/blob/298f356acbb57f56863680d41c0d307a2fd5cb91/src/Limelight-internal.h#L47-L50):
- `x-ss-general.encryptionSupported` - Sent from host to client in RTSP DESCRIBE to indicate which encryption features are supported by the host
- `x-ss-general.encryptionRequested` - Sent from host to client in RTSP DESCRIBE to indicate which encryption features are explicitly requested by the host
- `x-ss-general.encryptionEnabled` - Sent from the client to host in RTSP ANNOUNCE to inform the host which encryption features will be enabled for the session

The distinction between "supported" and "requested" primarily is down to which side of the connection determines whether the feature will be used. For features that are "supported" but not "requested" (`ENCRYPTION_MODE_OPPORTUNISTIC`), the client will pick whether the feature is used (based on `ENCFLG_` values in the `STREAM_CONFIGURATION`). For features that are "requested" (`ENCRYPTION_MODE_MANDATORY`), the client will always use the feature even if it wasn't opted-in via the corresponding `ENCFLG_` value.

The encryption itself is AES-128-GCM, like control stream encryption. I chose this over AES-128-CBC (used by audio encryption), because I wanted to avoid any forged packets getting to the video decoder, since parsing logic in decoders is often targeted via specially crafted media exploits. The IV and tag are prepended to the video packets, which allows us to reuse the existing encryption/decryption functions in Sunshine and Moonlight, and also encrypt packets in-place on the Sunshine side.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/a575a5e6-4781-47fd-83f8-fd81401649e4)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
