### PR TITLE
Encryption optimizations

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -128,7 +128,7 @@ namespace stream {
     }
 
     std::uint8_t iv[12];  // 12-byte IV is ideal for AES-GCM
-    std::uint32_t unused;
+    std::uint32_t frameNumber;
     std::uint8_t tag[16];
   };
 
@@ -1419,7 +1419,7 @@ namespace stream {
 
               // Encrypt the target buffer in place
               auto *prefix = (video_packet_enc_prefix_t *) shards.prefix(x);
-              prefix->unused = 0;
+              prefix->frameNumber = packet->frame_index();
               std::copy(std::begin(iv), std::end(iv), prefix->iv);
               session->video.cipher->encrypt(std::string_view { (char *) inspect, (size_t) blocksize }, prefix->tag, &iv);
             }


### PR DESCRIPTION
## Description
This PR contains a couple optimizations of our encryption code.

The first commit performs some minor refactoring to avoid constructing `crypto::aes_t` (`std::vector<uint8_t>`) over and over for each incoming and outgoing encrypted packet. Instead, we create one IV per encryption context and reuse that.

The second commit is a tiny backwards-compatible protocol update to repurpose the unused field in the encrypted video header as a frame number. This allows moonlight-common-c to avoid unnecessary decryption of FEC packets for frames that have already been successfully reconstructed. This reduces CPU time in video decryption by 20% when streaming with the default 20% FEC percentage. cc: @ABeltramo 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
