### PR TITLE
Name and unpair individual clients

### DIFF
--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -9,6 +9,9 @@
 // standard includes
 #include <string>
 
+// lib includes
+#include <boost/property_tree/ptree.hpp>
+
 // local includes
 #include "thread_safe.h"
 
@@ -43,7 +46,11 @@ namespace nvhttp {
   void
   start();
   bool
-  pin(std::string pin);
+  pin(std::string pin, std::string name);
+  int
+  unpair_client(std::string uniqueid);
+  boost::property_tree::ptree
+  get_all_clients();
   void
   erase_all_clients();
 }  // namespace nvhttp

--- a/src_assets/common/assets/web/pin.html
+++ b/src_assets/common/assets/web/pin.html
@@ -25,7 +25,7 @@
 
 <script type="module">
   import { createApp } from 'vue'
-  import i18n from './locale.js'
+  import i18nLocale from './locale.js'
   import Navbar from './Navbar.vue'
   import {initApp} from "./init";
 
@@ -35,8 +35,9 @@
     }
   });
 
-  initApp(app, (app => {
+  initApp(app, (async app => {
     // this must be after mounting the app
+    const i18n = await i18nLocale()
     document.querySelector("#form").addEventListener("submit", (e) => {
       e.preventDefault();
       let pin = document.querySelector("#pin-input").value;

--- a/src_assets/common/assets/web/pin.html
+++ b/src_assets/common/assets/web/pin.html
@@ -9,7 +9,7 @@
   <Navbar></Navbar>
   <div id="content" class="container">
     <h1 class="my-4 text-center">{{ $t('pin.pin_pairing') }}</h1>
-    <form action="" class="form d-flex flex-column align-items-center" id="form">
+    <form class="form d-flex flex-column align-items-center" id="form" @submit.prevent="registerDevice">
       <div class="card flex-column d-flex p-4 mb-4">
         <input type="text" pattern="\d*" :placeholder="`${$t('navbar.pin')}`" autofocus id="pin-input" class="form-control mt-2" required />
         <input type="text" :placeholder="`${$t('pin.device_name')}`" id="name-input" class="form-control my-4" required />
@@ -25,40 +25,38 @@
 
 <script type="module">
   import { createApp } from 'vue'
-  import i18nLocale from './locale.js'
+  import { initApp } from './init'
   import Navbar from './Navbar.vue'
-  import {initApp} from "./init";
 
   let app = createApp({
     components: {
       Navbar
+    },
+    inject: ['i18n'],
+    methods: {
+      registerDevice(e) {
+        let pin = document.querySelector("#pin-input").value;
+        let name = document.querySelector("#name-input").value;
+        document.querySelector("#status").innerHTML = "";
+        let b = JSON.stringify({pin: pin, name: name});
+        fetch("/api/pin", {method: "POST", body: b})
+          .then((response) => response.json())
+          .then((response) => {
+            if (response.status.toString().toLowerCase() === "true") {
+              document.querySelector(
+                "#status"
+              ).innerHTML = `<div class="alert alert-success" role="alert">${this.i18n.t('pin.pair_success')}</div>`;
+              document.querySelector("#pin-input").value = "";
+              document.querySelector("#name-input").value = "";
+            } else {
+              document.querySelector(
+                "#status"
+              ).innerHTML = `<div class="alert alert-danger" role="alert">${this.i18n.t('pin.pair_failure')}</div>`;
+            }
+          });
+      }
     }
   });
 
-  initApp(app, (async app => {
-    // this must be after mounting the app
-    const i18n = await i18nLocale()
-    document.querySelector("#form").addEventListener("submit", (e) => {
-      e.preventDefault();
-      let pin = document.querySelector("#pin-input").value;
-      let name = document.querySelector("#name-input").value;
-      document.querySelector("#status").innerHTML = "";
-      let b = JSON.stringify({ pin: pin, name: name });
-      fetch("/api/pin", { method: "POST", body: b })
-        .then((response) => response.json())
-        .then((response) => {
-          if (response.status.toString().toLowerCase() === "true") {
-            document.querySelector(
-              "#status"
-            ).innerHTML = `<div class="alert alert-success" role="alert">${i18n.global.t('pin.pair_success')}</div>`;
-            document.querySelector("#pin-input").value = "";
-            document.querySelector("#name-input").value = "";
-          } else {
-            document.querySelector(
-              "#status"
-            ).innerHTML = `<div class="alert alert-danger" role="alert">${i18n.global.t('pin.pair_failure')}</div>`;
-          }
-        });
-    });
-  }));
+  initApp(app);
 </script>

--- a/src_assets/common/assets/web/pin.html
+++ b/src_assets/common/assets/web/pin.html
@@ -8,10 +8,11 @@
 <body id="app" v-cloak>
   <Navbar></Navbar>
   <div id="content" class="container">
-    <h1 class="my-4">{{ $t('pin.pin_pairing') }}</h1>
+    <h1 class="my-4 text-center">{{ $t('pin.pin_pairing') }}</h1>
     <form action="" class="form d-flex flex-column align-items-center" id="form">
       <div class="card flex-column d-flex p-4 mb-4">
-        <input type="text" pattern="\d*" placeholder="PIN" autofocus id="pin-input" class="form-control my-4" />
+        <input type="text" pattern="\d*" :placeholder="`${$t('navbar.pin')}`" autofocus id="pin-input" class="form-control mt-2" required />
+        <input type="text" :placeholder="`${$t('pin.device_name')}`" id="name-input" class="form-control my-4" required />
         <button class="btn btn-primary">{{ $t('pin.send') }}</button>
       </div>
       <div class="alert alert-warning">
@@ -39,8 +40,9 @@
     document.querySelector("#form").addEventListener("submit", (e) => {
       e.preventDefault();
       let pin = document.querySelector("#pin-input").value;
+      let name = document.querySelector("#name-input").value;
       document.querySelector("#status").innerHTML = "";
-      let b = JSON.stringify({ pin: pin });
+      let b = JSON.stringify({ pin: pin, name: name });
       fetch("/api/pin", { method: "POST", body: b })
         .then((response) => response.json())
         .then((response) => {
@@ -49,6 +51,7 @@
               "#status"
             ).innerHTML = `<div class="alert alert-success" role="alert">${i18n.global.t('pin.pair_success')}</div>`;
             document.querySelector("#pin-input").value = "";
+            document.querySelector("#name-input").value = "";
           } else {
             document.querySelector(
               "#status"

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -7,6 +7,7 @@
     "cancel": "Cancel",
     "disabled": "Disabled",
     "disabled_def": "Disabled (default)",
+    "dismiss": "Dismiss",
     "do_cmd": "Do Command",
     "elevated": "Elevated",
     "enabled": "Enabled",
@@ -353,6 +354,7 @@
     "success_msg": "Password has been changed successfully! This page will reload soon, your browser will ask you for the new credentials."
   },
   "pin": {
+    "device_name": "Device Name",
     "pair_failure": "Pairing Failed: Check if the PIN is typed correctly",
     "pair_success": "Success! Please check Moonlight to continue",
     "pin_pairing": "PIN Pairing",
@@ -382,9 +384,13 @@
     "restart_sunshine_success": "Sunshine is restarting",
     "troubleshooting": "Troubleshooting",
     "unpair_all": "Unpair All",
-    "unpair_all_desc": "Remove all your paired devices",
     "unpair_all_error": "Error while unpairing",
-    "unpair_all_success": "Unpair Successful!"
+    "unpair_all_success": "All devices unpaired.",
+    "unpair_desc": "Remove your paired devices. Individually unpaired devices with an active session will remain connected, but cannot start or resume a session.",
+    "unpair_single_no_devices": "There are no paired devices.",
+    "unpair_single_success": "However, the device(s) may still be in an active session. Use the 'Force Close' button above to end any open sessions.",
+    "unpair_single_unknown": "Unknown Client",
+    "unpair_title": "Unpair Devices"
   },
   "welcome": {
     "confirm_password": "Confirm password",

--- a/src_assets/common/assets/web/troubleshooting.html
+++ b/src_assets/common/assets/web/troubleshooting.html
@@ -75,24 +75,39 @@
         </div>
       </div>
     </div>
-    <!-- Unpair all Clients -->
-    <div class="card p-2 my-4">
+    <!-- Unpair Clients -->
+    <div class="card my-4">
       <div class="card-body">
-        <h2 id="unpair">{{ $t('troubleshooting.unpair_all') }}</h2>
-        <br>
-        <p>{{ $t('troubleshooting.unpair_all_desc') }}</p>
-        <div class="alert alert-success" v-if="unpairAllStatus === true">
-          {{ $t('troubleshooting.unpair_all_success') }}
-        </div>
-        <div class="alert alert-danger" v-if="unpairAllStatus === false">
-          {{ $t('troubleshooting.unpair_all_error') }}
-        </div>
-        <div>
-          <button class="btn btn-danger" :disabled="unpairAllPressed" @click="unpairAll">
-            {{ $t('troubleshooting.unpair_all') }}
-          </button>
+        <div class="p-2">
+          <div class="d-flex justify-content-end align-items-center">
+            <h2 id="unpair" class="text-center me-auto">{{ $t('troubleshooting.unpair_title') }}</h2>
+            <button class="btn btn-danger" :disabled="unpairAllPressed" @click="unpairAll">
+              {{ $t('troubleshooting.unpair_all') }}
+            </button>
+          </div>
+          <br />
+          <p class="mb-0">{{ $t('troubleshooting.unpair_desc') }}</p>
+          <div id="apply-alert" class="alert alert-success d-flex align-items-center mt-3" :style="{ 'display': (showApplyMessage ? 'flex !important': 'none !important') }">
+            <div class="me-2"><b>{{ $t('_common.success') }}</b> {{ $t('troubleshooting.unpair_single_success') }}</div>
+            <button class="btn btn-success ms-auto apply" @click="clickedApplyBanner">{{ $t('_common.dismiss') }}</button>
+          </div>
+          <div class="alert alert-success mt-3" v-if="unpairAllStatus === true">
+            {{ $t('troubleshooting.unpair_all_success') }}
+          </div>
+          <div class="alert alert-danger mt-3" v-if="unpairAllStatus === false">
+            {{ $t('troubleshooting.unpair_all_error') }}
+          </div>
         </div>
       </div>
+      <ul id="client-list" class="list-group list-group-flush list-group-item-light" v-if="clients && clients.length > 0">
+        <div v-for="client in clients" class="list-group-item d-flex">
+          <div class="p-2 flex-grow-1">{{client.name != "" ? client.name : $t('troubleshooting.unpair_single_unknown')}}</div><div class="me-2 ms-auto btn btn-danger" @click="unpairSingle(client.uuid)"><i class="fas fa-trash"></i></div>
+        </div>
+      </ul>
+      <ul v-else class="list-group list-group-flush list-group-item-light">
+        <div class="list-group-item p-3 text-center"><em>{{ $t('troubleshooting.unpair_single_no_devices') }}</em></div>
+      </ul>
+      
     </div>
     <!-- Logs -->
     <div class="card p-2 my-4">
@@ -123,14 +138,16 @@
       },
       data() {
         return {
+          clients: [],
           closeAppPressed: false,
           closeAppStatus: null,
-          unpairAllPressed: false,
-          unpairAllStatus: null,
-          restartPressed: false,
           logs: 'Loading...',
           logFilter: null,
           logInterval: null,
+          restartPressed: false,
+          showApplyMessage: false,
+          unpairAllPressed: false,
+          unpairAllStatus: null,
         };
       },
       computed: {
@@ -146,6 +163,7 @@
           this.refreshLogs();
         }, 5000);
         this.refreshLogs();
+        this.refreshClients();
       },
       beforeDestroy() {
         clearInterval(this.logInterval);
@@ -172,7 +190,7 @@
         },
         unpairAll() {
           this.unpairAllPressed = true;
-          fetch("/api/clients/unpair", { method: "POST" })
+          fetch("/api/clients/unpair-all", { method: "POST" })
             .then((r) => r.json())
             .then((r) => {
               this.unpairAllPressed = false;
@@ -180,7 +198,31 @@
               setTimeout(() => {
                 this.unpairAllStatus = null;
               }, 5000);
+              this.refreshClients();
             });
+        },
+        unpairSingle(uuid) {
+          fetch("/api/clients/unpair", { method: "POST", body: JSON.stringify({ uuid }) }).then(() => {
+            this.showApplyMessage = true;
+            this.refreshClients();
+          });
+        },
+        refreshClients() {
+          fetch("/api/clients/list")
+            .then((response) => response.json())
+            .then((response) => {
+              const clientList = document.querySelector("#client-list");
+              if (response.status === 'true' && response.named_certs && response.named_certs.length) {
+                this.clients = response.named_certs.sort((a, b) => {
+                  return (a.name.toLowerCase() > b.name.toLowerCase() || a.name == "" ? 1 : -1)
+                });
+              } else {
+                this.clients = [];
+              }
+            });
+        },
+        clickedApplyBanner() {
+          this.showApplyMessage = false;
         },
         copyLogs() {
           navigator.clipboard.writeText(this.actualLogs);


### PR DESCRIPTION
## Description
Introduces the option to name clients during PIN pairing, along with a UI to remove individual client certificates. The format of `sunshine_state.json` was updated to include a `named_certs` array instead of the previous `certs` array. The old array is used for migration to the new format on startup.

Here's an example of the new format:

```json
{
    ...
    "root": {
        "uniqueid": "2258BFE6-698A-422C-5F0F-55B49A69C69E",
        "devices": [
            {
                "uniqueid": "0123456789ABCDEF",
                "named_certs": [
                    {
                        "name": "NVIDIA Shield",
                        "cert": "-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----\n",
                        "uniqueid": "41310952-60C8-1B01-A615-033CC8275E5F"
                    },
                    {
                        "name": "Steam Deck",
                        "cert": "-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----\n",
                        "uniqueid": "AE113204-32D9-6607-6285-7F3C200440EB"
                    }
                ]
            }
        ]
    }
}

```

The `named_certs` array includes a user-defined name and a generated UUID. The UUID allows for the same name to be used multiple times. It also helps target the correct client over the API without exposing the certificate.

The UI for managing clients has been added to the PIN page, under the PIN input. If a client wasn't named during the pairing process, or the certificate was imported from the old format, the client will be listed as "Unknown". After removing a paired client from the new UI, the user will be prompted to restart Sunshine in order to finish removing the certificate. 

While working on this, I was made aware of the [TheElixZammuto/Sunshine-1/state-revamp](https://github.com/TheElixZammuto/Sunshine-1/tree/state-revamp) fork, which has a similar goal. However, it looks like it's still missing the UI, API, and server code to deal with "unpairing". It also hasn't been updated since September, so it can't merge cleanly as-is. I understand if you prefer to use what that fork over mine, but I figured I would clean up my code and submit it, in case it's useful 

### Screenshot
![Screenshot 2024-01-20 032346](https://github.com/LizardByte/Sunshine/assets/33106561/12364477-c0e2-481e-9a83-3d52760ebf43)



### Issues Fixed or Closed
https://discord.com/channels/804382334370578482/1197647357030965328


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
