### PR TITLE
Make debuginfo artifacts harder to confuse with the Windows portable build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -843,11 +843,15 @@ jobs:
       - name: Package Windows Debug Info
         working-directory: build
         run: |
-          # save the original binaries with debug info
+          # use .dbg file extension for binaries to avoid confusion with real packages
+          Get-ChildItem -File -Recurse | `
+            % { Rename-Item -Path $_.PSPath -NewName $_.Name.Replace(".exe",".dbg") }
+
+          # save the binaries with debug info
           7z -r `
             "-xr!CMakeFiles" `
             "-xr!cpack_artifacts" `
-            a "../artifacts/sunshine-debuginfo-win32.zip" "*.exe"
+            a "../artifacts/sunshine-win32-debuginfo.7z" "*.dbg"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description
If a user accidentally downloads the debuginfo package, they will have a pretty confusing experience. They will see Sunshine.exe in there but then get a cryptic error when they try to run it (because a bunch of dependencies are missing). Based on our download stats, this confusion seems to happen quite regularly (probably because it's near the top in the list of artifacts today).

This change should move the debug info package down below the regular Windows binaries rather than being at the top above the "Show all assets" button. It also reduces the chance of confusion by renaming the files inside so they are not executable.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
