### PR TITLE
Use a common function to abort for debugging purposes

### DIFF
--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -167,6 +167,18 @@ namespace lifetime {
   }
 
   /**
+   * @brief Breaks into the debugger or terminates Sunshine if no debugger is attached.
+   */
+  void
+  debug_trap() {
+#ifdef _WIN32
+    DebugBreak();
+#else
+    std::raise(SIGTRAP);
+#endif
+  }
+
+  /**
    * @brief Gets the argv array passed to main().
    */
   char **

--- a/src/entry_handler.h
+++ b/src/entry_handler.h
@@ -42,6 +42,8 @@ namespace lifetime {
   extern std::atomic_int desired_exit_code;
   void
   exit_sunshine(int exit_code, bool async);
+  void
+  debug_trap();
   char **
   get_argv();
 }  // namespace lifetime

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,7 +318,7 @@ main(int argc, char *argv[]) {
     auto task = []() {
       BOOST_LOG(fatal) << "10 seconds passed, yet Sunshine's still running: Forcing shutdown"sv;
       log_flush();
-      std::abort();
+      lifetime::debug_trap();
     };
     force_shutdown = task_pool.pushDelayed(task, 10s).task_id;
 
@@ -331,7 +331,7 @@ main(int argc, char *argv[]) {
     auto task = []() {
       BOOST_LOG(fatal) << "10 seconds passed, yet Sunshine's still running: Forcing shutdown"sv;
       log_flush();
-      std::abort();
+      lifetime::debug_trap();
     };
     force_shutdown = task_pool.pushDelayed(task, 10s).task_id;
 

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -489,7 +489,7 @@ namespace platf {
       auto winerror = GetLastError();
       // Log the failure of reverting to self and its error code
       BOOST_LOG(fatal) << "Failed to revert to self after impersonation: "sv << winerror;
-      std::abort();
+      DebugBreak();
     }
 
     return ec;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1815,7 +1815,7 @@ namespace stream {
       auto task = []() {
         BOOST_LOG(fatal) << "Hang detected! Session failed to terminate in 10 seconds."sv;
         log_flush();
-        std::abort();
+        lifetime::debug_trap();
       };
       auto force_kill = task_pool.pushDelayed(task, 10s).task_id;
       auto fg = util::fail_guard([&force_kill]() {


### PR DESCRIPTION
## Description
`std::abort()` destroys important state that is useful for debugging (particularly on Windows), so let's use a different method that disturbs as little process state as possible before breaking into an attached debugger or generating a coredump. 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
