### PR TITLE
Use Win32 APIs for UTF-16<->UTF-8 conversion

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -3,7 +3,6 @@
  * @brief todo
  */
 #include <cmath>
-#include <codecvt>
 #include <initguid.h>
 #include <thread>
 
@@ -447,10 +446,8 @@ namespace platf::dxgi {
       return -1;
     }
 
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
-
-    auto adapter_name = converter.from_bytes(config::video.adapter_name);
-    auto output_name = converter.from_bytes(display_name);
+    auto adapter_name = from_utf8(config::video.adapter_name);
+    auto output_name = from_utf8(display_name);
 
     adapter_t::pointer adapter_p;
     for (int tries = 0; tries < 2; ++tries) {
@@ -561,7 +558,7 @@ namespace platf::dxgi {
     DXGI_ADAPTER_DESC adapter_desc;
     adapter->GetDesc(&adapter_desc);
 
-    auto description = converter.to_bytes(adapter_desc.Description);
+    auto description = to_utf8(adapter_desc.Description);
     BOOST_LOG(info)
       << std::endl
       << "Device Description : " << description << std::endl
@@ -1066,8 +1063,6 @@ namespace platf {
 
     BOOST_LOG(debug) << "Detecting monitors..."sv;
 
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
-
     // We must set the GPU preference before calling any DXGI APIs!
     if (!dxgi::probe_for_gpu_preference(config::video.output_name)) {
       BOOST_LOG(warning) << "Failed to set GPU preference. Capture may not work!"sv;
@@ -1088,7 +1083,7 @@ namespace platf {
       BOOST_LOG(debug)
         << std::endl
         << "====== ADAPTER ====="sv << std::endl
-        << "Device Name      : "sv << converter.to_bytes(adapter_desc.Description) << std::endl
+        << "Device Name      : "sv << to_utf8(adapter_desc.Description) << std::endl
         << "Device Vendor ID : 0x"sv << util::hex(adapter_desc.VendorId).to_string_view() << std::endl
         << "Device Device ID : 0x"sv << util::hex(adapter_desc.DeviceId).to_string_view() << std::endl
         << "Device Video Mem : "sv << adapter_desc.DedicatedVideoMemory / 1048576 << " MiB"sv << std::endl
@@ -1104,7 +1099,7 @@ namespace platf {
         DXGI_OUTPUT_DESC desc;
         output->GetDesc(&desc);
 
-        auto device_name = converter.to_bytes(desc.DeviceName);
+        auto device_name = to_utf8(desc.DeviceName);
 
         auto width = desc.DesktopCoordinates.right - desc.DesktopCoordinates.left;
         auto height = desc.DesktopCoordinates.bottom - desc.DesktopCoordinates.top;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -4,8 +4,6 @@
  */
 #include <cmath>
 
-#include <codecvt>
-
 #include <d3dcompiler.h>
 #include <directxmath.h>
 
@@ -342,9 +340,8 @@ namespace platf::dxgi {
 #ifndef NDEBUG
     flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #endif
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
 
-    auto wFile = converter.from_bytes(file);
+    auto wFile = from_utf8(file);
     auto status = D3DCompileFromFile(wFile.c_str(), nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, entrypoint, shader_model, flags, 0, &compiled_p, &msg_p);
 
     if (msg_p) {

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -20,4 +20,20 @@ namespace platf {
 
   std::chrono::nanoseconds
   qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2);
+
+  /**
+   * @brief Converts a UTF-8 string into a UTF-16 wide string.
+   * @param string The UTF-8 string.
+   * @return The converted UTF-16 wide string.
+   */
+  std::wstring
+  from_utf8(const std::string &string);
+
+  /**
+   * @brief Converts a UTF-16 wide string into a UTF-8 string.
+   * @param string The UTF-16 wide string.
+   * @return The converted UTF-8 string.
+   */
+  std::string
+  to_utf8(const std::wstring &string);
 }  // namespace platf

--- a/src/platform/windows/publish.cpp
+++ b/src/platform/windows/publish.cpp
@@ -107,12 +107,10 @@ namespace platf::publish {
   service(bool enable, PDNS_SERVICE_INSTANCE &existing_instance) {
     auto alarm = safe::make_alarm<PDNS_SERVICE_INSTANCE>();
 
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
-
     std::wstring name { SERVICE_INSTANCE_NAME.data(), SERVICE_INSTANCE_NAME.size() };
     std::wstring domain { SERVICE_TYPE_DOMAIN.data(), SERVICE_TYPE_DOMAIN.size() };
 
-    auto host = converter.from_bytes(boost::asio::ip::host_name() + ".local");
+    auto host = from_utf8(boost::asio::ip::host_name() + ".local");
 
     DNS_SERVICE_INSTANCE instance {};
     instance.pszInstanceName = name.data();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -29,6 +29,9 @@
 #include "utility.h"
 
 #ifdef _WIN32
+  // from_utf8() string conversion function
+  #include "platform/windows/misc.h"
+
   // _SH constants for _wfsopen()
   #include <share.h>
 #endif
@@ -187,8 +190,7 @@ namespace proc {
 #ifdef _WIN32
       // fopen() interprets the filename as an ANSI string on Windows, so we must convert it
       // to UTF-16 and use the wchar_t variants for proper Unicode log file path support.
-      std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
-      auto woutput = converter.from_bytes(_app.output);
+      auto woutput = platf::from_utf8(_app.output);
 
       // Use _SH_DENYNO to allow us to open this log file again for writing even if it is
       // still open from a previous execution. This is required to handle the case of a


### PR DESCRIPTION
## Description
`std::codecvt` for UTF-16 conversion is deprecated (without a replacement) since C++17 and seems broken for some characters/locales, so this PR switches to using the Win32 APIs for UTF-8<->UTF-16 conversion. Since all other platforms use UTF-8, this only affects Windows.

I was able to reproduce #1446 when using the Russian version of Windows 11 in a VM and confirmed this PR fixes the issue.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #1446 
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
