### PR TITLE
Fix heap corruption with monochrome cursor pixel counts that aren't divisible by 8

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -234,7 +234,7 @@ namespace platf::dxgi {
     auto xor_mask = std::begin(img_data) + bytes;
 
     for (auto x = 0; x < bytes; ++x) {
-      for (auto c = 7; c >= 0; --c) {
+      for (auto c = 7; c >= 0 && ((std::uint8_t *) pixel_data) != std::end(cursor_img); --c) {
         auto bit = 1 << c;
         auto color_type = ((*and_mask & bit) ? 1 : 0) + ((*xor_mask & bit) ? 2 : 0);
 
@@ -307,7 +307,7 @@ namespace platf::dxgi {
     auto xor_mask = std::begin(img_data) + bytes;
 
     for (auto x = 0; x < bytes; ++x) {
-      for (auto c = 7; c >= 0; --c) {
+      for (auto c = 7; c >= 0 && ((std::uint8_t *) pixel_data) != std::end(cursor_img); --c) {
         auto bit = 1 << c;
         auto color_type = ((*and_mask & bit) ? 1 : 0) + ((*xor_mask & bit) ? 2 : 0);
 


### PR DESCRIPTION
## Description
When a monochrome cursor contains a pixel count that is not evenly divisible by 8, we will run out of space in our cursor image buffer in the middle of processing a single byte of the cursor bitmap and start writing outside the bounds of the buffer. This is because we forgot to do a bounds check in the inner loop.

These cursors are apparently quite rare because this bug has existed in the codebase for over 4 years without being noticed or reported until a few days ago. Ryujinx in particular seems to quickly trigger it because it is frequently changing to a 1x1 pixel cursor and back, which corrupts a bit of memory each time until Sunshine eventually crashes.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #2219
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
