### PR TITLE
List KMS and Wlgrab displays and their indexes

### DIFF
--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -145,9 +145,12 @@ namespace platf {
     };
 
     struct monitor_t {
+      // Connector attributes
       std::uint32_t type;
-
       std::uint32_t index;
+
+      // Monitor index in the global list
+      std::uint32_t monitor_index;
 
       platf::touch_port_t viewport;
     };
@@ -1516,10 +1519,10 @@ namespace platf {
   correlate_to_wayland(std::vector<kms::card_descriptor_t> &cds) {
     auto monitors = wl::monitors();
 
+    BOOST_LOG(info) << "-------- Start of KMS monitor list --------"sv;
+
     for (auto &monitor : monitors) {
       std::string_view name = monitor->name;
-
-      BOOST_LOG(info) << name << ": "sv << monitor->description;
 
       // Try to convert names in the format:
       // {type}-{index}
@@ -1553,6 +1556,7 @@ namespace platf {
                 << monitor->viewport.width << 'x' << monitor->viewport.height;
             }
 
+            BOOST_LOG(info) << "Monitor " << monitor_descriptor.monitor_index << " is "sv << name << ": "sv << monitor->description;
             goto break_for_loop;
           }
         }
@@ -1561,6 +1565,8 @@ namespace platf {
 
       BOOST_LOG(verbose) << "Reduced to name: "sv << name << ": "sv << index;
     }
+
+    BOOST_LOG(info) << "--------- End of KMS monitor list ---------"sv;
   }
 
   // A list of names of displays accepted as display_name
@@ -1637,6 +1643,7 @@ namespace platf {
             (int) crtc->width,
             (int) crtc->height,
           };
+          it->second.monitor_index = count;
         }
 
         kms::env_width = std::max(kms::env_width, (int) (crtc->x + crtc->width));

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -836,27 +836,29 @@ namespace platf {
 #endif
 
 #ifdef SUNSHINE_BUILD_CUDA
-    if (config::video.capture.empty() || config::video.capture == "nvfbc") {
+    if ((config::video.capture.empty() && sources.none()) || config::video.capture == "nvfbc") {
       if (verify_nvfbc()) {
         sources[source::NVFBC] = true;
       }
     }
 #endif
 #ifdef SUNSHINE_BUILD_WAYLAND
-    if (config::video.capture.empty() || config::video.capture == "wlr") {
+    if ((config::video.capture.empty() && sources.none()) || config::video.capture == "wlr") {
       if (verify_wl()) {
         sources[source::WAYLAND] = true;
       }
     }
 #endif
 #ifdef SUNSHINE_BUILD_DRM
-    if (config::video.capture.empty() || config::video.capture == "kms") {
+    if ((config::video.capture.empty() && sources.none()) || config::video.capture == "kms") {
       if (verify_kms()) {
         sources[source::KMS] = true;
       }
     }
 #endif
 #ifdef SUNSHINE_BUILD_X11
+    // We enumerate this capture backend regardless of other suitable sources,
+    // since it may be needed as a NvFBC fallback for software encoding on X11.
     if (config::video.capture.empty() || config::video.capture == "x11") {
       if (verify_x11()) {
         sources[source::X11] = true;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -424,14 +424,20 @@ namespace platf {
 
     display.roundtrip();
 
+    BOOST_LOG(info) << "-------- Start of Wayland monitor list --------"sv;
+
     for (int x = 0; x < interface.monitors.size(); ++x) {
       auto monitor = interface.monitors[x].get();
 
       wl::env_width = std::max(wl::env_width, (int) (monitor->viewport.offset_x + monitor->viewport.width));
       wl::env_height = std::max(wl::env_height, (int) (monitor->viewport.offset_y + monitor->viewport.height));
 
+      BOOST_LOG(info) << "Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
+
       display_names.emplace_back(std::to_string(x));
     }
+
+    BOOST_LOG(info) << "--------- End of Wayland monitor list ---------"sv;
 
     return display_names;
   }


### PR DESCRIPTION
## Description
This introduces some new log messages that allow users using KMS and Wlgrab capture methods to know which display index they should specify to capture a given monitor.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/2695644/f3c82338-c23d-4f68-8f31-8086820152e8)

### Issues Fixed or Closed
Fixes #2079
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
