### PR TITLE
Implement backwards compatibility for NVENC APIs back to Video Codec SDK v11.0

### DIFF
--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -45,6 +45,17 @@ namespace nvenc {
     bool
     nvenc_failed(NVENCSTATUS status);
 
+    /**
+     * @brief This function returns the corresponding struct version for the minimum API required by the codec.
+     * @details Reducing the struct versions maximizes driver compatibility by avoiding needless API breaks.
+     * @param version The raw structure version from `NVENCAPI_STRUCT_VERSION()`.
+     * @param v11_struct_version Optionally specifies the struct version to use with v11 SDK major versions.
+     * @param v12_struct_version Optionally specifies the struct version to use with v12 SDK major versions.
+     * @return A suitable struct version for the active codec.
+     */
+    uint32_t
+    min_struct_version(uint32_t version, uint32_t v11_struct_version = 0, uint32_t v12_struct_version = 0);
+
     const NV_ENC_DEVICE_TYPE device_type;
     void *const device;
 
@@ -68,6 +79,7 @@ namespace nvenc {
 
   private:
     NV_ENC_OUTPUT_PTR output_bitstream = nullptr;
+    uint32_t minimum_api_version = 0;
 
     struct {
       uint64_t last_encoded_frame_index = 0;

--- a/src/nvenc/nvenc_d3d11.cpp
+++ b/src/nvenc/nvenc_d3d11.cpp
@@ -39,7 +39,7 @@ namespace nvenc {
     if ((dll = LoadLibraryEx(dll_name, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32))) {
       if (auto create_instance = (decltype(NvEncodeAPICreateInstance) *) GetProcAddress(dll, "NvEncodeAPICreateInstance")) {
         auto new_nvenc = std::make_unique<NV_ENCODE_API_FUNCTION_LIST>();
-        new_nvenc->version = NV_ENCODE_API_FUNCTION_LIST_VER;
+        new_nvenc->version = min_struct_version(NV_ENCODE_API_FUNCTION_LIST_VER);
         if (nvenc_failed(create_instance(new_nvenc.get()))) {
           BOOST_LOG(error) << "NvEncodeAPICreateInstance failed: " << last_error_string;
         }
@@ -83,7 +83,7 @@ namespace nvenc {
     }
 
     if (!registered_input_buffer) {
-      NV_ENC_REGISTER_RESOURCE register_resource = { NV_ENC_REGISTER_RESOURCE_VER };
+      NV_ENC_REGISTER_RESOURCE register_resource = { min_struct_version(NV_ENC_REGISTER_RESOURCE_VER, 3, 4) };
       register_resource.resourceType = NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX;
       register_resource.width = encoder_params.width;
       register_resource.height = encoder_params.height;


### PR DESCRIPTION
## Description
This implements a backwards compatibility solution for NvEncode API similar to what OBS did in https://github.com/obsproject/obs-studio/pull/7430 to reintroduce support for driver versions between 456.71 (minimum for v11.0) and 522.25 (minimum for v12.0). The net result is we now retain compatibility with drivers going back to October 2020.

I verified that AV1 still works as expected on my RTX 4080, while my RTX 2080 on extremely old drivers (456.71) can now stream with NVENC.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #2141
Fixes #2056
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
