### PR TITLE
Revert "Remove useless texture size queries for every frame in displa…

### DIFF
--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1259,11 +1259,18 @@ namespace platf {
 
         auto &rgb = *rgb_opt;
 
+        gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
+
+        // Don't remove these lines, see https://github.com/LizardByte/Sunshine/issues/453
+        int w, h;
+        gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
+        gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
+        BOOST_LOG(debug) << "width and height: w "sv << w << " h "sv << h;
+
         if (!pull_free_image_cb(img_out)) {
           return platf::capture_e::interrupted;
         }
 
-        gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
         gl::ctx.GetTextureSubImage(rgb->tex[0], 0, img_offset_x, img_offset_y, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
 
         if (cursor && captured_cursor.visible) {

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -182,6 +182,13 @@ namespace wl {
       }
 
       gl::ctx.BindTexture(GL_TEXTURE_2D, (*rgb_opt)->tex[0]);
+
+      // Don't remove these lines, see https://github.com/LizardByte/Sunshine/issues/453
+      int w, h;
+      gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
+      gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
+      BOOST_LOG(debug) << "width and height: w "sv << w << " h "sv << h;
+
       gl::ctx.GetTextureSubImage((*rgb_opt)->tex[0], 0, 0, 0, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
       gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
 


### PR DESCRIPTION
…y_ram_t"

This reverts commit ebe01ce20b06c6f10392f945c1c7083ed3aa733f.

Looks like this commit undos the fixes in #649 and #884. Might be wise to add a comment so it doesn't get removed again (since it doesn't look like it does anything)

## Description
Revert a change. It may be wise to add a comment here so it isn't removed again in the future.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
