### PR TITLE
fix(linux): automatically migrate config directory

### DIFF
--- a/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
+++ b/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
@@ -11,6 +11,7 @@ separate-locales: false
 finish-args:
   - --device=all  # access all devices
   - --env=PULSE_PROP_media.category=Manager  # allow sunshine to manage audio sinks
+  - --env=SUNSHINE_MIGRATE_CONFIG=1  # migrate config files to the new location
   - --filesystem=home  # need to save files in user's home directory
   - --share=ipc  # required for X11 shared memory extension
   - --share=network  # access network

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -100,22 +100,54 @@ namespace platf {
 
   fs::path
   appdata() {
+    bool found = false;
+    bool migrate_config = true;
     const char *dir;
+    const char *homedir;
+    fs::path config_path;
+
+    // Get the home directory
+    if ((homedir = getenv("HOME")) == nullptr || strlen(homedir) == 0) {
+      // If HOME is empty or not set, use the current user's home directory
+      homedir = getpwuid(geteuid())->pw_dir;
+    }
 
     // May be set if running under a systemd service with the ConfigurationDirectory= option set.
-    if ((dir = getenv("CONFIGURATION_DIRECTORY")) != nullptr) {
-      return fs::path { dir } / "sunshine"sv;
+    if ((dir = getenv("CONFIGURATION_DIRECTORY")) != nullptr && strlen(dir) > 0) {
+      found = true;
+      config_path = fs::path(dir) / "sunshine"sv;
     }
     // Otherwise, follow the XDG base directory specification:
     // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-    if ((dir = getenv("XDG_CONFIG_HOME")) != nullptr) {
-      return fs::path { dir } / "sunshine"sv;
+    if (!found && (dir = getenv("XDG_CONFIG_HOME")) != nullptr && strlen(dir) > 0) {
+      found = true;
+      config_path = fs::path(dir) / "sunshine"sv;
     }
-    if ((dir = getenv("HOME")) == nullptr) {
-      dir = getpwuid(geteuid())->pw_dir;
+    // As a last resort, use the home directory
+    if (!found) {
+      migrate_config = false;
+      config_path = fs::path(homedir) / ".config/sunshine"sv;
     }
 
-    return fs::path { dir } / ".config/sunshine"sv;
+    // migrate from the old config location if necessary
+    if (migrate_config && found && getenv("SUNSHINE_MIGRATE_CONFIG") == "1"sv) {
+      fs::path old_config_path = fs::path(homedir) / ".config/sunshine"sv;
+      if (old_config_path != config_path && fs::exists(old_config_path)) {
+        if (!fs::exists(config_path)) {
+          BOOST_LOG(info) << "Migrating config from "sv << old_config_path << " to "sv << config_path;
+          std::error_code ec;
+          fs::rename(old_config_path, config_path, ec);
+          if (ec) {
+            return old_config_path;
+          }
+        }
+        else {
+          BOOST_LOG(warning) << "Config exists in both "sv << old_config_path << " and "sv << config_path << ", using "sv << config_path << "... it is recommended to remove "sv << old_config_path;
+        }
+      }
+    }
+
+    return config_path;
   }
 
   std::string


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR fixes an issue on Linux where the config directory may be changed without the user knowing, after #2034 was merged... and was most prevalent on flatpak installs.

@istori1 FYI


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
