### PR TITLE
Encoder probing performance improvements

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -558,6 +558,13 @@ namespace platf {
   std::vector<std::string>
   display_names(mem_type_e hwdevice_type);
 
+  /**
+   * @brief Returns if GPUs/drivers have changed since the last call to this function.
+   * @return `true` if a change has occurred or if it is unknown whether a change occurred.
+   */
+  bool
+  needs_encoder_reenumeration();
+
   boost::process::child
   run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -773,6 +773,16 @@ namespace platf {
     return {};
   }
 
+  /**
+   * @brief Returns if GPUs/drivers have changed since the last call to this function.
+   * @return `true` if a change has occurred or if it is unknown whether a change occurred.
+   */
+  bool
+  needs_encoder_reenumeration() {
+    // We don't track GPU state, so we will always reenumerate. Fortunately, it is fast on Linux.
+    return true;
+  }
+
   std::shared_ptr<display_t>
   display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config) {
 #ifdef SUNSHINE_BUILD_CUDA

--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -181,4 +181,14 @@ namespace platf {
 
     return display_names;
   }
+
+  /**
+   * @brief Returns if GPUs/drivers have changed since the last call to this function.
+   * @return `true` if a change has occurred or if it is unknown whether a change occurred.
+   */
+  bool
+  needs_encoder_reenumeration() {
+    // We don't track GPU state, so we will always reenumerate. Fortunately, it is fast on macOS.
+    return true;
+  }
 }  // namespace platf

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1124,4 +1124,35 @@ namespace platf {
     return display_names;
   }
 
+  /**
+   * @brief Returns if GPUs/drivers have changed since the last call to this function.
+   * @return `true` if a change has occurred or if it is unknown whether a change occurred.
+   */
+  bool
+  needs_encoder_reenumeration() {
+    // Serialize access to the static DXGI factory
+    static std::mutex reenumeration_state_lock;
+    auto lg = std::lock_guard(reenumeration_state_lock);
+
+    // Keep a reference to the DXGI factory, which will keep track of changes internally.
+    static dxgi::factory1_t factory;
+    if (!factory || !factory->IsCurrent()) {
+      factory.reset();
+
+      auto status = CreateDXGIFactory1(IID_IDXGIFactory1, (void **) &factory);
+      if (FAILED(status)) {
+        BOOST_LOG(error) << "Failed to create DXGIFactory1 [0x"sv << util::hex(status).to_string_view() << ']';
+        factory.release();
+      }
+
+      // Always request reenumeration on the first streaming session just to ensure we
+      // can deal with any initialization races that may occur when the system is booting.
+      BOOST_LOG(info) << "Encoder reenumeration is required"sv;
+      return true;
+    }
+    else {
+      // The DXGI factory from last time is still current, so no encoder changes have occurred.
+      return false;
+    }
+  }
 }  // namespace platf

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2479,7 +2479,13 @@ namespace video {
       if (disp->is_codec_supported(encoder.hevc.name, config_autoselect)) {
       retry_hevc:
         auto max_ref_frames_hevc = validate_config(disp, encoder, config_max_ref_frames);
-        auto autoselect_hevc = max_ref_frames_hevc >= 0 ? max_ref_frames_hevc : validate_config(disp, encoder, config_autoselect);
+
+        // If H.264 succeeded with max ref frames specified, assume that we can count on
+        // HEVC to also succeed with max ref frames specified if HEVC is supported.
+        auto autoselect_hevc = (max_ref_frames_hevc >= 0 || max_ref_frames_h264 >= 0) ?
+                                 max_ref_frames_hevc :
+                                 validate_config(disp, encoder, config_autoselect);
+
         if (autoselect_hevc < 0 && encoder.hevc.qp && encoder.hevc[encoder_t::CBR]) {
           // It's possible the encoder isn't accepting Constant Bit Rate. Turn off CBR and make another attempt
           encoder.hevc.capabilities.set();
@@ -2511,7 +2517,13 @@ namespace video {
       if (disp->is_codec_supported(encoder.av1.name, config_autoselect)) {
       retry_av1:
         auto max_ref_frames_av1 = validate_config(disp, encoder, config_max_ref_frames);
-        auto autoselect_av1 = max_ref_frames_av1 >= 0 ? max_ref_frames_av1 : validate_config(disp, encoder, config_autoselect);
+
+        // If H.264 succeeded with max ref frames specified, assume that we can count on
+        // AV1 to also succeed with max ref frames specified if AV1 is supported.
+        auto autoselect_av1 = (max_ref_frames_av1 >= 0 || max_ref_frames_h264 >= 0) ?
+                                max_ref_frames_av1 :
+                                validate_config(disp, encoder, config_autoselect);
+
         if (autoselect_av1 < 0 && encoder.av1.qp && encoder.av1[encoder_t::CBR]) {
           // It's possible the encoder isn't accepting Constant Bit Rate. Turn off CBR and make another attempt
           encoder.av1.capabilities.set();

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -379,6 +379,10 @@ namespace video {
       std::vector<option_t> sdr_options;
       std::vector<option_t> hdr_options;
       std::vector<option_t> fallback_options;
+
+      // QP option to set in the case that CBR/VBR is not supported
+      // by the encoder. If CBR/VBR is guaranteed to be supported,
+      // don't specify this option to avoid wasteful encoder probing.
       std::optional<option_t> qp;
 
       std::string name;
@@ -595,7 +599,7 @@ namespace video {
       {},
       // Fallback options
       {},
-      std::nullopt,  // QP
+      std::nullopt,  // QP rate control fallback
       "av1_nvenc"s,
     },
     {
@@ -607,7 +611,7 @@ namespace video {
       {},
       // Fallback options
       {},
-      std::nullopt,  // QP
+      std::nullopt,  // QP rate control fallback
       "hevc_nvenc"s,
     },
     {
@@ -619,7 +623,7 @@ namespace video {
       {},
       // Fallback options
       {},
-      std::nullopt,  // QP
+      std::nullopt,  // QP rate control fallback
       "h264_nvenc"s,
     },
     PARALLEL_ENCODING | REF_FRAMES_INVALIDATION  // flags
@@ -660,7 +664,7 @@ namespace video {
       {},
       // Fallback options
       {},
-      std::nullopt,
+      std::nullopt,  // QP rate control fallback
       "av1_nvenc"s,
     },
     {
@@ -684,7 +688,7 @@ namespace video {
         { "profile"s, (int) nv::profile_hevc_e::main_10 },
       },
       {},  // Fallback options
-      std::nullopt,
+      std::nullopt,  // QP rate control fallback
       "hevc_nvenc"s,
     },
     {
@@ -705,7 +709,7 @@ namespace video {
       },
       {},  // HDR-specific options
       {},  // Fallback options
-      std::make_optional<encoder_t::option_t>({ "qp"s, &config::video.qp }),
+      std::nullopt,  // QP rate control fallback
       "h264_nvenc"s,
     },
     PARALLEL_ENCODING
@@ -735,7 +739,7 @@ namespace video {
       {},
       // Fallback options
       {},
-      std::make_optional<encoder_t::option_t>({ "qp"s, &config::video.qp }),
+      std::nullopt,  // QP rate control fallback
       "av1_qsv"s,
     },
     {
@@ -759,7 +763,7 @@ namespace video {
       },
       // Fallback options
       {},
-      std::make_optional<encoder_t::option_t>({ "qp"s, &config::video.qp }),
+      std::nullopt,  // QP rate control fallback
       "hevc_qsv"s,
     },
     {
@@ -786,7 +790,7 @@ namespace video {
       {
         { "low_power"s, 0 },  // Some old/low-end Intel GPUs don't support low power encoding
       },
-      std::make_optional<encoder_t::option_t>({ "qp"s, &config::video.qp }),
+      std::nullopt,  // QP rate control fallback
       "h264_qsv"s,
     },
     PARALLEL_ENCODING | CBR_WITH_VBR | RELAXED_COMPLIANCE | NO_RC_BUF_LIMIT
@@ -812,7 +816,7 @@ namespace video {
       {},  // SDR-specific options
       {},  // HDR-specific options
       {},  // Fallback options
-      std::make_optional<encoder_t::option_t>({ "qp_p"s, &config::video.qp }),
+      std::nullopt,  // QP rate control fallback
       "av1_amf"s,
     },
     {
@@ -833,7 +837,7 @@ namespace video {
       {},  // SDR-specific options
       {},  // HDR-specific options
       {},  // Fallback options
-      std::make_optional<encoder_t::option_t>({ "qp_p"s, &config::video.qp }),
+      std::nullopt,  // QP rate control fallback
       "hevc_amf"s,
     },
     {
@@ -857,7 +861,7 @@ namespace video {
       {
         { "usage"s, 2 /* AMF_VIDEO_ENCODER_USAGE_LOW_LATENCY */ },  // Workaround for https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/410
       },
-      std::make_optional<encoder_t::option_t>({ "qp_p"s, &config::video.qp }),
+      std::nullopt,  // QP rate control fallback
       "h264_amf"s,
     },
     PARALLEL_ENCODING
@@ -883,7 +887,9 @@ namespace video {
       {},  // SDR-specific options
       {},  // HDR-specific options
       {},  // Fallback options
-      std::make_optional<encoder_t::option_t>("qp"s, &config::video.qp),
+
+      // QP rate control fallback
+      std::nullopt,
 
 #ifdef ENABLE_BROKEN_AV1_ENCODER
       // Due to bugs preventing on-demand IDR frames from working and very poor
@@ -908,7 +914,7 @@ namespace video {
       {},  // SDR-specific options
       {},  // HDR-specific options
       {},  // Fallback options
-      std::make_optional<encoder_t::option_t>("qp"s, &config::video.qp),
+      std::nullopt,  // QP rate control fallback
       "libx265"s,
     },
     {
@@ -920,7 +926,7 @@ namespace video {
       {},  // SDR-specific options
       {},  // HDR-specific options
       {},  // Fallback options
-      std::make_optional<encoder_t::option_t>("qp"s, &config::video.qp),
+      std::nullopt,  // QP rate control fallback
       "libx264"s,
     },
     H264_ONLY | PARALLEL_ENCODING | ALWAYS_REPROBE

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2353,12 +2353,7 @@ namespace video {
   };
 
   int
-  validate_config(std::shared_ptr<platf::display_t> &disp, const encoder_t &encoder, const config_t &config) {
-    reset_display(disp, encoder.platform_formats->dev_type, config::video.output_name, config);
-    if (!disp) {
-      return -1;
-    }
-
+  validate_config(std::shared_ptr<platf::display_t> disp, const encoder_t &encoder, const config_t &config) {
     auto encode_device = make_encode_device(*disp, encoder, config);
     if (!encode_device) {
       return -1;
@@ -2560,6 +2555,12 @@ namespace video {
       h264.videoFormat = 0;
       hevc.videoFormat = 1;
       av1.videoFormat = 2;
+
+      // Reset the display since we're switching from SDR to HDR
+      reset_display(disp, encoder.platform_formats->dev_type, config::video.output_name, config);
+      if (!disp) {
+        return false;
+      }
 
       // HDR is not supported with H.264. Don't bother even trying it.
       encoder.h264[flag] = flag != encoder_t::DYNAMIC_RANGE && validate_config(disp, encoder, h264) >= 0;


### PR DESCRIPTION
## Description
Encoder reprobing takes a significant portion of the total time to connect, especially when streaming the desktop. This PR addresses this by avoiding reprobing in cases where we know the GPU hasn't change and improving the performance of reprobing when we do need to do it.

To skip reprobing, we can use `IDXGIFactory1::IsCurrent()` which will tell us if GPUs or outputs changed state since the factory object was created. This check does catch a bit more than is needed, since some output changes will trigger a reenumeration. However, for desktop streaming and for games where the user just wants to adjust some Moonlight settings and get right back in, this is a major improvement. We can probably do better once #2032 is in.

For reprobing optimizations, we now avoid testing an encoder again with QP rate control when we know that the encoder _always_ supports CBR/VBR. Trying again with QP just wastes time because we already know the encoder isn't present.

Likewise, we now don't bother trying again with an undefined reference frame count if we already found this encoder accepted a specific number of reference frames for H.264. I don't think there are any encoders in the real world that would accept reference frame count for H.264 but not HEVC or AV1.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
