### PR TITLE
refactor(main): move map_port to network

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -723,7 +723,7 @@ namespace confighttp {
   start() {
     auto shutdown_event = mail::man->event<bool>(mail::shutdown);
 
-    auto port_https = map_port(PORT_HTTPS);
+    auto port_https = net::map_port(PORT_HTTPS);
     auto address_family = net::af_from_enum_string(config::sunshine.address_family);
 
     https_server_t server { config::nvhttp.cert, config::nvhttp.pkey };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "httpcommon.h"
 #include "logging.h"
 #include "main.h"
+#include "network.h"
 #include "nvhttp.h"
 #include "platform/common.h"
 #include "process.h"
@@ -810,29 +811,4 @@ write_file(const char *path, const std::string_view &contents) {
   out << contents;
 
   return 0;
-}
-
-/**
- * @brief Map a specified port based on the base port.
- * @param port The port to map as a difference from the base port.
- * @return `std:uint16_t` : The mapped port number.
- *
- * EXAMPLES:
- * ```cpp
- * std::uint16_t mapped_port = map_port(1);
- * ```
- */
-std::uint16_t
-map_port(int port) {
-  // calculate the port from the config port
-  auto mapped_port = (std::uint16_t)((int) config::sunshine.port + port);
-
-  // Ensure port is in the range of 1024-65535
-  if (mapped_port < 1024 || mapped_port > 65535) {
-    BOOST_LOG(warning) << "Port out of range: "sv << mapped_port;
-  }
-
-  // TODO: Ensure port is not already in use by another application
-
-  return mapped_port;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -298,7 +298,7 @@ namespace service_ctrl {
         return false;
       }
 
-      uint16_t port_nbo = htons(map_port(confighttp::PORT_HTTPS));
+      uint16_t port_nbo = htons(net::map_port(confighttp::PORT_HTTPS));
       for (DWORD i = 0; i < tcp_table->dwNumEntries; i++) {
         auto &entry = tcp_table->table[i];
 
@@ -349,7 +349,7 @@ is_gamestream_enabled() {
  */
 void
 launch_ui() {
-  std::string url = "https://localhost:" + std::to_string(map_port(confighttp::PORT_HTTPS));
+  std::string url = "https://localhost:" + std::to_string(net::map_port(confighttp::PORT_HTTPS));
   platf::open_url(url);
 }
 
@@ -363,7 +363,7 @@ launch_ui() {
  */
 void
 launch_ui_with_path(std::string path) {
-  std::string url = "https://localhost:" + std::to_string(map_port(confighttp::PORT_HTTPS)) + path;
+  std::string url = "https://localhost:" + std::to_string(net::map_port(confighttp::PORT_HTTPS)) + path;
   platf::open_url(url);
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -30,8 +30,6 @@ std::string
 read_file(const char *path);
 int
 write_file(const char *path, const std::string_view &contents);
-std::uint16_t
-map_port(int port);
 void
 launch_ui();
 void

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -10,31 +10,6 @@
 
 using namespace std::literals;
 
-/**
- * @brief Map a specified port based on the base port.
- * @param port The port to map as a difference from the base port.
- * @return `std:uint16_t` : The mapped port number.
- *
- * EXAMPLES:
- * ```cpp
- * std::uint16_t mapped_port = map_port(1);
- * ```
- */
-std::uint16_t
-map_port(int port) {
-  // calculate the port from the config port
-  auto mapped_port = (std::uint16_t)((int) config::sunshine.port + port);
-
-  // Ensure port is in the range of 1024-65535
-  if (mapped_port < 1024 || mapped_port > 65535) {
-    BOOST_LOG(warning) << "Port out of range: "sv << mapped_port;
-  }
-
-  // TODO: Ensure port is not already in use by another application
-
-  return mapped_port;
-}
-
 namespace ip = boost::asio::ip;
 
 namespace net {
@@ -247,5 +222,30 @@ namespace net {
     });
 
     enet_host_destroy(host);
+  }
+
+  /**
+   * @brief Map a specified port based on the base port.
+   * @param port The port to map as a difference from the base port.
+   * @return `std:uint16_t` : The mapped port number.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * std::uint16_t mapped_port = net::map_port(1);
+   * ```
+   */
+  std::uint16_t
+  map_port(int port) {
+    // calculate the port from the config port
+    auto mapped_port = (std::uint16_t)((int) config::sunshine.port + port);
+
+    // Ensure port is in the range of 1024-65535
+    if (mapped_port < 1024 || mapped_port > 65535) {
+      BOOST_LOG(warning) << "Port out of range: "sv << mapped_port;
+    }
+
+    // TODO: Ensure port is not already in use by another application
+
+    return mapped_port;
   }
 }  // namespace net

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -4,10 +4,36 @@
  */
 #include "network.h"
 #include "config.h"
+#include "logging.h"
 #include "utility.h"
 #include <algorithm>
 
 using namespace std::literals;
+
+/**
+ * @brief Map a specified port based on the base port.
+ * @param port The port to map as a difference from the base port.
+ * @return `std:uint16_t` : The mapped port number.
+ *
+ * EXAMPLES:
+ * ```cpp
+ * std::uint16_t mapped_port = map_port(1);
+ * ```
+ */
+std::uint16_t
+map_port(int port) {
+  // calculate the port from the config port
+  auto mapped_port = (std::uint16_t)((int) config::sunshine.port + port);
+
+  // Ensure port is in the range of 1024-65535
+  if (mapped_port < 1024 || mapped_port > 65535) {
+    BOOST_LOG(warning) << "Port out of range: "sv << mapped_port;
+  }
+
+  // TODO: Ensure port is not already in use by another application
+
+  return mapped_port;
+}
 
 namespace ip = boost::asio::ip;
 

--- a/src/network.h
+++ b/src/network.h
@@ -12,13 +12,12 @@
 
 #include "utility.h"
 
-// functions
-std::uint16_t
-map_port(int port);
-
 namespace net {
   void
   free_host(ENetHost *host);
+
+  std::uint16_t
+  map_port(int port);
 
   using host_t = util::safe_ptr<ENetHost, free_host>;
   using peer_t = ENetPeer *;

--- a/src/network.h
+++ b/src/network.h
@@ -12,6 +12,10 @@
 
 #include "utility.h"
 
+// functions
+std::uint16_t
+map_port(int port);
+
 namespace net {
   void
   free_host(ENetHost *host);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -657,8 +657,8 @@ namespace nvhttp {
     tree.put("root.appversion", VERSION);
     tree.put("root.GfeVersion", GFE_VERSION);
     tree.put("root.uniqueid", http::unique_id);
-    tree.put("root.HttpsPort", map_port(PORT_HTTPS));
-    tree.put("root.ExternalPort", map_port(PORT_HTTP));
+    tree.put("root.HttpsPort", net::map_port(PORT_HTTPS));
+    tree.put("root.ExternalPort", net::map_port(PORT_HTTP));
     tree.put("root.mac", platf::get_mac_address(net::addr_to_normalized_string(local_endpoint.address())));
     tree.put("root.MaxLumaPixelsHEVC", video::active_hevc_mode > 1 ? "1869449984" : "0");
 
@@ -846,7 +846,7 @@ namespace nvhttp {
     tree.put("root.<xmlattr>.status_code", 200);
     tree.put("root.sessionUrl0", launch_session->rtsp_url_scheme +
                                    net::addr_to_url_escaped_string(request->local_endpoint().address()) + ':' +
-                                   std::to_string(map_port(rtsp_stream::RTSP_SETUP_PORT)));
+                                   std::to_string(net::map_port(rtsp_stream::RTSP_SETUP_PORT)));
     tree.put("root.gamesession", 1);
 
     rtsp_stream::launch_session_raise(launch_session);
@@ -932,7 +932,7 @@ namespace nvhttp {
     tree.put("root.<xmlattr>.status_code", 200);
     tree.put("root.sessionUrl0", launch_session->rtsp_url_scheme +
                                    net::addr_to_url_escaped_string(request->local_endpoint().address()) + ':' +
-                                   std::to_string(map_port(rtsp_stream::RTSP_SETUP_PORT)));
+                                   std::to_string(net::map_port(rtsp_stream::RTSP_SETUP_PORT)));
     tree.put("root.resume", 1);
 
     rtsp_stream::launch_session_raise(launch_session);
@@ -995,8 +995,8 @@ namespace nvhttp {
   start() {
     auto shutdown_event = mail::man->event<bool>(mail::shutdown);
 
-    auto port_http = map_port(PORT_HTTP);
-    auto port_https = map_port(PORT_HTTPS);
+    auto port_http = net::map_port(PORT_HTTP);
+    auto port_https = net::map_port(PORT_HTTPS);
     auto address_family = net::af_from_enum_string(config::sunshine.address_family);
 
     bool clean_slate = config::sunshine.flags[config::flag::FRESH_STATE];

--- a/src/platform/linux/publish.cpp
+++ b/src/platform/linux/publish.cpp
@@ -8,7 +8,7 @@
 
 #include "misc.h"
 #include "src/logging.h"
-#include "src/main.h"
+#include "src/network.h"
 #include "src/nvhttp.h"
 #include "src/platform/common.h"
 #include "src/utility.h"

--- a/src/platform/linux/publish.cpp
+++ b/src/platform/linux/publish.cpp
@@ -349,7 +349,7 @@ namespace platf::publish {
         name.get(),
         SERVICE_TYPE,
         nullptr, nullptr,
-        map_port(nvhttp::PORT_HTTP),
+        net::map_port(nvhttp::PORT_HTTP),
         nullptr);
 
       if (ret < 0) {

--- a/src/platform/macos/publish.cpp
+++ b/src/platform/macos/publish.cpp
@@ -8,7 +8,7 @@
 
 #include "misc.h"
 #include "src/logging.h"
-#include "src/main.h"
+#include "src/network.h"
 #include "src/nvhttp.h"
 #include "src/platform/common.h"
 #include "src/utility.h"

--- a/src/platform/macos/publish.cpp
+++ b/src/platform/macos/publish.cpp
@@ -349,7 +349,7 @@ namespace platf::publish {
         name.get(),
         SERVICE_TYPE,
         nullptr, nullptr,
-        map_port(nvhttp::PORT_HTTP),
+        net::map_port(nvhttp::PORT_HTTP),
         nullptr);
 
       if (ret < 0) {

--- a/src/platform/windows/publish.cpp
+++ b/src/platform/windows/publish.cpp
@@ -117,7 +117,7 @@ namespace platf::publish {
 
     DNS_SERVICE_INSTANCE instance {};
     instance.pszInstanceName = name.data();
-    instance.wPort = map_port(nvhttp::PORT_HTTP);
+    instance.wPort = net::map_port(nvhttp::PORT_HTTP);
     instance.pszHostName = host.data();
 
     // Setting these values ensures Windows mDNS answers comply with RFC 1035.

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -869,13 +869,13 @@ namespace rtsp_stream {
 
     std::uint16_t port;
     if (type == "audio"sv) {
-      port = map_port(stream::AUDIO_STREAM_PORT);
+      port = net::map_port(stream::AUDIO_STREAM_PORT);
     }
     else if (type == "video"sv) {
-      port = map_port(stream::VIDEO_STREAM_PORT);
+      port = net::map_port(stream::VIDEO_STREAM_PORT);
     }
     else if (type == "control"sv) {
-      port = map_port(stream::CONTROL_PORT);
+      port = net::map_port(stream::CONTROL_PORT);
     }
     else {
       cmd_not_found(sock, session, std::move(req));
@@ -1129,8 +1129,8 @@ namespace rtsp_stream {
     server.map("PLAY"sv, &cmd_play);
 
     boost::system::error_code ec;
-    if (server.bind(net::af_from_enum_string(config::sunshine.address_family), map_port(rtsp_stream::RTSP_SETUP_PORT), ec)) {
-      BOOST_LOG(fatal) << "Couldn't bind RTSP server to port ["sv << map_port(rtsp_stream::RTSP_SETUP_PORT) << "], " << ec.message();
+    if (server.bind(net::af_from_enum_string(config::sunshine.address_family), net::map_port(rtsp_stream::RTSP_SETUP_PORT), ec)) {
+      BOOST_LOG(fatal) << "Couldn't bind RTSP server to port ["sv << net::map_port(rtsp_stream::RTSP_SETUP_PORT) << "], " << ec.message();
       shutdown_event->raise(true);
 
       return;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1600,9 +1600,9 @@ namespace stream {
   start_broadcast(broadcast_ctx_t &ctx) {
     auto address_family = net::af_from_enum_string(config::sunshine.address_family);
     auto protocol = address_family == net::IPV4 ? udp::v4() : udp::v6();
-    auto control_port = map_port(CONTROL_PORT);
-    auto video_port = map_port(VIDEO_STREAM_PORT);
-    auto audio_port = map_port(AUDIO_STREAM_PORT);
+    auto control_port = net::map_port(CONTROL_PORT);
+    auto video_port = net::map_port(VIDEO_STREAM_PORT);
+    auto audio_port = net::map_port(AUDIO_STREAM_PORT);
 
     if (ctx.control_server.bind(address_family, control_port)) {
       BOOST_LOG(error) << "Couldn't bind Control server to port ["sv << control_port << "], likely another process already bound to the port"sv;

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -179,7 +179,7 @@ namespace upnp {
      * @return `true` on success.
      */
     bool
-    map_port(const IGDdatas &data, const urls_t &urls, const std::string &lan_addr, const mapping_t &mapping) {
+    map_upnp_port(const IGDdatas &data, const urls_t &urls, const std::string &lan_addr, const mapping_t &mapping) {
       char intClient[16];
       char intPort[6];
       char desc[80];
@@ -284,7 +284,7 @@ namespace upnp {
      * @param data urls_t from UPNP_GetValidIGD()
      */
     void
-    unmap_all_ports(const urls_t &urls, const IGDdatas &data) {
+    unmap_all_upnp_ports(const urls_t &urls, const IGDdatas &data) {
       for (auto it = std::begin(mappings); it != std::end(mappings); ++it) {
         auto status = UPNP_DeletePortMapping(
           urls->controlURL,
@@ -343,7 +343,7 @@ namespace upnp {
         BOOST_LOG(debug) << "Found valid IGD device: "sv << urls->rootdescURL;
 
         for (auto it = std::begin(mappings); it != std::end(mappings) && !shutdown_event->peek(); ++it) {
-          map_port(data, urls, lan_addr_str, *it);
+          map_upnp_port(data, urls, lan_addr_str, *it);
         }
 
         if (!mapped) {
@@ -365,7 +365,7 @@ namespace upnp {
       if (mapped) {
         // Unmap ports upon termination
         BOOST_LOG(info) << "Unmapping UPNP ports..."sv;
-        unmap_all_ports(mapped_urls, data);
+        unmap_all_upnp_ports(mapped_urls, data);
       }
     }
 

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -62,13 +62,13 @@ namespace upnp {
   class deinit_t: public platf::deinit_t {
   public:
     deinit_t() {
-      auto rtsp = std::to_string(::map_port(rtsp_stream::RTSP_SETUP_PORT));
-      auto video = std::to_string(::map_port(stream::VIDEO_STREAM_PORT));
-      auto audio = std::to_string(::map_port(stream::AUDIO_STREAM_PORT));
-      auto control = std::to_string(::map_port(stream::CONTROL_PORT));
-      auto gs_http = std::to_string(::map_port(nvhttp::PORT_HTTP));
-      auto gs_https = std::to_string(::map_port(nvhttp::PORT_HTTPS));
-      auto wm_http = std::to_string(::map_port(confighttp::PORT_HTTPS));
+      auto rtsp = std::to_string(net::map_port(rtsp_stream::RTSP_SETUP_PORT));
+      auto video = std::to_string(net::map_port(stream::VIDEO_STREAM_PORT));
+      auto audio = std::to_string(net::map_port(stream::AUDIO_STREAM_PORT));
+      auto control = std::to_string(net::map_port(stream::CONTROL_PORT));
+      auto gs_http = std::to_string(net::map_port(nvhttp::PORT_HTTP));
+      auto gs_https = std::to_string(net::map_port(nvhttp::PORT_HTTPS));
+      auto wm_http = std::to_string(net::map_port(confighttp::PORT_HTTPS));
 
       mappings.assign({
         { { rtsp, rtsp, "TCP"s }, "Sunshine - RTSP"s },


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR moves the `map_port` function out of `main`, and into `network`.

Enabler for #1603 


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
