### PR TITLE
Rewrite software scaling to improve performance and fix scaling issues with certain resolutions

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -975,19 +975,19 @@ keybindings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Description**
-   Minimum number of threads used for software encoding.
+   Minimum number of CPU threads used for encoding.
 
    .. note:: Increasing the value slightly reduces encoding efficiency, but the tradeoff is usually worth it to gain
       the use of more CPU cores for encoding. The ideal value is the lowest value that can reliably encode at your
       desired streaming settings on your hardware.
 
 **Default**
-   ``1``
+   ``2``
 
 **Example**
    .. code-block:: text
 
-      min_threads = 1
+      min_threads = 2
 
 `hevc_mode <https://localhost:47990/config/#hevc_mode>`__
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -320,7 +320,7 @@ namespace config {
     0,  // hevc_mode
     0,  // av1_mode
 
-    1,  // min_threads
+    2,  // min_threads
     {
       "superfast"s,  // preset
       "zerolatency"s,  // tune

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -316,7 +316,7 @@ namespace egl {
     static std::optional<sws_t>
     make(int in_width, int in_height, int out_width, int out_height, gl::tex_t &&tex);
     static std::optional<sws_t>
-    make(int in_width, int in_height, int out_width, int out_height, GLint gl_tex_internal_fmt);
+    make(int in_width, int in_height, int out_width, int out_height, AVPixelFormat format);
 
     // Convert the loaded image into the first two framebuffers
     int

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -195,25 +195,7 @@ namespace va {
         return -1;
       }
 
-      // Decide the bit depth format of the backing texture based the target frame format
-      GLint gl_format;
-      switch (hw_frames_ctx->sw_format) {
-        case AV_PIX_FMT_YUV420P:
-        case AV_PIX_FMT_NV12:
-          gl_format = GL_RGBA8;
-          break;
-
-        case AV_PIX_FMT_YUV420P10:
-        case AV_PIX_FMT_P010:
-          gl_format = GL_RGB10_A2;
-          break;
-
-        default:
-          BOOST_LOG(error) << "Unsupported pixel format for VA frame: "sv << hw_frames_ctx->sw_format;
-          return -1;
-      }
-
-      auto sws_opt = egl::sws_t::make(width, height, frame->width, frame->height, gl_format);
+      auto sws_opt = egl::sws_t::make(width, height, frame->width, frame->height, hw_frames_ctx->sw_format);
       if (!sws_opt) {
         return -1;
       }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -761,8 +761,8 @@
 
         <!-- Min Threads -->
         <div class="mb-3">
-          <label for="min_threads" class="form-label">Minimum Software Encoding Thread Count</label>
-          <input type="number" class="form-control" id="min_threads" placeholder="1" min="1" v-model="config.min_threads" />
+          <label for="min_threads" class="form-label">Minimum CPU Thread Count</label>
+          <input type="number" class="form-control" id="min_threads" placeholder="2" min="1" v-model="config.min_threads" />
           <div class="form-text">
             Increasing the value slightly reduces encoding efficiency, but the tradeoff is usually<br>
             worth it to gain the use of more CPU cores for encoding. The ideal value is the lowest<br>
@@ -1266,7 +1266,7 @@
               "channels": 1,
               "fec_percentage": 20,
               "qp": 28,
-              "min_threads": 1,
+              "min_threads": 2,
               "hevc_mode": 0,
               "av1_mode": 0,
               "capture": "",


### PR DESCRIPTION
## Description
This change adopts the new frame/sliced-based swscale API that allows multi-threaded scaling and color conversion. Multithreading significantly improves performance significantly with larger resolutions, since scaling and color conversion is largely bound by CPU performance.

During the rewrite, I also fixed a number of bugs including:
- Incorrect computations of offset and stride causing misaligned luma/chroma planes and/or visible green padding when scaling various resolutions
- Violating the swscale API buffer alignment requirements
- Hardcoded assumptions about pixel formats and chroma subsampling

As part of this PR, I also bumped the default minimum CPU thread count from 1 to 2. This lets us take advantage of swscale's multithreading support while also improving software encoding performance without a significant impact on encoding efficiency.

I'm using the same configuration value to set both CPU encoding threads and CPU color conversion threads. They're fundamentally similar options that would probably be tweaked by users together anyway. If encoding and color conversion performance turn out to scale very differently on some hardware, I can split them out later but I prefer not to introduce more config complexity if it's not needed.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
