### PR TITLE
fix(linux)!: use XDG spec for fetching Linux configuration directory

### DIFF
--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -99,12 +99,19 @@ namespace platf {
 
   fs::path
   appdata() {
-    const char *homedir;
-    if ((homedir = getenv("HOME")) == nullptr) {
-      homedir = getpwuid(geteuid())->pw_dir;
+    const char *dir;
+
+    if ((dir = getenv("CONFIGURATION_DIRECTORY")) != nullptr) {
+      return fs::path { dir } / "sunshine"sv;
+    }
+    if ((dir = getenv("XDG_CONFIG_HOME")) != nullptr) {
+      return fs::path { dir } / "sunshine"sv;
+    }
+    if ((dir = getenv("HOME")) == nullptr) {
+      dir = getpwuid(geteuid())->pw_dir;
     }
 
-    return fs::path { homedir } / ".config/sunshine"sv;
+    return fs::path { dir } / ".config/sunshine"sv;
   }
 
   std::string

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -101,9 +101,12 @@ namespace platf {
   appdata() {
     const char *dir;
 
+    // May be set if running under a systemd service with the ConfigurationDirectory= option set.
     if ((dir = getenv("CONFIGURATION_DIRECTORY")) != nullptr) {
       return fs::path { dir } / "sunshine"sv;
     }
+    // Otherwise, follow the XDG base directory specification:
+    // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
     if ((dir = getenv("XDG_CONFIG_HOME")) != nullptr) {
       return fs::path { dir } / "sunshine"sv;
     }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Makes Sunshine follow the XDG Base Directory specification when setting the configuration directory under Linux:
>  $XDG_CONFIG_HOME defines the base directory relative to which user-specific configuration files should be stored. If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used. 

https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

Additionally, following this change `$CONFIGURATION_DIRECTORY` will also be checked and used, if set. This is used by systemd services that explicitly specify a `ConfigurationDirectory=` option:
https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=



This should have minimal to no impact on existing Sunshine instances, since users with `$XDG_CONFIG_HOME` set will typically have their Sunshine instance still look for files in `$HOME/.config` . 
Existing Sunshine instances running under e.g a hand-made systemd service may have an unexpected configuration directory change, if they're using `ConfigurationDirectory=` , but I think this is a very niche use-case. Still labeling as a breaking change, just in case.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
N/A

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
I thought of putting a link to the spec above my changes, but I didn't see anything like that elsewhere in the code.
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
N/A (?)

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
