### PR TITLE
Expose more nvenc and nvprefs options (rebased)

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -1182,6 +1182,59 @@ keybindings
 
       nvenc_twopass = quarter_res
 
+`nvenc_spatial_aq <https://localhost:47990/config/#nvenc_spatial_aq>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   Assign higher QP values to flat regions of the video.
+   Recommended to enable when streaming at lower bitrates.
+
+   .. Note:: This option only applies when using NVENC `encoder`_.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   ========== ===========
+   Value      Description
+   ========== ===========
+   disabled   Don't enable Spatial AQ (faster)
+   enabled    Enable Spatial AQ (slower)
+   ========== ===========
+
+**Default**
+   ``disabled``
+
+**Example**
+   .. code-block:: text
+
+      nvenc_spatial_aq = disabled
+
+`nvenc_vbv_increase <https://localhost:47990/config/#nvenc_vbv_increase>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   Single-frame VBV/HRD percentage increase.
+   By default sunshine uses single-frame VBV/HRD, which means any encoded video frame size is not expected to exceed requested bitrate divided by requested frame rate.
+   Relaxing this restriction can be beneficial and act as low-latency variable bitrate, but may also lead to packet loss if the network doesn't have buffer headroom to handle bitrate spikes.
+   Maximum accepted value is 400, which corresponds to 5x increased encoded video frame upper size limit.
+
+   .. Note:: This option only applies when using NVENC `encoder`_.
+
+   .. Warning:: Can lead to network packet loss.
+
+**Default**
+   ``0``
+
+**Range**
+   ``0-400``
+
+**Example**
+   .. code-block:: text
+
+      nvenc_vbv_increase = 0
+
 `nvenc_realtime_hags <https://localhost:47990/config/#nvenc_realtime_hags>`__
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1213,6 +1266,69 @@ keybindings
    .. code-block:: text
 
       nvenc_realtime_hags = enabled
+
+`nvenc_latency_over_power <https://localhost:47990/config/#nvenc_latency_over_power>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   Adaptive P-State algorithm which NVIDIA drivers employ doesn't work well with low latency streaming, so sunshine requests high power mode explicitly.
+
+   .. Note:: This option only applies when using NVENC `encoder`_.
+
+   .. Warning:: Disabling it is not recommended since this can lead to significantly increased encoding latency.
+
+   .. Caution:: Applies to Windows only.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   ========== ===========
+   Value      Description
+   ========== ===========
+   disabled   Sunshine doesn't change GPU power preferences (not recommended)
+   enabled    Sunshine requests high power mode explicitly
+   ========== ===========
+
+**Default**
+   ``enabled``
+
+**Example**
+   .. code-block:: text
+
+      nvenc_latency_over_power = enabled
+
+`nvenc_opengl_vulkan_on_dxgi <https://localhost:47990/config/#nvenc_opengl_vulkan_on_dxgi>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   Sunshine can't capture fullscreen OpenGL and Vulkan programs at full frame rate unless they present on top of DXGI.
+   This is system-wide setting that is reverted on sunshine program exit.
+
+   .. Note:: This option only applies when using NVENC `encoder`_.
+
+   .. Caution:: Applies to Windows only.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   ========== ===========
+   Value      Description
+   ========== ===========
+   disabled   Sunshine leaves global Vulkan/OpenGL present method unchanged
+   enabled    Sunshine changes global Vulkan/OpenGL present method to "Prefer layered on DXGI Swapchain"
+   ========== ===========
+
+**Default**
+   ``enabled``
+
+**Example**
+   .. code-block:: text
+
+      nvenc_opengl_vulkan_on_dxgi = enabled
 
 `nvenc_h264_cavlc <https://localhost:47990/config/#nvenc_h264_cavlc>`__
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -939,6 +939,8 @@ namespace config {
     string_f(vars, "sw_tune", video.sw.sw_tune);
 
     int_between_f(vars, "nvenc_preset", video.nv.quality_preset, { 1, 7 });
+    int_between_f(vars, "nvenc_vbv_increase", video.nv.vbv_percentage_increase, { 0, 400 });
+    bool_f(vars, "nvenc_spatial_aq", video.nv.adaptive_quantization);
     generic_f(vars, "nvenc_twopass", video.nv.two_pass, nv::twopass_from_view);
     bool_f(vars, "nvenc_h264_cavlc", video.nv.h264_cavlc);
     bool_f(vars, "nvenc_realtime_hags", video.nv_realtime_hags);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -953,6 +953,8 @@ namespace config {
                                 video.nv.two_pass == nvenc::nvenc_two_pass::full_resolution    ? NV_ENC_TWO_PASS_FULL_RESOLUTION :
                                                                                                  NV_ENC_MULTI_PASS_DISABLED;
     video.nv_legacy.h264_coder = video.nv.h264_cavlc ? NV_ENC_H264_ENTROPY_CODING_MODE_CAVLC : NV_ENC_H264_ENTROPY_CODING_MODE_CABAC;
+    video.nv_legacy.aq = video.nv.adaptive_quantization;
+    video.nv_legacy.vbv_percentage_increase = video.nv.vbv_percentage_increase;
 #endif
 
     int_f(vars, "qsv_preset", video.qsv.qsv_preset, qsv::preset_from_view);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -329,6 +329,8 @@ namespace config {
 
     {},  // nv
     true,  // nv_realtime_hags
+    true,  // nv_opengl_vulkan_on_dxgi
+    true,  // nv_sunshine_high_power_mode
     {},  // nv_legacy
 
     {
@@ -940,6 +942,8 @@ namespace config {
     generic_f(vars, "nvenc_twopass", video.nv.two_pass, nv::twopass_from_view);
     bool_f(vars, "nvenc_h264_cavlc", video.nv.h264_cavlc);
     bool_f(vars, "nvenc_realtime_hags", video.nv_realtime_hags);
+    bool_f(vars, "nvenc_opengl_vulkan_on_dxgi", video.nv_opengl_vulkan_on_dxgi);
+    bool_f(vars, "nvenc_latency_over_power", video.nv_sunshine_high_power_mode);
 
 #ifndef __APPLE__
     video.nv_legacy.preset = video.nv.quality_preset + 11;

--- a/src/config.h
+++ b/src/config.h
@@ -37,6 +37,8 @@ namespace config {
       int preset;
       int multipass;
       int h264_coder;
+      int aq;
+      int vbv_percentage_increase;
     } nv_legacy;
 
     struct {

--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,8 @@ namespace config {
 
     nvenc::nvenc_config nv;
     bool nv_realtime_hags;
+    bool nv_opengl_vulkan_on_dxgi;
+    bool nv_sunshine_high_power_mode;
 
     struct {
       int preset;

--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -222,6 +222,9 @@ namespace nvenc {
 
     if (get_encoder_cap(NV_ENC_CAPS_SUPPORT_CUSTOM_VBV_BUF_SIZE)) {
       enc_config.rcParams.vbvBufferSize = client_config.bitrate * 1000 / client_config.framerate;
+      if (config.vbv_percentage_increase > 0) {
+        enc_config.rcParams.vbvBufferSize += enc_config.rcParams.vbvBufferSize * config.vbv_percentage_increase / 100;
+      }
     }
 
     auto set_h264_hevc_common_format_config = [&](auto &format_config) {
@@ -369,9 +372,10 @@ namespace nvenc {
       if (init_params.enableEncodeAsync) extra += " async";
       if (buffer_is_10bit()) extra += " 10-bit";
       if (enc_config.rcParams.multiPass != NV_ENC_MULTI_PASS_DISABLED) extra += " two-pass";
+      if (config.vbv_percentage_increase > 0 && get_encoder_cap(NV_ENC_CAPS_SUPPORT_CUSTOM_VBV_BUF_SIZE)) extra += " vbv+" + std::to_string(config.vbv_percentage_increase);
       if (encoder_params.rfi) extra += " rfi";
       if (init_params.enableWeightedPrediction) extra += " weighted-prediction";
-      if (enc_config.rcParams.enableAQ) extra += " adaptive-quantization";
+      if (enc_config.rcParams.enableAQ) extra += " spatial-aq";
       if (enc_config.rcParams.enableMinQP) extra += " qpmin=" + std::to_string(enc_config.rcParams.minQP.qpInterP);
       if (config.insert_filler_data) extra += " filler-data";
       BOOST_LOG(info) << "NvEnc: created encoder " << quality_preset_string_from_guid(init_params.presetGUID) << extra;

--- a/src/nvenc/nvenc_config.h
+++ b/src/nvenc/nvenc_config.h
@@ -20,6 +20,9 @@ namespace nvenc {
     // Use optional preliminary pass for better motion vectors, bitrate distribution and stricter VBV(HRD), uses CUDA cores
     nvenc_two_pass two_pass = nvenc_two_pass::quarter_resolution;
 
+    // Percentage increase of VBV/HRD from the default single frame, allows low-latency variable bitrate
+    int vbv_percentage_increase = 0;
+
     // Improves fades compression, uses CUDA cores
     bool weighted_prediction = false;
 

--- a/src/platform/windows/nvprefs/nvprefs_common.cpp
+++ b/src/platform/windows/nvprefs/nvprefs_common.cpp
@@ -2,6 +2,9 @@
 #include "nvprefs_common.h"
 #include "src/main.h"  // sunshine boost::log severity levels
 
+// read user override preferences from global sunshine config
+#include "src/config.h"
+
 namespace nvprefs {
 
   void
@@ -22,6 +25,14 @@ namespace nvprefs {
   void
   error_message(const std::string &message) {
     BOOST_LOG(error) << "nvprefs: " << message;
+  }
+
+  nvprefs_options
+  get_nvprefs_options() {
+    nvprefs_options options;
+    options.opengl_vulkan_on_dxgi = config::video.nv_opengl_vulkan_on_dxgi;
+    options.sunshine_high_power_mode = config::video.nv_sunshine_high_power_mode;
+    return options;
   }
 
 }  // namespace nvprefs

--- a/src/platform/windows/nvprefs/nvprefs_common.h
+++ b/src/platform/windows/nvprefs/nvprefs_common.h
@@ -45,4 +45,12 @@ namespace nvprefs {
   void
   error_message(const std::string &message);
 
+  struct nvprefs_options {
+    bool opengl_vulkan_on_dxgi = true;
+    bool sunshine_high_power_mode = true;
+  };
+
+  nvprefs_options
+  get_nvprefs_options();
+
 }  // namespace nvprefs

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -291,7 +291,7 @@ namespace system_tray {
     tray.icon = TRAY_ICON_PLAYING;
     tray.notification_title = "Stream Started";
     char msg[256];
-    sprintf(msg, "Streaming started for %s", app_name.c_str());
+    snprintf(msg, std::size(msg), "Streaming started for %s", app_name.c_str());
     tray.notification_text = msg;
     tray.tooltip = msg;
     tray.notification_icon = TRAY_ICON_PLAYING;
@@ -311,7 +311,7 @@ namespace system_tray {
     tray.icon = TRAY_ICON_PAUSING;
     tray_update(&tray);
     char msg[256];
-    sprintf(msg, "Streaming paused for %s", app_name.c_str());
+    snprintf(msg, std::size(msg), "Streaming paused for %s", app_name.c_str());
     tray.icon = TRAY_ICON_PAUSING;
     tray.notification_title = "Stream Paused";
     tray.notification_text = msg;
@@ -333,7 +333,7 @@ namespace system_tray {
     tray.icon = TRAY_ICON;
     tray_update(&tray);
     char msg[256];
-    sprintf(msg, "Application %s successfully stopped", app_name.c_str());
+    snprintf(msg, std::size(msg), "Application %s successfully stopped", app_name.c_str());
     tray.icon = TRAY_ICON;
     tray.notification_icon = TRAY_ICON;
     tray.notification_title = "Application Stopped";

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -638,6 +638,7 @@ namespace video {
         { "tune"s, NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY },
         { "rc"s, NV_ENC_PARAMS_RC_CBR },
         { "multipass"s, &config::video.nv_legacy.multipass },
+        { "aq"s, &config::video.nv_legacy.aq },
       },
       // SDR-specific options
       {},
@@ -658,6 +659,7 @@ namespace video {
         { "tune"s, NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY },
         { "rc"s, NV_ENC_PARAMS_RC_CBR },
         { "multipass"s, &config::video.nv_legacy.multipass },
+        { "aq"s, &config::video.nv_legacy.aq },
       },
       // SDR-specific options
       {
@@ -681,6 +683,7 @@ namespace video {
         { "rc"s, NV_ENC_PARAMS_RC_CBR },
         { "coder"s, &config::video.nv_legacy.h264_coder },
         { "multipass"s, &config::video.nv_legacy.multipass },
+        { "aq"s, &config::video.nv_legacy.aq },
       },
       // SDR-specific options
       {
@@ -1698,6 +1701,12 @@ namespace video {
           }
           else {
             ctx->rc_buffer_size = bitrate / config.framerate;
+
+#ifndef __APPLE__
+            if (encoder.name == "nvenc" && config::video.nv_legacy.vbv_percentage_increase > 0) {
+              ctx->rc_buffer_size += ctx->rc_buffer_size * config::video.nv_legacy.vbv_percentage_increase / 100;
+            }
+#endif
           }
         }
       }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -889,6 +889,35 @@
           </div>
         </div>
 
+        <!-- Spatial AQ -->
+        <div class="mb-3">
+          <label for="nvenc_spatial_aq" class="form-label">Spatial AQ</label>
+          <select id="nvenc_spatial_aq" class="form-select" v-model="config.nvenc_spatial_aq">
+            <option value="disabled">Disabled (faster, default)</option>
+            <option value="enabled">Enabled (slower)</option>
+          </select>
+          <div class="form-text">
+            Assign higher QP values to flat regions of the video.<br>
+            Recommended to enable when streaming at lower bitrates.
+          </div>
+        </div>
+
+        <!-- Single-frame VBV/HRD percentage increase -->
+        <div class="mb-3">
+          <label for="nvenc_vbv_increase" class="form-label">Single-frame VBV/HRD percentage increase</label>
+          <input type="number" min="0" max="400" class="form-control" id="nvenc_vbv_increase" placeholder="0"
+            v-model="config.nvenc_vbv_increase" />
+          <div class="form-text">
+            By default sunshine uses single-frame
+            <a href="https://en.wikipedia.org/wiki/Video_buffering_verifier">VBV/HRD</a>,
+            which means any encoded video frame size is not expected to exceed requested bitrate divided by requested frame
+            rate.<br>
+            Relaxing this restriction can be beneficial and act as low-latency variable bitrate,
+            but may also lead to packet loss if the network doesn't have buffer headroom to handle bitrate spikes.<br>
+            Maximum accepted value is 400, which corresponds to 5x increased encoded video frame upper size limit.
+          </div>
+        </div>
+
         <!-- Miscellaneous options -->
         <div class="accordion">
           <div class="accordion-item">
@@ -915,6 +944,36 @@
                     is enabled, realtime priority is used and VRAM utilization is close to maximum.<br>
                     Disabling this option lowers the priority to high, sidestepping the freeze at the cost of reduced
                     capture performance when the GPU is heavily loaded.
+                  </div>
+                </div>
+
+                <!-- Prefer lower encoding latency over increased power consumption -->
+                <div class="mb-3" v-if="platform === 'windows'">
+                  <label for="nvenc_latency_over_power" class="form-label">Prefer lower encoding latency over increased power
+                    consumption</label>
+                  <select id="nvenc_latency_over_power" class="form-select" v-model="config.nvenc_latency_over_power">
+                    <option value="disabled">Disabled</option>
+                    <option value="enabled">Enabled (default)</option>
+                  </select>
+                  <div class="form-text">
+                    Adaptive P-State algorithm which NVIDIA drivers employ doesn't work well with low latency streaming, so
+                    sunshine requests high power mode explicitly.<br>
+                    Disabling it is not recommended since this can lead to
+                    <strong>significantly increased encoding latency</strong>.
+                  </div>
+                </div>
+                
+                <!-- Present OpenGL/Vulkan on top of DXGI -->
+                <div class="mb-3" v-if="platform === 'windows'">
+                  <label for="nvenc_opengl_vulkan_on_dxgi" class="form-label">Present OpenGL/Vulkan on top of DXGI</label>
+                  <select id="nvenc_opengl_vulkan_on_dxgi" class="form-select" v-model="config.nvenc_opengl_vulkan_on_dxgi">
+                    <option value="disabled">Disabled</option>
+                    <option value="enabled">Enabled (default)</option>
+                  </select>
+                  <div class="form-text">
+                    Sunshine can't capture fullscreen OpenGL and Vulkan programs at full frame rate unless they present on top
+                    of DXGI.<br>
+                    This is system-wide setting that is reverted on sunshine program exit.
                   </div>
                 </div>
 
@@ -1220,7 +1279,11 @@
             options: {
               "nvenc_preset": 1,
               "nvenc_twopass": "quarter_res",
+              "nvenc_spatial_aq": "disabled",
+              "nvenc_vbv_increase": 0,
               "nvenc_realtime_hags": "enabled",
+              "nvenc_latency_over_power": "enabled",
+              "nvenc_opengl_vulkan_on_dxgi": "enabled",
               "nvenc_h264_cavlc": "disabled",
             },
           },


### PR DESCRIPTION
## Description
This PR contains the changes from #1798 rebased on the nightly branch with the feedback items addressed.

The only major change is the removal of the reference frame configuration option per the feedback I gave on the original PR. We can discuss reintroducing that option when @ns6089 has time.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/d921b976-49f6-4301-822a-8e6e5e2629bc)


### Issues Fixed or Closed
Fixes #1908
Fixes #1771
Closes #1798
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
