### PR TITLE
build(cmake): use CMAKE_SOURCE_DIR property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # set the module path, used for includes
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # set version info for this build
 include(${CMAKE_MODULE_PATH}/prep/build_version.cmake)

--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -23,70 +23,70 @@ elseif(UNIX)
     endif()
 endif()
 
-include_directories(SYSTEM third-party/nv-codec-headers/include)
+include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third-party/nv-codec-headers/include")
 file(GLOB NVENC_SOURCES CONFIGURE_DEPENDS "src/nvenc/*.cpp" "src/nvenc/*.h")
 list(APPEND PLATFORM_TARGET_FILES ${NVENC_SOURCES})
 
-configure_file(src/version.h.in version.h @ONLY)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+configure_file("${CMAKE_SOURCE_DIR}/src/version.h.in" version.h @ONLY)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 set(SUNSHINE_TARGET_FILES
-        third-party/nanors/rs.c
-        third-party/nanors/rs.h
-        third-party/moonlight-common-c/src/Input.h
-        third-party/moonlight-common-c/src/Rtsp.h
-        third-party/moonlight-common-c/src/RtspParser.c
-        third-party/moonlight-common-c/src/Video.h
-        third-party/tray/tray.h
-        src/upnp.cpp
-        src/upnp.h
-        src/cbs.cpp
-        src/utility.h
-        src/uuid.h
-        src/config.h
-        src/config.cpp
-        src/main.cpp
-        src/main.h
-        src/crypto.cpp
-        src/crypto.h
-        src/nvhttp.cpp
-        src/nvhttp.h
-        src/httpcommon.cpp
-        src/httpcommon.h
-        src/confighttp.cpp
-        src/confighttp.h
-        src/rtsp.cpp
-        src/rtsp.h
-        src/stream.cpp
-        src/stream.h
-        src/video.cpp
-        src/video.h
-        src/video_colorspace.cpp
-        src/video_colorspace.h
-        src/input.cpp
-        src/input.h
-        src/audio.cpp
-        src/audio.h
-        src/platform/common.h
-        src/process.cpp
-        src/process.h
-        src/network.cpp
-        src/network.h
-        src/move_by_copy.h
-        src/system_tray.cpp
-        src/system_tray.h
-        src/task_pool.h
-        src/thread_pool.h
-        src/thread_safe.h
-        src/sync.h
-        src/round_robin.h
-        src/stat_trackers.h
-        src/stat_trackers.cpp
+        "${CMAKE_SOURCE_DIR}/third-party/nanors/rs.c"
+        "${CMAKE_SOURCE_DIR}/third-party/nanors/rs.h"
+        "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/src/Input.h"
+        "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/src/Rtsp.h"
+        "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/src/RtspParser.c"
+        "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/src/Video.h"
+        "${CMAKE_SOURCE_DIR}/third-party/tray/tray.h"
+        "${CMAKE_SOURCE_DIR}/src/upnp.cpp"
+        "${CMAKE_SOURCE_DIR}/src/upnp.h"
+        "${CMAKE_SOURCE_DIR}/src/cbs.cpp"
+        "${CMAKE_SOURCE_DIR}/src/utility.h"
+        "${CMAKE_SOURCE_DIR}/src/uuid.h"
+        "${CMAKE_SOURCE_DIR}/src/config.h"
+        "${CMAKE_SOURCE_DIR}/src/config.cpp"
+        "${CMAKE_SOURCE_DIR}/src/main.cpp"
+        "${CMAKE_SOURCE_DIR}/src/main.h"
+        "${CMAKE_SOURCE_DIR}/src/crypto.cpp"
+        "${CMAKE_SOURCE_DIR}/src/crypto.h"
+        "${CMAKE_SOURCE_DIR}/src/nvhttp.cpp"
+        "${CMAKE_SOURCE_DIR}/src/nvhttp.h"
+        "${CMAKE_SOURCE_DIR}/src/httpcommon.cpp"
+        "${CMAKE_SOURCE_DIR}/src/httpcommon.h"
+        "${CMAKE_SOURCE_DIR}/src/confighttp.cpp"
+        "${CMAKE_SOURCE_DIR}/src/confighttp.h"
+        "${CMAKE_SOURCE_DIR}/src/rtsp.cpp"
+        "${CMAKE_SOURCE_DIR}/src/rtsp.h"
+        "${CMAKE_SOURCE_DIR}/src/stream.cpp"
+        "${CMAKE_SOURCE_DIR}/src/stream.h"
+        "${CMAKE_SOURCE_DIR}/src/video.cpp"
+        "${CMAKE_SOURCE_DIR}/src/video.h"
+        "${CMAKE_SOURCE_DIR}/src/video_colorspace.cpp"
+        "${CMAKE_SOURCE_DIR}/src/video_colorspace.h"
+        "${CMAKE_SOURCE_DIR}/src/input.cpp"
+        "${CMAKE_SOURCE_DIR}/src/input.h"
+        "${CMAKE_SOURCE_DIR}/src/audio.cpp"
+        "${CMAKE_SOURCE_DIR}/src/audio.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/common.h"
+        "${CMAKE_SOURCE_DIR}/src/process.cpp"
+        "${CMAKE_SOURCE_DIR}/src/process.h"
+        "${CMAKE_SOURCE_DIR}/src/network.cpp"
+        "${CMAKE_SOURCE_DIR}/src/network.h"
+        "${CMAKE_SOURCE_DIR}/src/move_by_copy.h"
+        "${CMAKE_SOURCE_DIR}/src/system_tray.cpp"
+        "${CMAKE_SOURCE_DIR}/src/system_tray.h"
+        "${CMAKE_SOURCE_DIR}/src/task_pool.h"
+        "${CMAKE_SOURCE_DIR}/src/thread_pool.h"
+        "${CMAKE_SOURCE_DIR}/src/thread_safe.h"
+        "${CMAKE_SOURCE_DIR}/src/sync.h"
+        "${CMAKE_SOURCE_DIR}/src/round_robin.h"
+        "${CMAKE_SOURCE_DIR}/src/stat_trackers.h"
+        "${CMAKE_SOURCE_DIR}/src/stat_trackers.cpp"
         ${PLATFORM_TARGET_FILES})
 
-set_source_files_properties(src/upnp.cpp PROPERTIES COMPILE_FLAGS -Wno-pedantic)
+set_source_files_properties("${CMAKE_SOURCE_DIR}/src/upnp.cpp" PROPERTIES COMPILE_FLAGS -Wno-pedantic)
 
-set_source_files_properties(third-party/nanors/rs.c
+set_source_files_properties("${CMAKE_SOURCE_DIR}/third-party/nanors/rs.c"
         PROPERTIES COMPILE_FLAGS "-include deps/obl/autoshim.h -ftree-vectorize")
 
 if(NOT SUNSHINE_ASSETS_DIR_DEF)
@@ -96,14 +96,14 @@ list(APPEND SUNSHINE_DEFINITIONS SUNSHINE_ASSETS_DIR="${SUNSHINE_ASSETS_DIR_DEF}
 
 list(APPEND SUNSHINE_DEFINITIONS SUNSHINE_TRAY=${SUNSHINE_TRAY})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories("${CMAKE_SOURCE_DIR}")
 
 include_directories(
         SYSTEM
-        ${CMAKE_CURRENT_SOURCE_DIR}/third-party
-        ${CMAKE_CURRENT_SOURCE_DIR}/third-party/moonlight-common-c/enet/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third-party/nanors
-        ${CMAKE_CURRENT_SOURCE_DIR}/third-party/nanors/deps/obl
+        "${CMAKE_SOURCE_DIR}/third-party"
+        "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/enet/include"
+        "${CMAKE_SOURCE_DIR}/third-party/nanors"
+        "${CMAKE_SOURCE_DIR}/third-party/nanors/deps/obl"
         ${FFMPEG_INCLUDE_DIRS}
         ${PLATFORM_INCLUDE_DIRS}
 )
@@ -111,7 +111,7 @@ include_directories(
 string(TOUPPER "x${CMAKE_BUILD_TYPE}" BUILD_TYPE)
 if("${BUILD_TYPE}" STREQUAL "XDEBUG")
     if(WIN32)
-        set_source_files_properties(src/nvhttp.cpp PROPERTIES COMPILE_FLAGS -O2)
+        set_source_files_properties("${CMAKE_SOURCE_DIR}/src/nvhttp.cpp" PROPERTIES COMPILE_FLAGS -O2)
     endif()
 else()
     add_definitions(-DNDEBUG)

--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -89,12 +89,12 @@ if(${SUNSHINE_ENABLE_CUDA})
     endif()
 endif()
 if(CUDA_FOUND)
-    include_directories(SYSTEM third-party/nvfbc)
+    include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third-party/nvfbc")
     list(APPEND PLATFORM_TARGET_FILES
-            src/platform/linux/cuda.h
-            src/platform/linux/cuda.cu
-            src/platform/linux/cuda.cpp
-            third-party/nvfbc/NvFBC.h)
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/cuda.h"
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/cuda.cu"
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/cuda.cpp"
+            "${CMAKE_SOURCE_DIR}/third-party/nvfbc/NvFBC.h")
 
     add_compile_definitions(SUNSHINE_BUILD_CUDA)
 endif()
@@ -112,7 +112,7 @@ if(LIBDRM_FOUND AND LIBCAP_FOUND)
     include_directories(SYSTEM ${LIBDRM_INCLUDE_DIRS} ${LIBCAP_INCLUDE_DIRS})
     list(APPEND PLATFORM_LIBRARIES ${LIBDRM_LIBRARIES} ${LIBCAP_LIBRARIES})
     list(APPEND PLATFORM_TARGET_FILES
-            src/platform/linux/kmsgrab.cpp)
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/kmsgrab.cpp")
     list(APPEND SUNSHINE_DEFINITIONS EGL_NO_X11=1)
 elseif(NOT LIBDRM_FOUND)
     message(WARNING "Missing libdrm")
@@ -131,8 +131,8 @@ if(LIBVA_FOUND)
     include_directories(SYSTEM ${LIBVA_INCLUDE_DIR})
     list(APPEND PLATFORM_LIBRARIES ${LIBVA_LIBRARIES} ${LIBVA_DRM_LIBRARIES})
     list(APPEND PLATFORM_TARGET_FILES
-            src/platform/linux/vaapi.h
-            src/platform/linux/vaapi.cpp)
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/vaapi.h"
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/vaapi.cpp")
 endif()
 
 # wayland
@@ -162,9 +162,9 @@ if(WAYLAND_FOUND)
 
     list(APPEND PLATFORM_LIBRARIES ${WAYLAND_LIBRARIES})
     list(APPEND PLATFORM_TARGET_FILES
-            src/platform/linux/wlgrab.cpp
-            src/platform/linux/wayland.h
-            src/platform/linux/wayland.cpp)
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/wlgrab.cpp"
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/wayland.h"
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/wayland.cpp")
 endif()
 
 # x11
@@ -178,8 +178,8 @@ if(X11_FOUND)
     include_directories(SYSTEM ${X11_INCLUDE_DIR})
     list(APPEND PLATFORM_LIBRARIES ${X11_LIBRARIES})
     list(APPEND PLATFORM_TARGET_FILES
-            src/platform/linux/x11grab.h
-            src/platform/linux/x11grab.cpp)
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/x11grab.h"
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/x11grab.cpp")
 endif()
 
 if(NOT ${CUDA_FOUND}
@@ -211,7 +211,7 @@ if(${SUNSHINE_ENABLE_TRAY})
         include_directories(SYSTEM ${APPINDICATOR_INCLUDE_DIRS} ${LIBNOTIFY_INCLUDE_DIRS})
         link_directories(${APPINDICATOR_LIBRARY_DIRS} ${LIBNOTIFY_LIBRARY_DIRS})
 
-        list(APPEND PLATFORM_TARGET_FILES third-party/tray/tray_linux.c)
+        list(APPEND PLATFORM_TARGET_FILES "${CMAKE_SOURCE_DIR}/third-party/tray/tray_linux.c")
         list(APPEND SUNSHINE_EXTERNAL_LIBRARIES ${APPINDICATOR_LIBRARIES} ${LIBNOTIFY_LIBRARIES})
     endif()
 else()
@@ -224,19 +224,19 @@ if (${SUNSHINE_TRAY} EQUAL 0 AND SUNSHINE_REQUIRE_TRAY)
 endif()
 
 list(APPEND PLATFORM_TARGET_FILES
-        src/platform/linux/publish.cpp
-        src/platform/linux/graphics.h
-        src/platform/linux/graphics.cpp
-        src/platform/linux/misc.h
-        src/platform/linux/misc.cpp
-        src/platform/linux/audio.cpp
-        src/platform/linux/input.cpp
-        third-party/glad/src/egl.c
-        third-party/glad/src/gl.c
-        third-party/glad/include/EGL/eglplatform.h
-        third-party/glad/include/KHR/khrplatform.h
-        third-party/glad/include/glad/gl.h
-        third-party/glad/include/glad/egl.h)
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/publish.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/graphics.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/graphics.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/misc.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/misc.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/audio.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/input.cpp"
+        "${CMAKE_SOURCE_DIR}/third-party/glad/src/egl.c"
+        "${CMAKE_SOURCE_DIR}/third-party/glad/src/gl.c"
+        "${CMAKE_SOURCE_DIR}/third-party/glad/include/EGL/eglplatform.h"
+        "${CMAKE_SOURCE_DIR}/third-party/glad/include/KHR/khrplatform.h"
+        "${CMAKE_SOURCE_DIR}/third-party/glad/include/glad/gl.h"
+        "${CMAKE_SOURCE_DIR}/third-party/glad/include/glad/egl.h")
 
 list(APPEND PLATFORM_LIBRARIES
         Boost::dynamic_linking
@@ -249,5 +249,5 @@ list(APPEND PLATFORM_LIBRARIES
 include_directories(
         SYSTEM
         /usr/include/libevdev-1.0
-        third-party/nv-codec-headers/include
-        third-party/glad/include)
+        "${CMAKE_SOURCE_DIR}/third-party/nv-codec-headers/include"
+        "${CMAKE_SOURCE_DIR}/third-party/glad/include")

--- a/cmake/compile_definitions/macos.cmake
+++ b/cmake/compile_definitions/macos.cmake
@@ -18,32 +18,32 @@ list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
 set(PLATFORM_INCLUDE_DIRS
         ${Boost_INCLUDE_DIR})
 
-set(APPLE_PLIST_FILE ${SUNSHINE_SOURCE_ASSETS_DIR}/macos/assets/Info.plist)
+set(APPLE_PLIST_FILE "${SUNSHINE_SOURCE_ASSETS_DIR}/macos/assets/Info.plist")
 
 # todo - tray is not working on macos
 set(SUNSHINE_TRAY 0)
 
 set(PLATFORM_TARGET_FILES
-        src/platform/macos/av_audio.h
-        src/platform/macos/av_audio.m
-        src/platform/macos/av_img_t.h
-        src/platform/macos/av_video.h
-        src/platform/macos/av_video.m
-        src/platform/macos/display.mm
-        src/platform/macos/input.cpp
-        src/platform/macos/microphone.mm
-        src/platform/macos/misc.mm
-        src/platform/macos/misc.h
-        src/platform/macos/nv12_zero_device.cpp
-        src/platform/macos/nv12_zero_device.h
-        src/platform/macos/publish.cpp
-        third-party/TPCircularBuffer/TPCircularBuffer.c
-        third-party/TPCircularBuffer/TPCircularBuffer.h
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/av_audio.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/av_audio.m"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/av_img_t.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/av_video.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/av_video.m"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/display.mm"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/input.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/microphone.mm"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/misc.mm"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/misc.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/nv12_zero_device.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/nv12_zero_device.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/publish.cpp"
+        "${CMAKE_SOURCE_DIR}/third-party/TPCircularBuffer/TPCircularBuffer.c"
+        "${CMAKE_SOURCE_DIR}/third-party/TPCircularBuffer/TPCircularBuffer.h"
         ${APPLE_PLIST_FILE})
 
 if(SUNSHINE_ENABLE_TRAY)
     list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
             ${COCOA})
     list(APPEND PLATFORM_TARGET_FILES
-            third-party/tray/tray_darwin.m)
+            "${CMAKE_SOURCE_DIR}/third-party/tray/tray_darwin.m")
 endif()

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -18,42 +18,42 @@ add_definitions(-DMINIUPNP_STATICLIB)
 add_subdirectory(tools)  # todo - this is temporary, only tools for Windows are needed, for now
 
 # nvidia
-include_directories(SYSTEM third-party/nvapi-open-source-sdk)
+include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third-party/nvapi-open-source-sdk")
 file(GLOB NVPREFS_FILES CONFIGURE_DEPENDS
-        "third-party/nvapi-open-source-sdk/*.h"
-        "src/platform/windows/nvprefs/*.cpp"
-        "src/platform/windows/nvprefs/*.h")
+        "${CMAKE_SOURCE_DIR}/third-party/nvapi-open-source-sdk/*.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/nvprefs/*.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/nvprefs/*.h")
 
 # vigem
-include_directories(SYSTEM third-party/ViGEmClient/include)
-set_source_files_properties(third-party/ViGEmClient/src/ViGEmClient.cpp
+include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/include")
+set_source_files_properties("${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/src/ViGEmClient.cpp"
         PROPERTIES COMPILE_DEFINITIONS "UNICODE=1;ERROR_INVALID_DEVICE_OBJECT_PARAMETER=650")
-set_source_files_properties(third-party/ViGEmClient/src/ViGEmClient.cpp
+set_source_files_properties("${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/src/ViGEmClient.cpp"
         PROPERTIES COMPILE_FLAGS "-Wno-unknown-pragmas -Wno-misleading-indentation -Wno-class-memaccess")
 
 # sunshine icon
 if(NOT DEFINED SUNSHINE_ICON_PATH)
-    set(SUNSHINE_ICON_PATH "${CMAKE_CURRENT_SOURCE_DIR}/sunshine.ico")
+    set(SUNSHINE_ICON_PATH "${CMAKE_SOURCE_DIR}/sunshine.ico")
 endif()
 
-configure_file(src/platform/windows/windows.rs.in windows.rc @ONLY)
+configure_file("${CMAKE_SOURCE_DIR}/src/platform/windows/windows.rs.in" windows.rc @ONLY)
 
 set(PLATFORM_TARGET_FILES
         "${CMAKE_CURRENT_BINARY_DIR}/windows.rc"
-        src/platform/windows/publish.cpp
-        src/platform/windows/misc.h
-        src/platform/windows/misc.cpp
-        src/platform/windows/input.cpp
-        src/platform/windows/display.h
-        src/platform/windows/display_base.cpp
-        src/platform/windows/display_vram.cpp
-        src/platform/windows/display_ram.cpp
-        src/platform/windows/audio.cpp
-        third-party/ViGEmClient/src/ViGEmClient.cpp
-        third-party/ViGEmClient/include/ViGEm/Client.h
-        third-party/ViGEmClient/include/ViGEm/Common.h
-        third-party/ViGEmClient/include/ViGEm/Util.h
-        third-party/ViGEmClient/include/ViGEm/km/BusShared.h
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/publish.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/misc.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/misc.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/input.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/display.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/display_base.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/display_vram.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/display_ram.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/audio.cpp"
+        "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/src/ViGEmClient.cpp"
+        "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/include/ViGEm/Client.h"
+        "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/include/ViGEm/Common.h"
+        "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/include/ViGEm/Util.h"
+        "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/include/ViGEm/km/BusShared.h"
         ${NVPREFS_FILES})
 
 set(OPENSSL_LIBRARIES
@@ -78,5 +78,5 @@ list(PREPEND PLATFORM_LIBRARIES
 
 if(SUNSHINE_ENABLE_TRAY)
     list(APPEND PLATFORM_TARGET_FILES
-            third-party/tray/tray_windows.c)
+            "${CMAKE_SOURCE_DIR}/third-party/tray/tray_windows.c")
 endif()

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -4,10 +4,10 @@
 # submodules
 # moonlight common library
 set(ENET_NO_INSTALL ON CACHE BOOL "Don't install any libraries build for enet")
-add_subdirectory(third-party/moonlight-common-c/enet)
+add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/enet")
 
 # web server
-add_subdirectory(third-party/Simple-Web-Server)
+add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/Simple-Web-Server")
 
 # common dependencies
 find_package(OpenSSL REQUIRED)
@@ -20,7 +20,7 @@ pkg_check_modules(MINIUPNP miniupnpc REQUIRED)
 include_directories(SYSTEM ${MINIUPNP_INCLUDE_DIRS})
 
 # nlohmann_json
-add_subdirectory(third-party/nlohmann_json)
+add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/nlohmann_json")
 
 # ffmpeg pre-compiled binaries
 if(WIN32)
@@ -28,12 +28,12 @@ if(WIN32)
         message(FATAL_ERROR "Unsupported system processor:" ${CMAKE_SYSTEM_PROCESSOR})
     endif()
     set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid vpl)
-    set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/build-deps/ffmpeg/windows-x86_64")
+    set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/windows-x86_64")
 elseif(APPLE)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/build-deps/ffmpeg/macos-x86_64")
+        set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/macos-x86_64")
     elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/build-deps/ffmpeg/macos-aarch64")
+        set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/macos-aarch64")
     elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "powerpc")
         message(FATAL_ERROR "PowerPC is not supported on macOS")
     else()
@@ -43,43 +43,43 @@ elseif(UNIX)
     set(FFMPEG_PLATFORM_LIBRARIES va va-drm va-x11 vdpau X11)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
         list(APPEND FFMPEG_PLATFORM_LIBRARIES mfx)
-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-x86_64")
+        set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-x86_64")
         set(CPACK_DEB_PLATFORM_PACKAGE_DEPENDS "libmfx1,")
         set(CPACK_RPM_PLATFORM_PACKAGE_REQUIRES "intel-mediasdk >= 22.3.0,")
     elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-aarch64")
+        set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-aarch64")
     elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64")
-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-powerpc64le")
+        set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-powerpc64le")
     else()
         message(FATAL_ERROR "Unsupported system processor:" ${CMAKE_SYSTEM_PROCESSOR})
     endif()
 endif()
 set(FFMPEG_INCLUDE_DIRS
-        ${FFMPEG_PREPARED_BINARIES}/include)
-if(EXISTS ${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a)
+        "${FFMPEG_PREPARED_BINARIES}/include")
+if(EXISTS "${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a")
     set(HDR10_PLUS_LIBRARY
-            ${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a)
+            "${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a")
 endif()
 set(FFMPEG_LIBRARIES
-        ${FFMPEG_PREPARED_BINARIES}/lib/libavcodec.a
-        ${FFMPEG_PREPARED_BINARIES}/lib/libavutil.a
-        ${FFMPEG_PREPARED_BINARIES}/lib/libcbs.a
-        ${FFMPEG_PREPARED_BINARIES}/lib/libSvtAv1Enc.a
-        ${FFMPEG_PREPARED_BINARIES}/lib/libswscale.a
-        ${FFMPEG_PREPARED_BINARIES}/lib/libx264.a
-        ${FFMPEG_PREPARED_BINARIES}/lib/libx265.a
+        "${FFMPEG_PREPARED_BINARIES}/lib/libavcodec.a"
+        "${FFMPEG_PREPARED_BINARIES}/lib/libavutil.a"
+        "${FFMPEG_PREPARED_BINARIES}/lib/libcbs.a"
+        "${FFMPEG_PREPARED_BINARIES}/lib/libSvtAv1Enc.a"
+        "${FFMPEG_PREPARED_BINARIES}/lib/libswscale.a"
+        "${FFMPEG_PREPARED_BINARIES}/lib/libx264.a"
+        "${FFMPEG_PREPARED_BINARIES}/lib/libx265.a"
         ${HDR10_PLUS_LIBRARY}
         ${FFMPEG_PLATFORM_LIBRARIES})
 
 # platform specific dependencies
 if(WIN32)
-    include(${CMAKE_MODULE_PATH}/dependencies/windows.cmake)
+    include("${CMAKE_MODULE_PATH}/dependencies/windows.cmake")
 elseif(UNIX)
-    include(${CMAKE_MODULE_PATH}/dependencies/unix.cmake)
+    include("${CMAKE_MODULE_PATH}/dependencies/unix.cmake")
 
     if(APPLE)
-        include(${CMAKE_MODULE_PATH}/dependencies/macos.cmake)
+        include("${CMAKE_MODULE_PATH}/dependencies/macos.cmake")
     else()
-        include(${CMAKE_MODULE_PATH}/dependencies/linux.cmake)
+        include("${CMAKE_MODULE_PATH}/dependencies/linux.cmake")
     endif()
 endif()

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -41,7 +41,7 @@ install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/assets/"
         COMPONENT assets)
 
 # set(CPACK_NSIS_MUI_HEADERIMAGE "") # TODO: image should be 150x57 bmp
-set(CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\sunshine.ico")
+set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}\\\\sunshine.ico")
 set(CPACK_NSIS_INSTALLED_ICON_NAME "${PROJECT__DIR}\\\\${PROJECT_EXE}")
 # The name of the directory that will be created in C:/Program files/
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_NAME}")

--- a/cmake/prep/build_version.cmake
+++ b/cmake/prep/build_version.cmake
@@ -14,12 +14,12 @@ if((DEFINED ENV{BRANCH}) AND (DEFINED ENV{BUILD_VERSION}) AND (DEFINED ENV{COMMI
 else()
     find_package(Git)
     if(GIT_EXECUTABLE)
-        MESSAGE("${CMAKE_CURRENT_SOURCE_DIR}")
-        get_filename_component(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+        MESSAGE("${CMAKE_SOURCE_DIR}")
+        get_filename_component(SRC_DIR "${CMAKE_SOURCE_DIR}" DIRECTORY)
         #Get current Branch
         execute_process(
                 COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-                #WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                #WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
                 OUTPUT_VARIABLE GIT_DESCRIBE_BRANCH
                 RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
                 OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -27,7 +27,7 @@ else()
         # Gather current commit
         execute_process(
                 COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-                #WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                #WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
                 OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
                 RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
                 OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -35,7 +35,7 @@ else()
         # Check if Dirty
         execute_process(
                 COMMAND ${GIT_EXECUTABLE} diff --quiet --exit-code
-                #WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                #WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
                 RESULT_VARIABLE GIT_IS_DIRTY
                 OUTPUT_STRIP_TRAILING_WHITESPACE
         )

--- a/cmake/prep/constants.cmake
+++ b/cmake/prep/constants.cmake
@@ -1,5 +1,5 @@
 # source assets will be installed from this directory
-set(SUNSHINE_SOURCE_ASSETS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src_assets")
+set(SUNSHINE_SOURCE_ASSETS_DIR "${CMAKE_SOURCE_DIR}/src_assets")
 
 # enable system tray, we will disable this later if we cannot find the required package config on linux
 set(SUNSHINE_TRAY 1)

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -36,6 +36,6 @@ target_compile_options(sunshine PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COM
 
 #WebUI build
 add_custom_target(web-ui ALL
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Installing NPM Dependencies and Building the Web UI"
         COMMAND bash -c \"npm install && SUNSHINE_SOURCE_ASSETS_DIR=${SUNSHINE_SOURCE_ASSETS_DIR} SUNSHINE_ASSETS_DIR=${CMAKE_BINARY_DIR} npm run build\") # cmake-lint: disable=C0301

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(sunshine_tools)
 
-include_directories(${CMAKE_SOURCE_DIR})
+include_directories("${CMAKE_SOURCE_DIR}")
 
 add_executable(dxgi-info dxgi.cpp)
 set_target_properties(dxgi-info PROPERTIES CXX_STANDARD 17)
@@ -36,4 +36,3 @@ target_link_libraries(ddprobe
         d3d11
         ${PLATFORM_LIBRARIES})
 target_compile_options(ddprobe PRIVATE ${SUNSHINE_COMPILE_OPTIONS})
-


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use CMAKE_SOURCE_DIR property in cmake
- Add quotes in case some paths have spaces
- Replace CMAKE_CURRENT_SOURCE_DIR with CMAKE_SOURCE_DIR in some places

This was originally part of #1603, but decided to break it out as it's not necessarily a change that is only needed for unit testing.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
