### PR TITLE
build(macos): fix publishing of portfile

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -753,14 +753,14 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload Artifacts
-        if: ${{ matrix.release == 'true' }}
+        if: ${{ matrix.release }}
         uses: actions/upload-artifact@v4
         with:
           name: sunshine-macports
           path: artifacts/
 
       - name: Create/Update GitHub Release
-        if: ${{ needs.setup_release.outputs.create_release == 'true' && matrix.release == 'true' }}
+        if: ${{ needs.setup_release.outputs.create_release == 'true' && matrix.release }}
         uses: ncipollo/release-action@v1
         with:
           name: ${{ needs.setup_release.outputs.release_name }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes a small syntax mistake in the CI workflow.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
