### PR TITLE
build(cmake): error build on warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -400,7 +400,9 @@ jobs:
           mkdir -p artifacts
 
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release \
+          cmake \
+            -DBUILD_WERROR=ON \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DSUNSHINE_ASSETS_DIR=share/sunshine \
             -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
@@ -576,7 +578,9 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release \
+          cmake \
+            -DBUILD_WERROR=ON \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DSUNSHINE_ASSETS_DIR=local/sunshine/assets \
             -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
@@ -784,7 +788,9 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          cmake \
+            -DBUILD_WERROR=ON \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DSUNSHINE_ASSETS_DIR=assets \
             -G "MinGW Makefiles" \
             ..

--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -3,7 +3,25 @@
 
 list(APPEND SUNSHINE_COMPILE_OPTIONS -Wall -Wno-sign-compare)
 # Wall - enable all warnings
+# Werror - treat warnings as errors
+# Wno-maybe-uninitialized/Wno-uninitialized - disable warnings for maybe uninitialized variables
 # Wno-sign-compare - disable warnings for signed/unsigned comparisons
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # GCC specific compile options
+
+    # GCC 12 and higher will complain about maybe-uninitialized
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
+        list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-maybe-uninitialized)
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Clang specific compile options
+
+    # Clang doesn't actually complain about this this, so disabling for now
+    # list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-uninitialized)
+endif()
+if(BUILD_WERROR)
+    list(APPEND SUNSHINE_COMPILE_OPTIONS -Werror)
+endif()
 
 # setup assets directory
 if(NOT SUNSHINE_ASSETS_DIR)
@@ -28,7 +46,7 @@ file(GLOB NVENC_SOURCES CONFIGURE_DEPENDS "src/nvenc/*.cpp" "src/nvenc/*.h")
 list(APPEND PLATFORM_TARGET_FILES ${NVENC_SOURCES})
 
 configure_file("${CMAKE_SOURCE_DIR}/src/version.h.in" version.h @ONLY)
-include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")  # required for importing version.h
 
 set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/third-party/nanors/rs.c"

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -6,6 +6,9 @@ enable_language(RC)
 set(CMAKE_RC_COMPILER windres)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
 
+# gcc complains about misleading indentation in some mingw includes
+list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-misleading-indentation)
+
 # curl
 add_definitions(-DCURL_STATICLIB)
 include_directories(SYSTEM ${CURL_STATIC_INCLUDE_DIRS})
@@ -28,8 +31,14 @@ file(GLOB NVPREFS_FILES CONFIGURE_DEPENDS
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/include")
 set_source_files_properties("${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/src/ViGEmClient.cpp"
         PROPERTIES COMPILE_DEFINITIONS "UNICODE=1;ERROR_INVALID_DEVICE_OBJECT_PARAMETER=650")
+set(VIGEM_COMPILE_FLAGS "")
+string(APPEND VIGEM_COMPILE_FLAGS "-Wno-unknown-pragmas ")
+string(APPEND VIGEM_COMPILE_FLAGS "-Wno-misleading-indentation ")
+string(APPEND VIGEM_COMPILE_FLAGS "-Wno-class-memaccess ")
+string(APPEND VIGEM_COMPILE_FLAGS "-Wno-unused-function ")
+string(APPEND VIGEM_COMPILE_FLAGS "-Wno-unused-variable ")
 set_source_files_properties("${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/src/ViGEmClient.cpp"
-        PROPERTIES COMPILE_FLAGS "-Wno-unknown-pragmas -Wno-misleading-indentation -Wno-class-memaccess")
+        PROPERTIES COMPILE_FLAGS ${VIGEM_COMPILE_FLAGS})
 
 # sunshine icon
 if(NOT DEFINED SUNSHINE_ICON_PATH)

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -1,3 +1,5 @@
+option(BUILD_WERROR "Enable -Werror flag." OFF)
+
 # if this option is set, the build will exit after configuring special package configuration files
 option(SUNSHINE_CONFIGURE_ONLY "Configure special files only, then exit." OFF)
 

--- a/docker/debian-bookworm.dockerfile
+++ b/docker/debian-bookworm.dockerfile
@@ -105,6 +105,7 @@ RUN <<_MAKE
 #!/bin/bash
 set -e
 cmake \
+  -DBUILD_WERROR=ON \
   -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \

--- a/docker/debian-bullseye.dockerfile
+++ b/docker/debian-bullseye.dockerfile
@@ -119,6 +119,7 @@ set -e
 source "$HOME/.nvm/nvm.sh"
 nvm use 20.9.0
 cmake \
+  -DBUILD_WERROR=ON \
   -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -105,6 +105,7 @@ RUN <<_MAKE
 #!/bin/bash
 set -e
 cmake \
+  -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DSUNSHINE_ASSETS_DIR=share/sunshine \

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -105,6 +105,7 @@ RUN <<_MAKE
 #!/bin/bash
 set -e
 cmake \
+  -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DSUNSHINE_ASSETS_DIR=share/sunshine \

--- a/docker/ubuntu-20.04.dockerfile
+++ b/docker/ubuntu-20.04.dockerfile
@@ -155,6 +155,7 @@ set -e
 source "$HOME/.nvm/nvm.sh"
 nvm use 20.9.0
 cmake \
+  -DBUILD_WERROR=ON \
   -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \

--- a/docker/ubuntu-22.04.dockerfile
+++ b/docker/ubuntu-22.04.dockerfile
@@ -120,6 +120,7 @@ source "$HOME/.nvm/nvm.sh"
 nvm use 20.9.0
 #Actually build
 cmake \
+  -DBUILD_WERROR=ON \
   -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -61,6 +61,7 @@ build() {
         -S "$pkgname" \
         -B build \
         -Wno-dev \
+        -D BUILD_WERROR=ON \
         -D CMAKE_INSTALL_PREFIX=/usr \
         -D SUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
         -D SUNSHINE_ASSETS_DIR="share/sunshine"

--- a/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
+++ b/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
@@ -330,6 +330,7 @@ modules:
         npm_config_nodedir: /usr/lib/sdk/node18
         NPM_CONFIG_LOGLEVEL: info
     config-opts:
+      - -DBUILD_WERROR=ON
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX=/app
       - -DCMAKE_CUDA_COMPILER=/app/cuda/bin/nvcc

--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -40,7 +40,8 @@ depends_lib              port:avahi \
 
 boost.version            1.81
 
-configure.args           -DCMAKE_INSTALL_PREFIX=${prefix} \
+configure.args           -DBUILD_WERROR=ON \
+                         -DCMAKE_INSTALL_PREFIX=${prefix} \
                          -DSUNSHINE_ASSETS_DIR=etc/sunshine/assets
 
 startupitem.create       yes


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR will error cmake on warning, causing CI to fail.

Todo:
- [x] Fix existing warnings
- [x] Add CMake option to disable -Werror


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
