### PR TITLE
Add workaround for RTX HDR driver bug

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -125,6 +125,9 @@ namespace platf::dxgi {
     // the first successful capture of a desktop frame
     bool dummy = false;
 
+    // Set to true if the image is blank (contains no content at all, including a cursor)
+    bool blank = true;
+
     // Unique identifier for this image
     uint32_t id = 0;
 
@@ -382,38 +385,40 @@ namespace platf::dxgi {
       }
 
       auto &img = (img_d3d_t &) img_base;
-      auto &img_ctx = img_ctx_map[img.id];
+      if (!img.blank) {
+        auto &img_ctx = img_ctx_map[img.id];
 
-      // Open the shared capture texture with our ID3D11Device
-      if (initialize_image_context(img, img_ctx)) {
-        return -1;
+        // Open the shared capture texture with our ID3D11Device
+        if (initialize_image_context(img, img_ctx)) {
+          return -1;
+        }
+
+        // Acquire encoder mutex to synchronize with capture code
+        auto status = img_ctx.encoder_mutex->AcquireSync(0, INFINITE);
+        if (status != S_OK) {
+          BOOST_LOG(error) << "Failed to acquire encoder mutex [0x"sv << util::hex(status).to_string_view() << ']';
+          return -1;
+        }
+
+        device_ctx->OMSetRenderTargets(1, &nv12_Y_rt, nullptr);
+        device_ctx->VSSetShader(scene_vs.get(), nullptr, 0);
+        device_ctx->PSSetShader(img.format == DXGI_FORMAT_R16G16B16A16_FLOAT ? convert_Y_fp16_ps.get() : convert_Y_ps.get(), nullptr, 0);
+        device_ctx->RSSetViewports(1, &outY_view);
+        device_ctx->PSSetShaderResources(0, 1, &img_ctx.encoder_input_res);
+        device_ctx->Draw(3, 0);
+
+        device_ctx->OMSetRenderTargets(1, &nv12_UV_rt, nullptr);
+        device_ctx->VSSetShader(convert_UV_vs.get(), nullptr, 0);
+        device_ctx->PSSetShader(img.format == DXGI_FORMAT_R16G16B16A16_FLOAT ? convert_UV_fp16_ps.get() : convert_UV_ps.get(), nullptr, 0);
+        device_ctx->RSSetViewports(1, &outUV_view);
+        device_ctx->Draw(3, 0);
+
+        // Release encoder mutex to allow capture code to reuse this image
+        img_ctx.encoder_mutex->ReleaseSync(0);
+
+        ID3D11ShaderResourceView *emptyShaderResourceView = nullptr;
+        device_ctx->PSSetShaderResources(0, 1, &emptyShaderResourceView);
       }
-
-      // Acquire encoder mutex to synchronize with capture code
-      auto status = img_ctx.encoder_mutex->AcquireSync(0, INFINITE);
-      if (status != S_OK) {
-        BOOST_LOG(error) << "Failed to acquire encoder mutex [0x"sv << util::hex(status).to_string_view() << ']';
-        return -1;
-      }
-
-      device_ctx->OMSetRenderTargets(1, &nv12_Y_rt, nullptr);
-      device_ctx->VSSetShader(scene_vs.get(), nullptr, 0);
-      device_ctx->PSSetShader(img.format == DXGI_FORMAT_R16G16B16A16_FLOAT ? convert_Y_fp16_ps.get() : convert_Y_ps.get(), nullptr, 0);
-      device_ctx->RSSetViewports(1, &outY_view);
-      device_ctx->PSSetShaderResources(0, 1, &img_ctx.encoder_input_res);
-      device_ctx->Draw(3, 0);
-
-      device_ctx->OMSetRenderTargets(1, &nv12_UV_rt, nullptr);
-      device_ctx->VSSetShader(convert_UV_vs.get(), nullptr, 0);
-      device_ctx->PSSetShader(img.format == DXGI_FORMAT_R16G16B16A16_FLOAT ? convert_UV_fp16_ps.get() : convert_UV_ps.get(), nullptr, 0);
-      device_ctx->RSSetViewports(1, &outUV_view);
-      device_ctx->Draw(3, 0);
-
-      // Release encoder mutex to allow capture code to reuse this image
-      img_ctx.encoder_mutex->ReleaseSync(0);
-
-      ID3D11ShaderResourceView *emptyShaderResourceView = nullptr;
-      device_ctx->PSSetShaderResources(0, 1, &emptyShaderResourceView);
 
       return 0;
     }
@@ -1144,6 +1149,9 @@ namespace platf::dxgi {
         return { nullptr, nullptr };
       }
 
+      // Clear the blank flag now that we're ready to capture into the image
+      d3d_img->blank = false;
+
       return { std::move(d3d_img), std::move(lock_helper) };
     };
 
@@ -1289,15 +1297,14 @@ namespace platf::dxgi {
         // Clear the image if it has been used as a dummy.
         // It can have the mouse cursor blended onto it.
         auto old_d3d_img = (img_d3d_t *) img_out.get();
-        bool reclear_dummy = old_d3d_img->dummy && old_d3d_img->capture_texture;
+        bool reclear_dummy = !old_d3d_img->blank && old_d3d_img->capture_texture;
 
         auto [d3d_img, lock] = get_locked_d3d_img(img_out, true);
         if (!d3d_img) return capture_e::error;
 
         if (reclear_dummy) {
-          auto dummy_data = std::make_unique<std::uint8_t[]>(d3d_img->row_pitch * d3d_img->height);
-          std::fill_n(dummy_data.get(), d3d_img->row_pitch * d3d_img->height, 0);
-          device_ctx->UpdateSubresource(d3d_img->capture_texture.get(), 0, nullptr, dummy_data.get(), d3d_img->row_pitch, 0);
+          const float rgb_black[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+          device_ctx->ClearRenderTargetView(d3d_img->capture_rt.get(), rgb_black);
         }
 
         if (blend_mouse_cursor_flag) {
@@ -1409,6 +1416,7 @@ namespace platf::dxgi {
     img->width = width_before_rotation;
     img->height = height_before_rotation;
     img->id = next_image_id++;
+    img->blank = true;
 
     return img;
   }
@@ -1456,20 +1464,7 @@ namespace platf::dxgi {
     t.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
     t.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
 
-    HRESULT status;
-    if (dummy) {
-      auto dummy_data = std::make_unique<std::uint8_t[]>(img->row_pitch * img->height);
-      std::fill_n(dummy_data.get(), img->row_pitch * img->height, 0);
-      D3D11_SUBRESOURCE_DATA initial_data {
-        dummy_data.get(),
-        (UINT) img->row_pitch,
-        0
-      };
-      status = device->CreateTexture2D(&t, &initial_data, &img->capture_texture);
-    }
-    else {
-      status = device->CreateTexture2D(&t, nullptr, &img->capture_texture);
-    }
+    auto status = device->CreateTexture2D(&t, nullptr, &img->capture_texture);
     if (FAILED(status)) {
       BOOST_LOG(error) << "Failed to create img buf texture [0x"sv << util::hex(status).to_string_view() << ']';
       return -1;


### PR DESCRIPTION
## Description
This reworks our dummy image handling to avoid triggering a driver bug with 551.61 drivers and RTX HDR enabled. It also provides a small performance improvement for that (uncommon) case of interacting with dummy image textures.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #2163
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
