### PR TITLE
Reenumerate displays when the display is reinitialized or switched

### DIFF
--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1036,8 +1036,9 @@ namespace platf {
 
         auto fb = card.fb(plane.get());
         if (!fb) {
-          BOOST_LOG(error) << "Couldn't get drm fb for plane ["sv << plane->fb_id << "]: "sv << strerror(errno);
-          return capture_e::error;
+          // This can happen if the display is being reconfigured while streaming
+          BOOST_LOG(warning) << "Couldn't get drm fb for plane ["sv << plane->fb_id << "]: "sv << strerror(errno);
+          return capture_e::timeout;
         }
 
         if (!fb->handles[0]) {

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -376,11 +376,15 @@ namespace platf::dxgi {
     // Check if we can use the Desktop Duplication API on this output
     for (int x = 0; x < 2; ++x) {
       dup_t dup;
+
+      // Ensure we can duplicate the current display
+      syncThreadDesktop();
+
       status = output1->DuplicateOutput((IUnknown *) device.get(), &dup);
       if (SUCCEEDED(status)) {
         return true;
       }
-      Sleep(200);
+      std::this_thread::sleep_for(200ms);
     }
 
     BOOST_LOG(error) << "DuplicateOutput() test failed [0x"sv << util::hex(status).to_string_view() << ']';
@@ -404,9 +408,6 @@ namespace platf::dxgi {
 
       FreeLibrary(user32);
     });
-
-    // Ensure we can duplicate the current display
-    syncThreadDesktop();
 
     // Get rectangle of full desktop for absolute mouse coordinates
     env_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
@@ -679,6 +680,9 @@ namespace platf::dxgi {
 
         // We try this twice, in case we still get an error on reinitialization
         for (int x = 0; x < 2; ++x) {
+          // Ensure we can duplicate the current display
+          syncThreadDesktop();
+
           status = output5->DuplicateOutput1((IUnknown *) device.get(), 0, supported_formats.size(), supported_formats.data(), &dup.dup);
           if (SUCCEEDED(status)) {
             break;
@@ -705,6 +709,9 @@ namespace platf::dxgi {
         }
 
         for (int x = 0; x < 2; ++x) {
+          // Ensure we can duplicate the current display
+          syncThreadDesktop();
+
           status = output1->DuplicateOutput((IUnknown *) device.get(), &dup.dup);
           if (SUCCEEDED(status)) {
             break;


### PR DESCRIPTION
## Description
This PR fixes a bug in Linux KMS capture where changing the display resolution while streaming would cause the stream image to become garbled. The issue turned out to be a mismatch between the Wayland viewports (enumerated in `kms_display_names()` once before the stream starts) and the actual framebuffer size (which can change when the display is reinitialized). The mismatch causes various GL errors and corrupt output.

This change also addresses the Windows issue of GPU driver updates while streaming causing Sunshine to hang due to all the old displays going away.

I've also included additional fixes for bugs discovered while testing, including:
- Fixed delayed switch to UAC secure desktop
- Fixed stream disconnecting with KMS grab when changing the desktop resolution in X11

Testing checklist:
- [x] Linux KMS Capture
- [x] Linux X11 Capture
- [x] Linux NvFBC Capture
- [x] Linux Wlroots Capture
- [x] Windows
- [x] Driver update during stream
- [x] Display switching

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
