### PR TITLE
Find the correct install paths for systemd units and udev rules

### DIFF
--- a/cmake/FindSystemd.cmake
+++ b/cmake/FindSystemd.cmake
@@ -7,28 +7,28 @@
 
 IF (NOT WIN32)
 
-	find_package(PkgConfig QUIET)
-	if(PKG_CONFIG_FOUND)
-		pkg_check_modules(SYSTEMD "systemd")
-	endif()
+    find_package(PkgConfig QUIET)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(SYSTEMD "systemd")
+    endif()
 
-	if (SYSTEMD_FOUND)
-		execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
-			--variable=systemd_user_unit_dir systemd
-			OUTPUT_VARIABLE SYSTEMD_USER_UNIT_INSTALL_DIR)
+    if (SYSTEMD_FOUND)
+        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+            --variable=systemd_user_unit_dir systemd
+            OUTPUT_VARIABLE SYSTEMD_USER_UNIT_INSTALL_DIR)
 
-		string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_USER_UNIT_INSTALL_DIR
-			"${SYSTEMD_USER_UNIT_INSTALL_DIR}")
+        string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_USER_UNIT_INSTALL_DIR
+            "${SYSTEMD_USER_UNIT_INSTALL_DIR}")
 
-		execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
-			--variable=systemd_system_unit_dir systemd
-			OUTPUT_VARIABLE SYSTEMD_SYSTEM_UNIT_INSTALL_DIR)
+        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+            --variable=systemd_system_unit_dir systemd
+            OUTPUT_VARIABLE SYSTEMD_SYSTEM_UNIT_INSTALL_DIR)
 
-		string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SYSTEM_UNIT_INSTALL_DIR
-			"${SYSTEMD_SYSTEM_UNIT_INSTALL_DIR}")
+        string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SYSTEM_UNIT_INSTALL_DIR
+            "${SYSTEMD_SYSTEM_UNIT_INSTALL_DIR}")
 
-		mark_as_advanced(SYSTEMD_USER_UNIT_INSTALL_DIR SYSTEMD_SYSTEM_UNIT_INSTALL_DIR)
+        mark_as_advanced(SYSTEMD_USER_UNIT_INSTALL_DIR SYSTEMD_SYSTEM_UNIT_INSTALL_DIR)
 
-	endif ()
+    endif ()
 
 ENDIF ()

--- a/cmake/FindSystemd.cmake
+++ b/cmake/FindSystemd.cmake
@@ -1,0 +1,34 @@
+# - Try to find Systemd
+# Once done this will define
+#
+# SYSTEMD_FOUND - system has systemd
+# SYSTEMD_USER_UNIT_INSTALL_DIR - the systemd system unit install directory
+# SYSTEMD_SYSTEM_UNIT_INSTALL_DIR - the systemd user unit install directory
+
+IF (NOT WIN32)
+
+	find_package(PkgConfig QUIET)
+	if(PKG_CONFIG_FOUND)
+		pkg_check_modules(SYSTEMD "systemd")
+	endif()
+
+	if (SYSTEMD_FOUND)
+		execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+			--variable=systemd_user_unit_dir systemd
+			OUTPUT_VARIABLE SYSTEMD_USER_UNIT_INSTALL_DIR)
+
+		string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_USER_UNIT_INSTALL_DIR
+			"${SYSTEMD_USER_UNIT_INSTALL_DIR}")
+
+		execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+			--variable=systemd_system_unit_dir systemd
+			OUTPUT_VARIABLE SYSTEMD_SYSTEM_UNIT_INSTALL_DIR)
+
+		string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SYSTEM_UNIT_INSTALL_DIR
+			"${SYSTEMD_SYSTEM_UNIT_INSTALL_DIR}")
+
+		mark_as_advanced(SYSTEMD_USER_UNIT_INSTALL_DIR SYSTEMD_SYSTEM_UNIT_INSTALL_DIR)
+
+	endif ()
+
+ENDIF ()

--- a/cmake/FindSystemd.cmake
+++ b/cmake/FindSystemd.cmake
@@ -14,14 +14,14 @@ IF (NOT WIN32)
 
     if (SYSTEMD_FOUND)
         execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
-            --variable=systemd_user_unit_dir systemd
+            --variable=systemduserunitdir systemd
             OUTPUT_VARIABLE SYSTEMD_USER_UNIT_INSTALL_DIR)
 
         string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_USER_UNIT_INSTALL_DIR
             "${SYSTEMD_USER_UNIT_INSTALL_DIR}")
 
         execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
-            --variable=systemd_system_unit_dir systemd
+            --variable=systemdsystemunitdir systemd
             OUTPUT_VARIABLE SYSTEMD_SYSTEM_UNIT_INSTALL_DIR)
 
         string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SYSTEM_UNIT_INSTALL_DIR

--- a/cmake/FindUdev.cmake
+++ b/cmake/FindUdev.cmake
@@ -6,23 +6,23 @@
 
 IF (NOT WIN32)
 
-  find_package(PkgConfig QUIET)
-  if(PKG_CONFIG_FOUND)
-    pkg_check_modules(UDEV "udev")
-  endif()
+    find_package(PkgConfig QUIET)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(UDEV "udev")
+    endif()
 
-  if (UDEV_FOUND)
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
-        --variable=udevdir udev
-        OUTPUT_VARIABLE UDEV_RULES_INSTALL_DIR)
+    if (UDEV_FOUND)
+        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+            --variable=udevdir udev
+            OUTPUT_VARIABLE UDEV_RULES_INSTALL_DIR)
 
-    string(REGEX REPLACE "[ \t\n]+" "" UDEV_RULES_INSTALL_DIR
-      "${UDEV_RULES_INSTALL_DIR}")
-      
-    set(UDEV_RULES_INSTALL_DIR "${UDEV_RULES_INSTALL_DIR}/rules.d")
+        string(REGEX REPLACE "[ \t\n]+" "" UDEV_RULES_INSTALL_DIR
+            "${UDEV_RULES_INSTALL_DIR}")
 
-    mark_as_advanced(UDEV_RULES_INSTALL_DIR)
+        set(UDEV_RULES_INSTALL_DIR "${UDEV_RULES_INSTALL_DIR}/rules.d")
 
-  endif ()
+        mark_as_advanced(UDEV_RULES_INSTALL_DIR)
+
+    endif ()
 
 ENDIF ()

--- a/cmake/FindUdev.cmake
+++ b/cmake/FindUdev.cmake
@@ -1,0 +1,28 @@
+# - Try to find Udev
+# Once done this will define
+#
+# UDEV_FOUND - system has udev
+# UDEV_RULES_INSTALL_DIR - the udev rules install directory
+
+IF (NOT WIN32)
+
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(UDEV "udev")
+  endif()
+
+  if (UDEV_FOUND)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+        --variable=udevdir udev
+        OUTPUT_VARIABLE UDEV_RULES_INSTALL_DIR)
+
+    string(REGEX REPLACE "[ \t\n]+" "" UDEV_RULES_INSTALL_DIR
+      "${UDEV_RULES_INSTALL_DIR}")
+      
+    set(UDEV_RULES_INSTALL_DIR "${UDEV_RULES_INSTALL_DIR}/rules.d")
+
+    mark_as_advanced(UDEV_RULES_INSTALL_DIR)
+
+  endif ()
+
+ENDIF ()

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -8,10 +8,13 @@ if(${SUNSHINE_BUILD_APPIMAGE} OR ${SUNSHINE_BUILD_FLATPAK})
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service"
             DESTINATION "${SUNSHINE_ASSETS_DIR}/systemd/user")
 else()
+    find_package(Systemd)
+    find_package(Udev)
+
     install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/85-sunshine.rules"
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/udev/rules.d")
+            DESTINATION "${UDEV_RULES_INSTALL_DIR}")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service"
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/user")
+            DESTINATION "${SYSTEMD_USER_UNIT_INSTALL_DIR}")
 endif()
 
 # Post install

--- a/docker/debian-bookworm.dockerfile
+++ b/docker/debian-bookworm.dockerfile
@@ -61,6 +61,7 @@ apt-get install -y --no-install-recommends \
   libxtst-dev \
   nodejs \
   npm \
+  udev \
   wget
 if [[ "${TARGETPLATFORM}" == 'linux/amd64' ]]; then
   apt-get install -y --no-install-recommends \

--- a/docker/debian-bullseye.dockerfile
+++ b/docker/debian-bullseye.dockerfile
@@ -60,6 +60,7 @@ apt-get install -y --no-install-recommends \
   libxfixes-dev \
   libxrandr-dev \
   libxtst-dev \
+  udev \
   wget
 if [[ "${TARGETPLATFORM}" == 'linux/amd64' ]]; then
   apt-get install -y --no-install-recommends \

--- a/docker/ubuntu-20.04.dockerfile
+++ b/docker/ubuntu-20.04.dockerfile
@@ -61,6 +61,7 @@ apt-get install -y --no-install-recommends \
   libxfixes-dev \
   libxrandr-dev \
   libxtst-dev \
+  udev \
   wget
 if [[ "${TARGETPLATFORM}" == 'linux/amd64' ]]; then
   apt-get install -y --no-install-recommends \

--- a/docker/ubuntu-22.04.dockerfile
+++ b/docker/ubuntu-22.04.dockerfile
@@ -60,6 +60,7 @@ apt-get install -y --no-install-recommends \
   libxfixes-dev \
   libxrandr-dev \
   libxtst-dev \
+  udev \
   wget
 if [[ "${TARGETPLATFORM}" == 'linux/amd64' ]]; then
   apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Description
- Added FindSystemd.cmake
- Added FindUdev.cmake
- Edited linux.cmake to load these two new modules and read the new path variables for these modules

Instead of using `CMAKE_INSTALL_LIBDIR` to get the system lib directory where a library would be installed (can be 'lib' or 'lib64'), now the actual install path of `systemd` and `udev` are queried via `pkg-config`. This should be more reliable for linux builds.

My knowledge of `cmake` is limited so a review would appreciated.

### Issues Fixed or Closed
- Fixes #2038 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
