### PR TITLE
Fix and simplify handling of some shell argument replacements

### DIFF
--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -711,13 +711,15 @@ namespace platf {
     while ((match_pos = cmd_string.find_first_of(L'%', match_pos)) != std::wstring::npos) {
       std::wstring match_replacement;
 
-      // Shell command replacements are strictly '%' followed by a single non-'%' character
-      auto next_char = std::tolower(match_pos + 1 < cmd_string.size() ? cmd_string.at(match_pos + 1) : 0);
-      switch (next_char) {
-        // No next character
-        case 0:
-          break;
+      // If no additional character exists after the match, the dangling '%' is stripped
+      if (match_pos + 1 == cmd_string.size()) {
+        cmd_string.erase(match_pos, 1);
+        break;
+      }
 
+      // Shell command replacements are strictly '%' followed by a single non-'%' character
+      auto next_char = std::tolower(cmd_string.at(match_pos + 1));
+      switch (next_char) {
         // Escape character
         case L'%':
           // Skip this character and the next one

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -722,9 +722,8 @@ namespace platf {
       switch (next_char) {
         // Escape character
         case L'%':
-          // Skip this character and the next one
-          match_pos += 2;
-          continue;
+          match_replacement = L'%';
+          break;
 
         // Argument replacements
         case L'0':

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -753,6 +753,9 @@ namespace platf {
         // All arguments following the target
         case L'*':
           for (int i = 1; i < raw_cmd_parts.size(); i++) {
+            if (i > 1) {
+              match_replacement += L' ';
+            }
             match_replacement += raw_cmd_parts.at(i);
           }
           break;


### PR DESCRIPTION
## Description
This PR makes a few fixes and simplifications in the argument handling, including the fixing the issue reported in #2121 that broke handling of the `%*` argument replacement when there were more than 2 arguments being matched.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #2121 
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
