### PR TITLE
Cloak MAC address from unpaired clients

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -660,8 +660,16 @@ namespace nvhttp {
     tree.put("root.uniqueid", http::unique_id);
     tree.put("root.HttpsPort", net::map_port(PORT_HTTPS));
     tree.put("root.ExternalPort", net::map_port(PORT_HTTP));
-    tree.put("root.mac", platf::get_mac_address(net::addr_to_normalized_string(local_endpoint.address())));
     tree.put("root.MaxLumaPixelsHEVC", video::active_hevc_mode > 1 ? "1869449984" : "0");
+
+    // Only include the MAC address for requests sent from paired clients over HTTPS.
+    // For HTTP requests, use a placeholder MAC address that Moonlight knows to ignore.
+    if constexpr (std::is_same_v<SimpleWeb::HTTPS, T>) {
+      tree.put("root.mac", platf::get_mac_address(net::addr_to_normalized_string(local_endpoint.address())));
+    }
+    else {
+      tree.put("root.mac", "00:00:00:00:00:00");
+    }
 
     // Moonlight clients track LAN IPv6 addresses separately from LocalIP which is expected to
     // always be an IPv4 address. If we return that same IPv6 address here, it will clobber the


### PR DESCRIPTION
## Description
GFE provides the MAC address over both HTTP and HTTPS queries for /serverinfo, but there's no real good reason an unpaired client needs access to that information. Let's restrict the MAC address to the HTTPS endpoint for paired clients only.

The only use case this breaks is quite contrived anyway. It would have to be a client that previously discovered a host but _didn't_ pair with it, then later that same client wants to wake the PC up after it has gone to sleep. TBH, I think that scenario is closer to an unwanted annoyance than an actual feature due to the possibility another client on the network abusing this by waking your PC over and over again.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
