### PR TITLE
build(cmake): add option to skip cuda inheriting compile options

### DIFF
--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -6,6 +6,10 @@ option(SUNSHINE_REQUIRE_TRAY "Require system tray icon. Fail the build if tray r
 
 option(SUNSHINE_SYSTEM_WAYLAND_PROTOCOLS "Use system installation of wayland-protocols rather than the submodule." OFF)
 
+option(CUDA_INHERIT_COMPILE_OPTIONS
+        "When building CUDA code, inherit compile options from the the main project. You may want to disable this if
+        your IDE throws errors about unknown flags after running cmake." ON)
+
 if(APPLE)
     option(SUNSHINE_CONFIGURE_PORTFILE
             "Configure macOS Portfile. Recommended to use with SUNSHINE_CONFIGURE_ONLY" OFF)

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -28,9 +28,12 @@ set_target_properties(sunshine PROPERTIES CXX_STANDARD 17
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR})
 
-foreach(flag IN LISTS SUNSHINE_COMPILE_OPTIONS)
-    list(APPEND SUNSHINE_COMPILE_OPTIONS_CUDA "$<$<COMPILE_LANGUAGE:CUDA>:--compiler-options=${flag}>")
-endforeach()
+# CLion complains about unknown flags after running cmake, and cannot add symbols to the index for cuda files
+if(CUDA_INHERIT_COMPILE_OPTIONS)
+    foreach(flag IN LISTS SUNSHINE_COMPILE_OPTIONS)
+        list(APPEND SUNSHINE_COMPILE_OPTIONS_CUDA "$<$<COMPILE_LANGUAGE:CUDA>:--compiler-options=${flag}>")
+    endforeach()
+endif()
 
 target_compile_options(sunshine PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>;$<$<COMPILE_LANGUAGE:CUDA>:${SUNSHINE_COMPILE_OPTIONS_CUDA};-std=c++17>)  # cmake-lint: disable=C0301
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds an option to prevent cuda from inheriting the original compile options. This is necessary to prevent CLion (and maybe other IDEs) from complaining about unknown flags after running the cmake command, when the IDE tries to index symbols.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
