### PR TITLE
RTSP encryption support

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -3,6 +3,7 @@
  * @brief todo
  */
 #include "network.h"
+#include "config.h"
 #include "utility.h"
 #include <algorithm>
 
@@ -171,6 +172,22 @@ namespace net {
     }
     else {
       return address.to_string();
+    }
+  }
+
+  /**
+   * @brief Returns the encryption mode for the given remote endpoint address.
+   * @param address The address used to look up the desired encryption mode.
+   * @return The WAN or LAN encryption mode, based on the provided address.
+   */
+  int
+  encryption_mode_for_address(boost::asio::ip::address address) {
+    auto nettype = net::from_address(address.to_string());
+    if (nettype == net::net_e::PC || nettype == net::net_e::LAN) {
+      return config::stream.lan_encryption_mode;
+    }
+    else {
+      return config::stream.wan_encryption_mode;
     }
   }
 

--- a/src/network.h
+++ b/src/network.h
@@ -84,4 +84,12 @@ namespace net {
    */
   std::string
   addr_to_url_escaped_string(boost::asio::ip::address address);
+
+  /**
+   * @brief Returns the encryption mode for the given remote endpoint address.
+   * @param address The address used to look up the desired encryption mode.
+   * @return The WAN or LAN encryption mode, based on the provided address.
+   */
+  int
+  encryption_mode_for_address(boost::asio::ip::address address);
 }  // namespace net

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -820,6 +820,17 @@ namespace nvhttp {
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     auto launch_session = make_launch_session(host_audio, args);
 
+    auto encryption_mode = net::encryption_mode_for_address(request->remote_endpoint().address());
+    if (!launch_session->rtsp_cipher && encryption_mode == config::ENCRYPTION_MODE_MANDATORY) {
+      BOOST_LOG(error) << "Rejecting client that cannot comply with mandatory encryption requirement"sv;
+
+      tree.put("root.<xmlattr>.status_code", 403);
+      tree.put("root.<xmlattr>.status_message", "Encryption is mandatory for this host but unsupported by the client");
+      tree.put("root.gamesession", 0);
+
+      return;
+    }
+
     if (appid > 0) {
       auto err = proc::proc.execute(appid, launch_session);
       if (err) {
@@ -905,6 +916,17 @@ namespace nvhttp {
     }
 
     auto launch_session = make_launch_session(host_audio, args);
+
+    auto encryption_mode = net::encryption_mode_for_address(request->remote_endpoint().address());
+    if (!launch_session->rtsp_cipher && encryption_mode == config::ENCRYPTION_MODE_MANDATORY) {
+      BOOST_LOG(error) << "Rejecting client that cannot comply with mandatory encryption requirement"sv;
+
+      tree.put("root.<xmlattr>.status_code", 403);
+      tree.put("root.<xmlattr>.status_message", "Encryption is mandatory for this host but unsupported by the client");
+      tree.put("root.gamesession", 0);
+
+      return;
+    }
 
     tree.put("root.<xmlattr>.status_code", 200);
     tree.put("root.sessionUrl0", launch_session->rtsp_url_scheme +

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -136,7 +136,7 @@ namespace proc {
   }
 
   int
-  proc_t::execute(int app_id, rtsp_stream::launch_session_t launch_session) {
+  proc_t::execute(int app_id, std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
     // Ensure starting from a clean slate
     terminate();
 
@@ -157,14 +157,14 @@ namespace proc {
     // Add Stream-specific environment variables
     _env["SUNSHINE_APP_ID"] = std::to_string(_app_id);
     _env["SUNSHINE_APP_NAME"] = _app.name;
-    _env["SUNSHINE_CLIENT_WIDTH"] = std::to_string(launch_session.width);
-    _env["SUNSHINE_CLIENT_HEIGHT"] = std::to_string(launch_session.height);
-    _env["SUNSHINE_CLIENT_FPS"] = std::to_string(launch_session.fps);
-    _env["SUNSHINE_CLIENT_HDR"] = launch_session.enable_hdr ? "true" : "false";
-    _env["SUNSHINE_CLIENT_GCMAP"] = std::to_string(launch_session.gcmap);
-    _env["SUNSHINE_CLIENT_HOST_AUDIO"] = launch_session.host_audio ? "true" : "false";
-    _env["SUNSHINE_CLIENT_ENABLE_SOPS"] = launch_session.enable_sops ? "true" : "false";
-    int channelCount = launch_session.surround_info & (65535);
+    _env["SUNSHINE_CLIENT_WIDTH"] = std::to_string(launch_session->width);
+    _env["SUNSHINE_CLIENT_HEIGHT"] = std::to_string(launch_session->height);
+    _env["SUNSHINE_CLIENT_FPS"] = std::to_string(launch_session->fps);
+    _env["SUNSHINE_CLIENT_HDR"] = launch_session->enable_hdr ? "true" : "false";
+    _env["SUNSHINE_CLIENT_GCMAP"] = std::to_string(launch_session->gcmap);
+    _env["SUNSHINE_CLIENT_HOST_AUDIO"] = launch_session->host_audio ? "true" : "false";
+    _env["SUNSHINE_CLIENT_ENABLE_SOPS"] = launch_session->enable_sops ? "true" : "false";
+    int channelCount = launch_session->surround_info & (65535);
     switch (channelCount) {
       case 2:
         _env["SUNSHINE_CLIENT_AUDIO_CONFIGURATION"] = "2.0";

--- a/src/process.h
+++ b/src/process.h
@@ -75,7 +75,7 @@ namespace proc {
         _apps(std::move(apps)) {}
 
     int
-    execute(int app_id, rtsp_stream::launch_session_t launch_session);
+    execute(int app_id, std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
 
     /**
      * @return _app_id if a process is running, otherwise returns 0

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -41,6 +41,40 @@ namespace rtsp_stream {
     delete msg;
   }
 
+#pragma pack(push, 1)
+
+  struct encrypted_rtsp_header_t {
+    // We set the MSB in encrypted RTSP messages to allow format-agnostic
+    // parsing code to be able to tell encrypted from plaintext messages.
+    static constexpr std::uint32_t ENCRYPTED_MESSAGE_TYPE_BIT = 0x80000000;
+
+    uint8_t *
+    payload() {
+      return (uint8_t *) (this + 1);
+    }
+
+    std::uint32_t
+    payload_length() {
+      return util::endian::big<std::uint32_t>(typeAndLength) & ~ENCRYPTED_MESSAGE_TYPE_BIT;
+    }
+
+    bool
+    is_encrypted() {
+      return !!(util::endian::big<std::uint32_t>(typeAndLength) & ENCRYPTED_MESSAGE_TYPE_BIT);
+    }
+
+    // This field is the length of the payload + ENCRYPTED_MESSAGE_TYPE_BIT in big-endian
+    std::uint32_t typeAndLength;
+
+    // This field is the number used to initialize the bottom 4 bytes of the AES IV in big-endian
+    std::uint32_t sequenceNumber;
+
+    // This field is the AES GCM authentication tag
+    std::uint8_t tag[16];
+  };
+
+#pragma pack(pop)
+
   class rtsp_server_t;
 
   using msg_t = util::safe_ptr<RTSP_MESSAGE, free_msg>;
@@ -58,61 +92,207 @@ namespace rtsp_stream {
     socket_t(boost::asio::io_service &ios, std::function<void(tcp::socket &sock, launch_session_t &, msg_t &&)> &&handle_data_fn):
         handle_data_fn { std::move(handle_data_fn) }, sock { ios } {}
 
+    /**
+     * @brief Queues an asynchronous read to begin the next message.
+     */
     void
     read() {
-      if (begin == std::end(msg_buf)) {
+      if (begin == std::end(msg_buf) || (session->rtsp_cipher && begin + sizeof(encrypted_rtsp_header_t) >= std::end(msg_buf))) {
         BOOST_LOG(error) << "RTSP: read(): Exceeded maximum rtsp packet size: "sv << msg_buf.size();
 
         respond(sock, *session, nullptr, 400, "BAD REQUEST", 0, {});
 
-        sock.close();
+        boost::system::error_code ec;
+        sock.close(ec);
 
         return;
       }
 
-      sock.async_read_some(
-        boost::asio::buffer(begin, (std::size_t)(std::end(msg_buf) - begin)),
-        boost::bind(
-          &socket_t::handle_read, shared_from_this(),
-          boost::asio::placeholders::error,
-          boost::asio::placeholders::bytes_transferred));
-    }
-
-    void
-    read_payload() {
-      if (begin == std::end(msg_buf)) {
-        BOOST_LOG(error) << "RTSP: read_payload(): Exceeded maximum rtsp packet size: "sv << msg_buf.size();
-
-        respond(sock, *session, nullptr, 400, "BAD REQUEST", 0, {});
-
-        sock.close();
-
-        return;
+      if (session->rtsp_cipher) {
+        // For encrypted RTSP, we will read the the entire header first
+        boost::asio::async_read(sock,
+          boost::asio::buffer(begin, sizeof(encrypted_rtsp_header_t)),
+          boost::bind(
+            &socket_t::handle_read_encrypted_header, shared_from_this(),
+            boost::asio::placeholders::error,
+            boost::asio::placeholders::bytes_transferred));
       }
-
-      sock.async_read_some(
-        boost::asio::buffer(begin, (std::size_t)(std::end(msg_buf) - begin)),
-        boost::bind(
-          &socket_t::handle_payload, shared_from_this(),
-          boost::asio::placeholders::error,
-          boost::asio::placeholders::bytes_transferred));
+      else {
+        sock.async_read_some(
+          boost::asio::buffer(begin, (std::size_t)(std::end(msg_buf) - begin)),
+          boost::bind(
+            &socket_t::handle_read_plaintext, shared_from_this(),
+            boost::asio::placeholders::error,
+            boost::asio::placeholders::bytes_transferred));
+      }
     }
 
+    /**
+     * @brief Handles the initial read of the header of an encrypted message.
+     * @param socket The socket the message was received on.
+     * @param ec The error code of the read operation.
+     * @param bytes The number of bytes read.
+     */
     static void
-    handle_payload(std::shared_ptr<socket_t> &socket, const boost::system::error_code &ec, std::size_t bytes) {
-      BOOST_LOG(debug) << "handle_payload(): Handle read of size: "sv << bytes << " bytes"sv;
+    handle_read_encrypted_header(std::shared_ptr<socket_t> &socket, const boost::system::error_code &ec, std::size_t bytes) {
+      BOOST_LOG(debug) << "handle_read_encrypted_header(): Handle read of size: "sv << bytes << " bytes"sv;
 
       auto sock_close = util::fail_guard([&socket]() {
         boost::system::error_code ec;
         socket->sock.close(ec);
 
         if (ec) {
-          BOOST_LOG(error) << "RTSP: handle_payload(): Couldn't close tcp socket: "sv << ec.message();
+          BOOST_LOG(error) << "RTSP: handle_read_encrypted_header(): Couldn't close tcp socket: "sv << ec.message();
+        }
+      });
+
+      if (ec || bytes < sizeof(encrypted_rtsp_header_t)) {
+        BOOST_LOG(error) << "RTSP: handle_read_encrypted_header(): Couldn't read from tcp socket: "sv << ec.message();
+
+        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        return;
+      }
+
+      auto header = (encrypted_rtsp_header_t *) socket->begin;
+      if (!header->is_encrypted()) {
+        BOOST_LOG(error) << "RTSP: handle_read_encrypted_header(): Rejecting unencrypted RTSP message"sv;
+
+        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        return;
+      }
+
+      auto payload_length = header->payload_length();
+
+      // Check if we have enough space to read this message
+      if (socket->begin + sizeof(*header) + payload_length >= std::end(socket->msg_buf)) {
+        BOOST_LOG(error) << "RTSP: handle_read_encrypted_header(): Exceeded maximum rtsp packet size: "sv << socket->msg_buf.size();
+
+        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        return;
+      }
+
+      sock_close.disable();
+
+      // Read the remainder of the header and full encrypted payload
+      boost::asio::async_read(socket->sock,
+        boost::asio::buffer(socket->begin + bytes, payload_length),
+        boost::bind(
+          &socket_t::handle_read_encrypted_message, socket->shared_from_this(),
+          boost::asio::placeholders::error,
+          boost::asio::placeholders::bytes_transferred));
+    }
+
+    /**
+     * @brief Handles the final read of the content of an encrypted message.
+     * @param socket The socket the message was received on.
+     * @param ec The error code of the read operation.
+     * @param bytes The number of bytes read.
+     */
+    static void
+    handle_read_encrypted_message(std::shared_ptr<socket_t> &socket, const boost::system::error_code &ec, std::size_t bytes) {
+      BOOST_LOG(debug) << "handle_read_encrypted(): Handle read of size: "sv << bytes << " bytes"sv;
+
+      auto sock_close = util::fail_guard([&socket]() {
+        boost::system::error_code ec;
+        socket->sock.close(ec);
+
+        if (ec) {
+          BOOST_LOG(error) << "RTSP: handle_read_encrypted_message(): Couldn't close tcp socket: "sv << ec.message();
+        }
+      });
+
+      auto header = (encrypted_rtsp_header_t *) socket->begin;
+      auto payload_length = header->payload_length();
+      auto seq = util::endian::big<std::uint32_t>(header->sequenceNumber);
+
+      if (ec || bytes < payload_length) {
+        BOOST_LOG(error) << "RTSP: handle_read_encrypted(): Couldn't read from tcp socket: "sv << ec.message();
+
+        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        return;
+      }
+
+      // We use the deterministic IV construction algorithm specified in NIST SP 800-38D
+      // Section 8.2.1. The sequence number is our "invocation" field and the 'RC' in the
+      // high bytes is the "fixed" field. Because each client provides their own unique
+      // key, our values in the fixed field need only uniquely identify each independent
+      // use of the client's key with AES-GCM in our code.
+      //
+      // The sequence number is 32 bits long which allows for 2^32 RTSP messages to be
+      // received from each client before the IV repeats.
+      crypto::aes_t iv(12);
+      std::copy_n((uint8_t *) &seq, sizeof(seq), std::begin(iv));
+      iv[10] = 'C';  // Client originated
+      iv[11] = 'R';  // RTSP
+
+      std::vector<uint8_t> plaintext;
+      if (socket->session->rtsp_cipher->decrypt(std::string_view { (const char *) header->tag, sizeof(header->tag) + bytes }, plaintext, &iv)) {
+        BOOST_LOG(error) << "Failed to verify RTSP message tag"sv;
+
+        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        return;
+      }
+
+      msg_t req { new msg_t::element_type {} };
+      if (auto status = parseRtspMessage(req.get(), (char *) plaintext.data(), plaintext.size())) {
+        BOOST_LOG(error) << "Malformed RTSP message: ["sv << status << ']';
+
+        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        return;
+      }
+
+      sock_close.disable();
+
+      print_msg(req.get());
+
+      socket->handle_data(std::move(req));
+    }
+
+    /**
+     * @brief Queues an asynchronous read of the payload portion of a plaintext message.
+     */
+    void
+    read_plaintext_payload() {
+      if (begin == std::end(msg_buf)) {
+        BOOST_LOG(error) << "RTSP: read_plaintext_payload(): Exceeded maximum rtsp packet size: "sv << msg_buf.size();
+
+        respond(sock, *session, nullptr, 400, "BAD REQUEST", 0, {});
+
+        boost::system::error_code ec;
+        sock.close(ec);
+
+        return;
+      }
+
+      sock.async_read_some(
+        boost::asio::buffer(begin, (std::size_t)(std::end(msg_buf) - begin)),
+        boost::bind(
+          &socket_t::handle_plaintext_payload, shared_from_this(),
+          boost::asio::placeholders::error,
+          boost::asio::placeholders::bytes_transferred));
+    }
+
+    /**
+     * @brief Handles the read of the payload portion of a plaintext message.
+     * @param socket The socket the message was received on.
+     * @param ec The error code of the read operation.
+     * @param bytes The number of bytes read.
+     */
+    static void
+    handle_plaintext_payload(std::shared_ptr<socket_t> &socket, const boost::system::error_code &ec, std::size_t bytes) {
+      BOOST_LOG(debug) << "handle_plaintext_payload(): Handle read of size: "sv << bytes << " bytes"sv;
+
+      auto sock_close = util::fail_guard([&socket]() {
+        boost::system::error_code ec;
+        socket->sock.close(ec);
+
+        if (ec) {
+          BOOST_LOG(error) << "RTSP: handle_plaintext_payload(): Couldn't close tcp socket: "sv << ec.message();
         }
       });
 
       if (ec) {
-        BOOST_LOG(error) << "RTSP: handle_payload(): Couldn't read from tcp socket: "sv << ec.message();
+        BOOST_LOG(error) << "RTSP: handle_plaintext_payload(): Couldn't read from tcp socket: "sv << ec.message();
 
         return;
       }
@@ -122,14 +302,14 @@ namespace rtsp_stream {
       if (auto status = parseRtspMessage(req.get(), socket->msg_buf.data(), (std::size_t)(end - socket->msg_buf.data()))) {
         BOOST_LOG(error) << "Malformed RTSP message: ["sv << status << ']';
 
-        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", req->sequenceNumber, {});
+        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
         return;
       }
 
       sock_close.disable();
 
       auto fg = util::fail_guard([&socket]() {
-        socket->read_payload();
+        socket->read_plaintext_payload();
       });
 
       auto content_length = 0;
@@ -161,18 +341,24 @@ namespace rtsp_stream {
       socket->begin = end;
     }
 
+    /**
+     * @brief Handles the read of the header portion of a plaintext message.
+     * @param socket The socket the message was received on.
+     * @param ec The error code of the read operation.
+     * @param bytes The number of bytes read.
+     */
     static void
-    handle_read(std::shared_ptr<socket_t> &socket, const boost::system::error_code &ec, std::size_t bytes) {
-      BOOST_LOG(debug) << "handle_read(): Handle read of size: "sv << bytes << " bytes"sv;
+    handle_read_plaintext(std::shared_ptr<socket_t> &socket, const boost::system::error_code &ec, std::size_t bytes) {
+      BOOST_LOG(debug) << "handle_read_plaintext(): Handle read of size: "sv << bytes << " bytes"sv;
 
       if (ec) {
-        BOOST_LOG(error) << "RTSP: handle_read(): Couldn't read from tcp socket: "sv << ec.message();
+        BOOST_LOG(error) << "RTSP: handle_read_plaintext(): Couldn't read from tcp socket: "sv << ec.message();
 
         boost::system::error_code ec;
         socket->sock.close(ec);
 
         if (ec) {
-          BOOST_LOG(error) << "RTSP: handle_read(): Couldn't close tcp socket: "sv << ec.message();
+          BOOST_LOG(error) << "RTSP: handle_read_plaintext(): Couldn't close tcp socket: "sv << ec.message();
         }
 
         return;
@@ -201,7 +387,7 @@ namespace rtsp_stream {
       buf_size = end - socket->begin;
 
       fg.disable();
-      handle_payload(socket, ec, buf_size);
+      handle_plaintext_payload(socket, ec, buf_size);
     }
 
     void
@@ -280,7 +466,8 @@ namespace rtsp_stream {
         cmd_not_found(sock, session, std::move(req));
       }
 
-      sock.shutdown(boost::asio::socket_base::shutdown_type::shutdown_both);
+      boost::system::error_code ec;
+      sock.shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
     }
 
     void
@@ -293,18 +480,27 @@ namespace rtsp_stream {
         return;
       }
 
-      auto launch_session { launch_event.view() };
+      auto socket = std::move(next_socket);
+
+      auto launch_session { launch_event.view(0s) };
       if (launch_session) {
         // Associate the current RTSP session with this socket and start reading
-        auto socket = std::move(next_socket);
         socket->session = launch_session;
         socket->read();
+      }
+      else {
+        // This can happen due to normal things like port scanning, so let's not make these visible by default
+        BOOST_LOG(debug) << "No pending session for incoming RTSP connection"sv;
 
-        next_socket = std::make_shared<socket_t>(ios, [this](tcp::socket &sock, launch_session_t &session, msg_t &&msg) {
-          handle_msg(sock, session, std::move(msg));
-        });
+        // If there is no session pending, close the connection immediately
+        boost::system::error_code ec;
+        socket->sock.close(ec);
       }
 
+      // Queue another asynchronous accept for the next incoming connection
+      next_socket = std::make_shared<socket_t>(ios, [this](tcp::socket &sock, launch_session_t &session, msg_t &&msg) {
+        handle_msg(sock, session, std::move(msg));
+      });
       acceptor.async_accept(next_socket->sock, [this](const auto &ec) {
         handle_accept(ec);
       });
@@ -343,7 +539,7 @@ namespace rtsp_stream {
     session_clear(uint32_t launch_session_id) {
       // We currently only support a single pending RTSP session,
       // so the ID should always match the one for that session.
-      auto launch_session = launch_event.view();
+      auto launch_session = launch_event.view(0s);
       if (launch_session) {
         if (launch_session->id != launch_session_id) {
           BOOST_LOG(error) << "Attempted to clear unexpected session: "sv << launch_session_id << " vs "sv << launch_session->id;
@@ -498,13 +694,53 @@ namespace rtsp_stream {
       << std::string_view { payload.first, (std::size_t) payload.second } << std::endl
       << "---End Response---"sv << std::endl;
 
-    std::string_view tmp_resp { raw_resp.get(), (size_t) serialized_len };
+    // Encrypt the RTSP message if encryption is enabled
+    if (session.rtsp_cipher) {
+      // We use the deterministic IV construction algorithm specified in NIST SP 800-38D
+      // Section 8.2.1. The sequence number is our "invocation" field and the 'RH' in the
+      // high bytes is the "fixed" field. Because each client provides their own unique
+      // key, our values in the fixed field need only uniquely identify each independent
+      // use of the client's key with AES-GCM in our code.
+      //
+      // The sequence number is 32 bits long which allows for 2^32 RTSP messages to be
+      // sent to each client before the IV repeats.
+      crypto::aes_t iv(12);
+      session.rtsp_iv_counter++;
+      std::copy_n((uint8_t *) &session.rtsp_iv_counter, sizeof(session.rtsp_iv_counter), std::begin(iv));
+      iv[10] = 'H';  // Host originated
+      iv[11] = 'R';  // RTSP
 
-    if (send(sock, tmp_resp)) {
-      return;
+      // Allocate the message with an empty header and reserved space for the payload
+      auto payload_length = serialized_len + payload.second;
+      std::vector<uint8_t> message(sizeof(encrypted_rtsp_header_t));
+      message.reserve(message.size() + payload_length);
+
+      // Copy the complete plaintext into the message
+      std::copy_n(raw_resp.get(), serialized_len, std::back_inserter(message));
+      std::copy_n(payload.first, payload.second, std::back_inserter(message));
+
+      // Initialize the message header
+      auto header = (encrypted_rtsp_header_t *) message.data();
+      header->typeAndLength = util::endian::big<std::uint32_t>(encrypted_rtsp_header_t::ENCRYPTED_MESSAGE_TYPE_BIT + payload_length);
+      header->sequenceNumber = util::endian::big<std::uint32_t>(session.rtsp_iv_counter);
+
+      // Encrypt the RTSP message in place
+      session.rtsp_cipher->encrypt(std::string_view { (const char *) header->payload(), (std::size_t) payload_length }, header->tag, &iv);
+
+      // Send the full encrypted message
+      send(sock, std::string_view { (char *) message.data(), message.size() });
     }
+    else {
+      std::string_view tmp_resp { raw_resp.get(), (size_t) serialized_len };
 
-    send(sock, std::string_view { payload.first, (std::size_t) payload.second });
+      // Send the plaintext RTSP message header
+      if (send(sock, tmp_resp)) {
+        return;
+      }
+
+      // Send the plaintext RTSP message payload (if present)
+      send(sock, std::string_view { payload.first, (std::size_t) payload.second });
+    }
   }
 
   void

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -789,14 +789,7 @@ namespace rtsp_stream {
     uint32_t encryption_flags_requested = SS_ENC_CONTROL_V2;
 
     // Determine the encryption desired for this remote endpoint
-    auto nettype = net::from_address(sock.remote_endpoint().address().to_string());
-    int encryption_mode;
-    if (nettype == net::net_e::PC || nettype == net::net_e::LAN) {
-      encryption_mode = config::stream.lan_encryption_mode;
-    }
-    else {
-      encryption_mode = config::stream.wan_encryption_mode;
-    }
+    auto encryption_mode = net::encryption_mode_for_address(sock.remote_endpoint().address());
     if (encryption_mode != config::ENCRYPTION_MODE_NEVER) {
       // Advertise support for video encryption if it's not disabled
       encryption_flags_supported |= SS_ENC_VIDEO;
@@ -1080,14 +1073,7 @@ namespace rtsp_stream {
     }
 
     // Check that any required encryption is enabled
-    auto nettype = net::from_address(sock.remote_endpoint().address().to_string());
-    int encryption_mode;
-    if (nettype == net::net_e::PC || nettype == net::net_e::LAN) {
-      encryption_mode = config::stream.lan_encryption_mode;
-    }
-    else {
-      encryption_mode = config::stream.wan_encryption_mode;
-    }
+    auto encryption_mode = net::encryption_mode_for_address(sock.remote_endpoint().address());
     if (encryption_mode == config::ENCRYPTION_MODE_MANDATORY &&
         (config.encryptionFlagsEnabled & (SS_ENC_VIDEO | SS_ENC_AUDIO)) != (SS_ENC_VIDEO | SS_ENC_AUDIO)) {
       BOOST_LOG(error) << "Rejecting client that cannot comply with mandatory encryption requirement"sv;

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -31,6 +31,10 @@ namespace rtsp_stream {
     int surround_info;
     bool enable_hdr;
     bool enable_sops;
+
+    std::optional<crypto::cipher::gcm_t> rtsp_cipher;
+    std::string rtsp_url_scheme;
+    uint32_t rtsp_iv_counter;
   };
 
   void

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -13,6 +13,8 @@ namespace rtsp_stream {
   constexpr auto RTSP_SETUP_PORT = 21;
 
   struct launch_session_t {
+    uint32_t id;
+
     crypto::aes_t gcm_key;
     crypto::aes_t iv;
 
@@ -32,7 +34,11 @@ namespace rtsp_stream {
   };
 
   void
-  launch_session_raise(launch_session_t launch_session);
+  launch_session_raise(std::shared_ptr<launch_session_t> launch_session);
+
+  void
+  launch_session_clear(uint32_t launch_session_id);
+
   int
   session_count();
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -411,6 +411,8 @@ namespace stream {
       safe::mail_raw_t::event_t<video::hdr_info_t> hdr_queue;
     } control;
 
+    std::uint32_t launch_session_id;
+
     safe::mail_raw_t::event_t<bool> shutdown_event;
     safe::signal_t controlEnd;
 
@@ -522,6 +524,9 @@ namespace stream {
           BOOST_LOG(debug) << "Initialized new control stream session by IP address match [v1]"sv;
         }
       }
+
+      // Once the control stream connection is established, RTSP session state can be torn down
+      rtsp_stream::launch_session_clear(session_p->launch_session_id);
 
       session_p->control.peer = peer;
 
@@ -1881,6 +1886,7 @@ namespace stream {
       auto mail = std::make_shared<safe::mail_raw_t>();
 
       session->shutdown_event = mail->event<bool>(mail::shutdown);
+      session->launch_session_id = launch_session.id;
 
       session->config = config;
 

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -82,7 +82,7 @@ namespace safe {
     }
 
     // pop and view should not be used interchangeably
-    const status_t &
+    status_t
     view() {
       std::unique_lock ul { _lock };
 


### PR DESCRIPTION
## Description
This PR completes the full end-to-end encryption implementation by encrypting the RTSP traffic that is sent during session negotation. This completes the chain of trust from HTTPS -> RTSP -> Audio/Video/Control to prevent downgrade attacks on the other encryption schemes via manipulation of RTSP messages between Sunshine and Moonlight.

The first 2 commits are refactoring to get the code ready for the addition of encryption then https://github.com/LizardByte/Sunshine/pull/2095/commits/204489cac638a2eef2aff1c0a2a5fd13031d522a adds the actual encryption. cc: @ABeltramo 

### Negotiation

Since RTSP is typically the flexible mechanism that we use to negotiate new options, encrypting RTSP is somewhat tricky to avoid breaking compatibility on both ends while still not allowing downgrade attacks against new clients and servers.

To allow the client to advertise support for RTSP encryption, clients send a new `corever` parameter to the launch/resume request. Clients that support RTSP encryption will report `corever=1` (or later). This new parameter can be used for similar changes in the future where this type of backwards compatibility is required prior to RTSP negotiation.

If the server also supports RTSP encryption, it will use an alternate URL scheme (`rtspenc://`) in the `sessionUrl0` XML attribute included in the launch/resume response if (and only if) `corever >= 1`. This tells the client that server also supports RTSP encryption and thus RTSP encryption will be used.

Due to the risk of downgrade attacks, it is _critical_ that client and server both do not accept unencrypted RTSP when encryption is supported (ie when server saw `corever >= 1` and when client saw `rtspenc://`).

### Encrypted Messages

The general encryption scheme is very similar to the new control stream encryption from #2025 with the addition of a dedicated length field in the encrypted message header (since TCP doesn't provide message boundaries). It also has the most significant bit set in the first byte of the message to allow RTSP implementations to tell the RTSP encrypted messages from unencrypted messages by just reading the first byte, if they need that ability.

An additional benefit of this change is that hosts no longer have to parse the RTSP message itself to understand when the full RTSP request has been received. Now it's possible to simply read the entire message header which will give you the length of the payload with no message parsing required.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
