### PR TITLE
Fix CUDA context leak causing encoder init failures using X11 capture with NVENC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - (Capture/Linux) Fix missing mouse cursor when using KMS capture on a GPU with hardware cursor support
 - (Capture/Windows) Add workaround for Nvidia driver bug causing Sunshine to crash when RTX HDR is globally enabled
 - (Capture/Windows) Add workaround for AMD driver bug on pre-RDNA GPUs causing hardware encoding failure
-- (Capture/Windows) Reintroduce support for encoding on older Nvidia GPU drivers (v456.71-v522.25)
+- (Capture/Windows) Reintroduce support for NVENC on older Nvidia GPU drivers (v456.71-v522.25)
 - (Capture/Windows) Fix encoding on old Intel GPUs that don't support low-power H.264 encoding
 - (Capture/Linux) Fix GL errors or corrupt video output on GPUs that use aux planes such as Intel Arc
 - (Capture/Linux) Fix GL errors or corrupt video output on GPUs that use DRM modifiers on YUV buffers
@@ -68,6 +68,7 @@
 - (Capture/Windows) Fix delay displaying UAC dialogs when the mouse cursor is not moving
 - (Capture/Linux) Fix corrupt video output or stream disconnections if the display resolution changes while streaming
 - (Capture/Linux) Fix color of aspect ratio padding in the capture image with VAAPI
+- (Capture/Linux) Fix NVENC initialization error when using X11 capture with some GPUs
 - (Tray/Linux) Fix random crash when the tray icon is updating
 - (Network) Fix QoS tagging when running in IPv4+IPv6 mode
 - (Process) Fix termination of child processes upon app quit when the parent has already terminated

--- a/src/platform/linux/cuda.cu
+++ b/src/platform/linux/cuda.cu
@@ -222,7 +222,7 @@ std::optional<tex_t> tex_t::make(int height, int pitch) {
   return tex;
 }
 
-tex_t::tex_t() : array {}, texture { INVALID_TEXTURE } {}
+tex_t::tex_t() : array {}, texture { INVALID_TEXTURE, INVALID_TEXTURE } {}
 tex_t::tex_t(tex_t &&other) : array { other.array }, texture { other.texture } {
   other.array          = 0;
   other.texture.point  = INVALID_TEXTURE;


### PR DESCRIPTION
## Description
Trivial fix to prevent freeing a bogus texture object (which ironically causes a CUDA context leak due to `cudaDestroyTextureObject()` retaining the default context). The leaked context prevents the next CUDA hwcontext initialization from succeeding due to [incompatible flags](https://github.com/FFmpeg/FFmpeg/blob/f904e60c32a87f4124c3b94598a3b0141cd8b1b9/libavutil/hwcontext_cuda.c#L351)

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated