### PR TITLE
Avoid broken fallback to cross-adapter NVENC encoding with KMS

### DIFF
--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -766,13 +766,13 @@ namespace platf {
 
 #ifdef SUNSHINE_BUILD_DRM
   std::vector<std::string>
-  kms_display_names();
+  kms_display_names(mem_type_e hwdevice_type);
   std::shared_ptr<display_t>
   kms_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
 
   bool
   verify_kms() {
-    return !kms_display_names().empty();
+    return !kms_display_names(mem_type_e::unknown).empty();
   }
 #endif
 
@@ -798,7 +798,7 @@ namespace platf {
     if (sources[source::WAYLAND]) return wl_display_names();
 #endif
 #ifdef SUNSHINE_BUILD_DRM
-    if (sources[source::KMS]) return kms_display_names();
+    if (sources[source::KMS]) return kms_display_names(hwdevice_type);
 #endif
 #ifdef SUNSHINE_BUILD_X11
     if (sources[source::X11]) return x11_display_names();


### PR DESCRIPTION
## Description
This avoids trying to use broken cross-adapter encoding for NVENC when a non-Nvidia GPU is driving the display, like the issue described in #2140 and a support thread on Discord. Since NVENC appears earlier than VAAPI in the encoder list, this broken scenario will happen right out of the box with an Intel/AMD + Nvidia GPU setup.

The logic for detecting an Nvidia GPU is from [nvidia-vaapi-driver](https://github.com/elFarto/nvidia-vaapi-driver/blob/746d5510eabe949def3c79acc856393596d75cf5/src/backend-common.c#L21-L38).

Testing results with monitor connected to AMD GPU and Nvidia GPU present:
- With v0.21, we will fall back to X11 capture + NVENC in this scenario which works but the perf is horrible due to the CPU copyback.
- With v0.22, we try to use KMS capture with NVENC, but we fail because the DMA-BUFs aren't importable on the Nvidia GPU and get the black screen and GL errors.
- With this PR, we use KMS capture with VAAPI which is the optimal result since it's zero-copy on the same GPU for capture and encoding.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
