### PR TITLE
docs(build): add missing libcurl build dep for ubuntu

### DIFF
--- a/docs/source/building/linux.rst
+++ b/docs/source/building/linux.rst
@@ -106,6 +106,7 @@ Install Requirements
           libboost-log-dev \
           libboost-program-options-dev \
           libcap-dev \  # KMS
+          libcurl4-openssl-dev \
           libdrm-dev \  # KMS
           libevdev-dev \
           libminiupnpc-dev \
@@ -156,6 +157,7 @@ Install Requirements
           libboost-log-dev \
           libboost-program-options-dev \
           libcap-dev \  # KMS
+          libcurl4-openssl-dev \
           libdrm-dev \  # KMS
           libevdev-dev \
           libminiupnpc-dev \


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`libcurl` was missing from Ubuntu build docs.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
