### PR TITLE
fix(config): properly save global_prep_cmd and fps

### DIFF
--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -1408,12 +1408,20 @@
         this.tabs.forEach(tab => {
           Object.keys(tab.options).forEach(optionKey => {
             let delete_value = false
-            if (optionKey === "global_prep_cmd" || optionKey === "resolutions" || optionKey === "fps") {
-              let regex = /([\d]+x[\d]+)/g  // this regex is only needed for resolutions
-              // Use a regular expression to find each value and replace it with a quoted version
 
-              let config_value = JSON.parse(config[optionKey].replace(regex, '"$1"')).toString()
-              let default_value = JSON.parse(tab.options[optionKey].replace(regex, '"$1"')).toString()
+            if (["resolutions", "fps", "global_prep_cmd"].includes(optionKey)) {
+              let config_value, default_value
+
+              if (optionKey === "resolutions") {
+                let regex = /([\d]+x[\d]+)/g
+
+                // Use a regular expression to find each value and replace it with a quoted version
+                config_value = JSON.parse(config[optionKey].replace(regex, '"$1"')).toString()
+                default_value = JSON.parse(tab.options[optionKey].replace(regex, '"$1"')).toString()
+              } else {
+                config_value = JSON.parse(config[optionKey])
+                default_value = JSON.parse(tab.options[optionKey])
+              }
 
               if (config_value === default_value) {
                 delete_value = true


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The `global_prep_cmd` and `fps` option mistakenly had regex replacement occurring while saving the config from the UI. This PR modifies the behavior to handle `resolutions` separately from other json style config options.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #2160 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
