### PR TITLE
Working Docker cross-compiling for Fedora 39

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,6 @@ venv/
 
 # ignore artifacts
 artifacts/
+
+# ignore Dockerfiles themselves
+/docker/

--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -223,6 +223,11 @@ if (${SUNSHINE_TRAY} EQUAL 0 AND SUNSHINE_REQUIRE_TRAY)
     message(FATAL_ERROR "Tray icon is required")
 endif()
 
+pkg_check_modules(EVDEV libevdev REQUIRED)
+include_directories(SYSTEM ${EVDEV_INCLUDE_DIRS})
+link_directories(${EVDEV_LIBRARY_DIRS})
+list(APPEND SUNSHINE_EXTERNAL_LIBRARIES ${EVDEV_LIBRARIES})
+
 list(APPEND PLATFORM_TARGET_FILES
         src/platform/linux/publish.cpp
         src/platform/linux/graphics.h
@@ -241,13 +246,11 @@ list(APPEND PLATFORM_TARGET_FILES
 list(APPEND PLATFORM_LIBRARIES
         Boost::dynamic_linking
         dl
-        evdev
         numa
         pulse
         pulse-simple)
 
 include_directories(
         SYSTEM
-        /usr/include/libevdev-1.0
         third-party/nv-codec-headers/include
         third-party/glad/include)

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -1,17 +1,22 @@
 # syntax=docker/dockerfile:1.4
 # artifacts: true
 # platforms: linux/amd64,linux/arm64/v8
-# platforms_pr: linux/amd64
+# platforms_pr: linux/amd64,linux/arm64/v8
 # no-cache-filters: sunshine-base,artifacts,sunshine
 ARG BASE=fedora
 ARG TAG=39
-FROM ${BASE}:${TAG} AS sunshine-base
+FROM --platform=$BUILDPLATFORM ${BASE}:${TAG} AS sunshine-base
 
 FROM sunshine-base as sunshine-build
+
+# reused args from base
+ARG TAG
+ENV TAG=${TAG}
 
 ARG TARGETPLATFORM
 RUN echo "target_platform: ${TARGETPLATFORM}"
 
+# args from ci workflow
 ARG BRANCH
 ARG BUILD_VERSION
 ARG COMMIT
@@ -22,25 +27,77 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV COMMIT=${COMMIT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# install dependencies
-# hadolint ignore=DL3041
-RUN <<_DEPS
+# setup env
+WORKDIR /env
+RUN <<_ENV
 #!/bin/bash
 set -e
+case "${TARGETPLATFORM}" in
+  linux/amd64)
+    echo TARGETARCH=x86_64 >> ./env
+    echo TUPLE=x86_64-linux-gnu >> ./env
+    ;;
+  linux/arm64)
+    echo TARGETARCH=aarch64 >> ./env
+    echo TUPLE=aarch64-linux-gnu >> ./env
+    ;;
+  *)
+    echo "unsupported platform: ${TARGETPLATFORM}";
+    exit 1
+    ;;
+esac
+_ENV
+
+# reset workdir
+WORKDIR /
+
+# install build dependencies
+# hadolint ignore=DL3041
+RUN <<_DEPS_A
+#!/bin/bash
+set -e
+
+# shellcheck source=/dev/null
+source /env/env
+
 dnf -y update
-dnf -y group install "Development Tools"
 dnf -y install \
-  boost-devel-1.81.0* \
   cmake-3.27.* \
-  gcc-13.2.* \
-  gcc-c++-13.2.* \
-  git \
+  gcc-"${TARGETARCH}"-linux-gnu-13.2.* \
+  gcc-c++-"${TARGETARCH}"-linux-gnu-13.2.* \
+  git-core \
+  nodejs \
+  pkgconf-pkg-config \
+  rpm-build \
+  wayland-devel \
+  wget \
+  which
+dnf clean all
+_DEPS_A
+
+# install host dependencies
+# hadolint ignore=DL3041
+RUN <<_DEPS_B
+#!/bin/bash
+set -e
+
+# shellcheck source=/dev/null
+source /env/env
+
+DNF=( dnf -y --installroot /mnt/cross --releasever "${TAG}" --forcearch "${TARGETARCH}" )
+"${DNF[@]}" install \
+  filesystem
+"${DNF[@]}" --setopt=tsflags=noscripts install \
+  $([[ "${TARGETARCH}" == x86_64 ]] && echo intel-mediasdk-devel) \
+  boost-devel-1.81.0* \
+  glibc-devel \
   libappindicator-gtk3-devel \
   libcap-devel \
   libcurl-devel \
   libdrm-devel \
   libevdev-devel \
   libnotify-devel \
+  libstdc++-devel \
   libva-devel \
   libvdpau-devel \
   libX11-devel \
@@ -53,20 +110,13 @@ dnf -y install \
   libXtst-devel \
   mesa-libGL-devel \
   miniupnpc-devel \
-  nodejs \
   numactl-devel \
   openssl-devel \
   opus-devel \
   pulseaudio-libs-devel \
-  rpm-build \
-  wget \
-  which
-if [[ "${TARGETPLATFORM}" == 'linux/amd64' ]]; then
-  dnf -y install intel-mediasdk-devel
-fi
-dnf clean all
-rm -rf /var/cache/yum
-_DEPS
+  wayland-devel
+"${DNF[@]}" clean all
+_DEPS_B
 
 # todo - enable cuda once it's supported for gcc 13 and fedora 39
 ## install cuda
@@ -78,9 +128,12 @@ _DEPS
 #RUN <<_INSTALL_CUDA
 ##!/bin/bash
 #set -e
+#
+## shellcheck source=/dev/null
+#source /env/env
 #cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
 #cuda_suffix=""
-#if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
+#if [[ "${TARGETARCH}" == 'aarch64' ]]; then
 #  cuda_suffix="_sbsa"
 #fi
 #url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
@@ -104,7 +157,20 @@ WORKDIR /build/sunshine/build
 RUN <<_MAKE
 #!/bin/bash
 set -e
+
+# shellcheck source=/dev/null
+source /env/env
+
+export \
+  CXXFLAGS="-isystem $(echo /mnt/cross/usr/include/c++/[0-9]*/) -isystem $(echo /mnt/cross/usr/include/c++/[0-9]*/${TUPLE%%-*}-*/)" \
+  LDFLAGS="-L$(echo /mnt/cross/usr/lib/gcc/${TUPLE%%-*}-*/[0-9]*/)" \
+  PKG_CONFIG_LIBDIR=/mnt/cross/usr/lib64/pkgconfig:/mnt/cross/usr/share/pkgconfig \
+  PKG_CONFIG_SYSROOT_DIR=/mnt/cross \
+  PKG_CONFIG_SYSTEM_INCLUDE_PATH=/mnt/cross/usr/include \
+  PKG_CONFIG_SYSTEM_LIBRARY_PATH=/mnt/cross/usr/lib64
+
 cmake \
+  -DCMAKE_TOOLCHAIN_FILE=toolchain-${TARGETARCH}-linux-gnu.cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DSUNSHINE_ASSETS_DIR=share/sunshine \
@@ -124,7 +190,7 @@ ARG TAG
 ARG TARGETARCH
 COPY --link --from=sunshine-build /build/sunshine/build/cpack_artifacts/Sunshine.rpm /sunshine-${BASE}-${TAG}-${TARGETARCH}.rpm
 
-FROM sunshine-base as sunshine
+FROM ${BASE}:${TAG} AS sunshine
 
 # copy deb from builder
 COPY --link --from=artifacts /sunshine*.rpm /sunshine.rpm

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -88,36 +88,48 @@ set -e
 # shellcheck source=/dev/null
 source /env/env
 
+# Initialize an array for packages
+packages=(
+  boost-devel-1.81.0*
+  glibc-devel
+  libappindicator-gtk3-devel
+  libcap-devel
+  libcurl-devel
+  libdrm-devel
+  libevdev-devel
+  libnotify-devel
+  libstdc++-devel
+  libva-devel
+  libvdpau-devel
+  libX11-devel
+  libxcb-devel
+  libXcursor-devel
+  libXfixes-devel
+  libXi-devel
+  libXinerama-devel
+  libXrandr-devel
+  libXtst-devel
+  mesa-libGL-devel
+  miniupnpc-devel
+  numactl-devel
+  openssl-devel
+  opus-devel
+  pulseaudio-libs-devel
+  wayland-devel
+)
+
+# Conditionally include arch specific packages
+if [[ "${TARGETARCH}" == 'x86_64' ]]; then
+   packages+=(intel-mediasdk-devel)
+fi
+
 "${DNF[@]}" install \
   filesystem
-"${DNF[@]}" --setopt=tsflags=noscripts install \
-  $([[ "${TARGETARCH}" == x86_64 ]] && echo intel-mediasdk-devel) \
-  boost-devel-1.81.0* \
-  glibc-devel \
-  libappindicator-gtk3-devel \
-  libcap-devel \
-  libcurl-devel \
-  libdrm-devel \
-  libevdev-devel \
-  libnotify-devel \
-  libstdc++-devel \
-  libva-devel \
-  libvdpau-devel \
-  libX11-devel \
-  libxcb-devel \
-  libXcursor-devel \
-  libXfixes-devel \
-  libXi-devel \
-  libXinerama-devel \
-  libXrandr-devel \
-  libXtst-devel \
-  mesa-libGL-devel \
-  miniupnpc-devel \
-  numactl-devel \
-  openssl-devel \
-  opus-devel \
-  pulseaudio-libs-devel \
-  wayland-devel
+
+# Install packages using the array
+"${DNF[@]}" --setopt=tsflags=noscripts install "${packages[@]}"
+
+# Clean up
 "${DNF[@]}" clean all
 _DEPS_B
 
@@ -164,18 +176,28 @@ set -e
 # shellcheck source=/dev/null
 source /env/env
 
+# shellcheck disable=SC2086
 if [[ "${TARGETARCH}" == 'aarch64' ]]; then
+  CXX_FLAG_1="$(echo /mnt/cross/usr/include/c++/[0-9]*/)"
+  CXX_FLAG_2="$(echo /mnt/cross/usr/include/c++/[0-9]*/${TUPLE%%-*}-*/)"
+  LD_FLAG="$(echo /mnt/cross/usr/lib/gcc/${TUPLE%%-*}-*/[0-9]*/)"
+
   export \
-    CXXFLAGS="-isystem $(echo /mnt/cross/usr/include/c++/[0-9]*/) -isystem $(echo /mnt/cross/usr/include/c++/[0-9]*/${TUPLE%%-*}-*/)" \
-    LDFLAGS="-L$(echo /mnt/cross/usr/lib/gcc/${TUPLE%%-*}-*/[0-9]*/)" \
+    CXXFLAGS="-isystem ${CXX_FLAG_1} -isystem ${CXX_FLAG_2}" \
+    LDFLAGS="-L${LD_FLAG}" \
     PKG_CONFIG_LIBDIR=/mnt/cross/usr/lib64/pkgconfig:/mnt/cross/usr/share/pkgconfig \
     PKG_CONFIG_SYSROOT_DIR=/mnt/cross \
     PKG_CONFIG_SYSTEM_INCLUDE_PATH=/mnt/cross/usr/include \
     PKG_CONFIG_SYSTEM_LIBRARY_PATH=/mnt/cross/usr/lib64
 fi
 
+TOOLCHAIN_OPTION=""
+if [[ "${TARGETARCH}" != 'x86_64' ]]; then
+  TOOLCHAIN_OPTION="-DCMAKE_TOOLCHAIN_FILE=toolchain-${TUPLE}.cmake"
+fi
+
 cmake \
-  $([[ "${TARGETARCH}" != x86_64 ]] && echo -DCMAKE_TOOLCHAIN_FILE=toolchain-${TARGETARCH}-linux-gnu.cmake) \
+  "$TOOLCHAIN_OPTION" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DSUNSHINE_ASSETS_DIR=share/sunshine \

--- a/docker/ubuntu-22.04.dockerfile
+++ b/docker/ubuntu-22.04.dockerfile
@@ -1,19 +1,29 @@
 # syntax=docker/dockerfile:1.4
 # artifacts: true
 # platforms: linux/amd64,linux/arm64/v8
-# platforms_pr: linux/amd64
+# platforms_pr: linux/amd64,linux/arm64/v8
 # no-cache-filters: sunshine-base,artifacts,sunshine
 ARG BASE=ubuntu
 ARG TAG=22.04
-FROM ${BASE}:${TAG} AS sunshine-base
+ARG DIST=jammy
+FROM --platform=$BUILDPLATFORM ${BASE}:${TAG} AS sunshine-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 FROM sunshine-base as sunshine-build
 
+# reused args from base
+ARG TAG
+ENV TAG=${TAG}
+ARG DIST
+ENV DIST=${DIST}
+
+ARG BUILDPLATFORM
 ARG TARGETPLATFORM
+RUN echo "build_platform: ${BUILDPLATFORM}"
 RUN echo "target_platform: ${TARGETPLATFORM}"
 
+# args from ci workflow
 ARG BRANCH
 ARG BUILD_VERSION
 ARG COMMIT
@@ -24,47 +34,125 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV COMMIT=${COMMIT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# setup env
+WORKDIR /env
+RUN <<_ENV
+#!/bin/bash
+set -e
+case "${BUILDPLATFORM}" in
+  linux/amd64)
+    BUILDARCH=amd64
+    ;;
+  linux/arm64)
+    BUILDARCH=arm64
+    ;;
+  *)
+    echo "unsupported platform: ${TARGETPLATFORM}";
+    exit 1
+    ;;
+esac
+
+case "${TARGETPLATFORM}" in
+  linux/amd64)
+    PACKAGEARCH=amd64
+    TARGETARCH=x86_64
+    ;;
+  linux/arm64)
+    PACKAGEARCH=arm64
+    TARGETARCH=aarch64
+    ;;
+  *)
+    echo "unsupported platform: ${TARGETPLATFORM}";
+    exit 1
+    ;;
+esac
+
+mirror="http://ports.ubuntu.com/ubuntu-ports"
+extra_sources=$(cat <<- VAREOF
+  deb [arch=$PACKAGEARCH] $mirror $DIST main restricted
+  deb [arch=$PACKAGEARCH] $mirror $DIST-updates main restricted
+  deb [arch=$PACKAGEARCH] $mirror $DIST universe
+  deb [arch=$PACKAGEARCH] $mirror $DIST-updates universe
+  deb [arch=$PACKAGEARCH] $mirror $DIST multiverse
+  deb [arch=$PACKAGEARCH] $mirror $DIST-updates multiverse
+  deb [arch=$PACKAGEARCH] $mirror $DIST-backports main restricted universe multiverse
+  deb [arch=$PACKAGEARCH] $mirror $DIST-security main restricted
+  deb [arch=$PACKAGEARCH] $mirror $DIST-security universe
+  deb [arch=$PACKAGEARCH] $mirror $DIST-security multiverse
+VAREOF
+)
+
+if [[ "${BUILDPLATFORM}" != "${TARGETPLATFORM}" ]]; then
+  # fix original sources
+  sed -i -e "s#deb http#deb [arch=$BUILDARCH] http#g" /etc/apt/sources.list
+  dpkg --add-architecture $PACKAGEARCH
+
+  echo "$extra_sources" | tee -a /etc/apt/sources.list
+fi
+
+echo PACKAGEARCH=${PACKAGEARCH}; \
+echo TARGETARCH=${TARGETARCH}; \
+echo TUPLE=${TARGETARCH}-linux-gnu >> ./env
+_ENV
+
 # install dependencies
 RUN <<_DEPS
 #!/bin/bash
 set -e
-apt-get update -y
-apt-get install -y --no-install-recommends \
-  build-essential \
-  cmake=3.22.* \
-  ca-certificates \
-  git \
-  libayatana-appindicator3-dev \
-  libavdevice-dev \
-  libboost-filesystem-dev=1.74.* \
-  libboost-locale-dev=1.74.* \
-  libboost-log-dev=1.74.* \
-  libboost-program-options-dev=1.74.* \
-  libcap-dev \
-  libcurl4-openssl-dev \
-  libdrm-dev \
-  libevdev-dev \
-  libminiupnpc-dev \
-  libnotify-dev \
-  libnuma-dev \
-  libopus-dev \
-  libpulse-dev \
-  libssl-dev \
-  libva-dev \
-  libvdpau-dev \
-  libwayland-dev \
-  libx11-dev \
-  libxcb-shm0-dev \
-  libxcb-xfixes0-dev \
-  libxcb1-dev \
-  libxfixes-dev \
-  libxrandr-dev \
-  libxtst-dev \
-  wget
-if [[ "${TARGETPLATFORM}" == 'linux/amd64' ]]; then
-  apt-get install -y --no-install-recommends \
-    libmfx-dev
+
+# shellcheck source=/dev/null
+source /env/env
+
+# Initialize an array for packages
+packages=(
+  "build-essential"
+  "cmake=3.22.*"
+  "ca-certificates"
+  "git"
+  "libayatana-appindicator3-dev"
+  "libavdevice-dev"
+  "libboost-filesystem-dev=1.74.*"
+  "libboost-locale-dev=1.74.*"
+  "libboost-log-dev=1.74.*"
+  "libboost-program-options-dev=1.74.*"
+  "libcap-dev"
+  "libcurl4-openssl-dev"
+  "libdrm-dev"
+  "libevdev-dev"
+  "libminiupnpc-dev"
+  "libnotify-dev"
+  "libnuma-dev"
+  "libopus-dev"
+  "libpulse-dev"
+  "libssl-dev"
+  "libva-dev"
+  "libvdpau-dev"
+  "libwayland-dev"
+  "libx11-dev"
+  "libxcb-shm0-dev"
+  "libxcb-xfixes0-dev"
+  "libxcb1-dev"
+  "libxfixes-dev"
+  "libxrandr-dev"
+  "libxtst-dev"
+  "wget"
+)
+
+# Conditionally include arch specific packages
+if [[ "${TARGETARCH}" == 'x86_64' ]]; then
+  packages+=(
+    "libmfx-dev"
+  )
 fi
+if [[ "${BUILDPLATFORM}" != "${TARGETPLATFORM}" ]]; then
+  packages+=(
+    "g++-${TUPLE}=4:11.2.*"
+    "gcc-${TUPLE}=4:11.2.*"
+  )
+fi
+
+apt-get update -y
+apt-get install -y --no-install-recommends "${packages[@]}"
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 _DEPS
@@ -91,7 +179,7 @@ RUN <<_INSTALL_CUDA
 set -e
 cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
 cuda_suffix=""
-if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
+if [[ "${TARGETARCH}" == 'aarch64' ]]; then
   cuda_suffix="_sbsa"
 fi
 url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
@@ -117,8 +205,20 @@ set -e
 #Set Node version
 source "$HOME/.nvm/nvm.sh"
 nvm use 20.9.0
+
+# shellcheck source=/dev/null
+source /env/env
+
+TOOLCHAIN_OPTION=""
+if [[ "${BUILDPLATFORM}" != "${TARGETPLATFORM}" ]]; then
+  export "CCPREFIX=/usr/bin/${TUPLE}-"
+
+  TOOLCHAIN_OPTION="-DCMAKE_TOOLCHAIN_FILE=toolchain-${TUPLE}-debian.cmake"
+fi
+
 #Actually build
 cmake \
+  "$TOOLCHAIN_OPTION" \
   -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
@@ -139,7 +239,7 @@ ARG TAG
 ARG TARGETARCH
 COPY --link --from=sunshine-build /build/sunshine/build/cpack_artifacts/Sunshine.deb /sunshine-${BASE}-${TAG}-${TARGETARCH}.deb
 
-FROM sunshine-base as sunshine
+FROM ${BASE}:${TAG} as sunshine
 
 # copy deb from builder
 COPY --link --from=artifacts /sunshine*.deb /sunshine.deb

--- a/toolchain-aarch64-linux-gnu-debian.cmake
+++ b/toolchain-aarch64-linux-gnu-debian.cmake
@@ -1,0 +1,26 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Linux)
+
+# set processor type
+SET(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+SET(COMPILER_PREFIX ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+
+# which compilers to use for C and C++
+SET(CMAKE_ASM_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_ASM-ATT_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
+
+# here is the target environment located
+SET(CMAKE_FIND_ROOT_PATH /usr/${COMPILER_PREFIX})
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# packaging
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")

--- a/toolchain-aarch64-linux-gnu.cmake
+++ b/toolchain-aarch64-linux-gnu.cmake
@@ -1,0 +1,29 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Linux)
+
+# set processor type
+SET(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+SET(COMPILER_PREFIX ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+
+# which compilers to use for C and C++
+SET(CMAKE_ASM_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_ASM-ATT_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
+
+# here is the target environment located
+set(CMAKE_SYSROOT "/mnt/cross")
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_AR "${COMPILER_PREFIX}-gcc-ar" CACHE FILEPATH "Archive manager" FORCE)
+set(CMAKE_RANLIB "${COMPILER_PREFIX}-gcc-ranlib" CACHE FILEPATH "Archive index generator" FORCE)
+
+# packaging
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")

--- a/toolchain-x86_64-linux-gnu.cmake
+++ b/toolchain-x86_64-linux-gnu.cmake
@@ -1,0 +1,29 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Linux)
+
+# set processor type
+SET(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+SET(COMPILER_PREFIX ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+
+# which compilers to use for C and C++
+SET(CMAKE_ASM_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_ASM-ATT_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
+SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
+
+# here is the target environment located
+set(CMAKE_SYSROOT "/mnt/cross")
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_AR "${COMPILER_PREFIX}-gcc-ar" CACHE FILEPATH "Archive manager" FORCE)
+set(CMAKE_RANLIB "${COMPILER_PREFIX}-gcc-ranlib" CACHE FILEPATH "Archive index generator" FORCE)
+
+# packaging
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")


### PR DESCRIPTION
Improvements to #2020 so that Fedora 39 now works.

* Does not require QEMU at all!
* Caches dnf metadata and downloads between rebuilds.
* Respects TARGETARCH as a Docker variable, adding DNF_ARCH instead.
* Reduces downloads and image size by ignoring weak dependencies.

~The image is still a little large at 591MB, twice what you have now. I'm not sure why, but I don't think you were doing `dnf update` before? That can bloat it quite a bit.~

I think you may need `setcap` to give Sunshine the correct permissions, but you didn't seem to have this before?