### PR TITLE
fix(Linux/Fedora): re-enable CUDA and bump to 12.4.0

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -316,7 +316,7 @@ jobs:
         id: buildx
 
       - name: Cache Docker Layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: Docker-buildx${{ matrix.tag }}-${{ github.sha }}

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -316,7 +316,7 @@ jobs:
         id: buildx
 
       - name: Cache Docker Layers
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: Docker-buildx${{ matrix.tag }}-${{ github.sha }}

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -68,12 +68,12 @@ dnf clean all
 rm -rf /var/cache/yum
 _DEPS
 
-## install cuda
+# install cuda
 WORKDIR /build/cuda
-## versions: https://developer.nvidia.com/cuda-toolkit-archive
+# versions: https://developer.nvidia.com/cuda-toolkit-archive
 ENV CUDA_VERSION="12.4.0"
 ENV CUDA_BUILD="550.54.14"
-## hadolint ignore=SC3010
+# hadolint ignore=SC3010
 RUN <<_INSTALL_CUDA
 #!/bin/bash
 set -e

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -68,12 +68,12 @@ dnf clean all
 rm -rf /var/cache/yum
 _DEPS
 
-# install cuda
+## install cuda
 WORKDIR /build/cuda
-# versions: https://developer.nvidia.com/cuda-toolkit-archive
+## versions: https://developer.nvidia.com/cuda-toolkit-archive
 ENV CUDA_VERSION="12.4.0"
 ENV CUDA_BUILD="550.54.14"
-# hadolint ignore=SC3010
+## hadolint ignore=SC3010
 RUN <<_INSTALL_CUDA
 #!/bin/bash
 set -e

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -98,12 +98,11 @@ COPY --link .. .
 WORKDIR /build/sunshine/build
 
 # cmake and cpack
-# todo - add cmake argument back in for cuda support "-DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \"
-# todo - re-enable "DSUNSHINE_ENABLE_CUDA"
 RUN <<_MAKE
 #!/bin/bash
 set -e
 cmake \
+  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc
   -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
@@ -112,7 +111,7 @@ cmake \
   -DSUNSHINE_ENABLE_WAYLAND=ON \
   -DSUNSHINE_ENABLE_X11=ON \
   -DSUNSHINE_ENABLE_DRM=ON \
-  -DSUNSHINE_ENABLE_CUDA=OFF \
+  -DSUNSHINE_ENABLE_CUDA=ON \
   /build/sunshine
 make -j "$(nproc)"
 cpack -G RPM

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -68,28 +68,27 @@ dnf clean all
 rm -rf /var/cache/yum
 _DEPS
 
-# todo - enable cuda once it's supported for gcc 13 and fedora 38
 ## install cuda
-#WORKDIR /build/cuda
+WORKDIR /build/cuda
 ## versions: https://developer.nvidia.com/cuda-toolkit-archive
-#ENV CUDA_VERSION="12.0.0"
-#ENV CUDA_BUILD="525.60.13"
+ENV CUDA_VERSION="12.4.0"
+ENV CUDA_BUILD="550.54.14"
 ## hadolint ignore=SC3010
-#RUN <<_INSTALL_CUDA
-##!/bin/bash
-#set -e
-#cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-#cuda_suffix=""
-#if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-#  cuda_suffix="_sbsa"
-#fi
-#url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
-#echo "cuda url: ${url}"
-#wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
-#chmod a+x ./cuda.run
-#./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
-#rm ./cuda.run
-#_INSTALL_CUDA
+RUN <<_INSTALL_CUDA
+#!/bin/bash
+set -e
+cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
+cuda_suffix=""
+if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
+  cuda_suffix="_sbsa"
+fi
+url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
+echo "cuda url: ${url}"
+wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
+chmod a+x ./cuda.run
+./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
+rm ./cuda.run
+_INSTALL_CUDA
 
 # copy repository
 WORKDIR /build/sunshine/

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -102,7 +102,7 @@ RUN <<_MAKE
 #!/bin/bash
 set -e
 cmake \
-  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc
+  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
   -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -98,12 +98,11 @@ COPY --link .. .
 WORKDIR /build/sunshine/build
 
 # cmake and cpack
-# todo - add cmake argument back in for cuda support "-DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \"
-# todo - re-enable "DSUNSHINE_ENABLE_CUDA"
 RUN <<_MAKE
 #!/bin/bash
 set -e
 cmake \
+  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc
   -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
@@ -112,7 +111,7 @@ cmake \
   -DSUNSHINE_ENABLE_WAYLAND=ON \
   -DSUNSHINE_ENABLE_X11=ON \
   -DSUNSHINE_ENABLE_DRM=ON \
-  -DSUNSHINE_ENABLE_CUDA=OFF \
+  -DSUNSHINE_ENABLE_CUDA=ON \
   /build/sunshine
 make -j "$(nproc)"
 cpack -G RPM

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -68,28 +68,27 @@ dnf clean all
 rm -rf /var/cache/yum
 _DEPS
 
-# todo - enable cuda once it's supported for gcc 13 and fedora 39
-## install cuda
-#WORKDIR /build/cuda
-## versions: https://developer.nvidia.com/cuda-toolkit-archive
-#ENV CUDA_VERSION="12.0.0"
-#ENV CUDA_BUILD="525.60.13"
-## hadolint ignore=SC3010
-#RUN <<_INSTALL_CUDA
-##!/bin/bash
-#set -e
-#cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-#cuda_suffix=""
-#if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-#  cuda_suffix="_sbsa"
-#fi
-#url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
-#echo "cuda url: ${url}"
-#wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
-#chmod a+x ./cuda.run
-#./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
-#rm ./cuda.run
-#_INSTALL_CUDA
+# install cuda
+WORKDIR /build/cuda
+# versions: https://developer.nvidia.com/cuda-toolkit-archive
+ENV CUDA_VERSION="12.4.0"
+ENV CUDA_BUILD="550.54.14"
+# hadolint ignore=SC3010
+RUN <<_INSTALL_CUDA
+#!/bin/bash
+set -e
+cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
+cuda_suffix=""
+if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
+  cuda_suffix="_sbsa"
+fi
+url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
+echo "cuda url: ${url}"
+wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
+chmod a+x ./cuda.run
+./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
+rm ./cuda.run
+_INSTALL_CUDA
 
 # copy repository
 WORKDIR /build/sunshine/

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -102,7 +102,7 @@ RUN <<_MAKE
 #!/bin/bash
 set -e
 cmake \
-  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc
+  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
   -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \

--- a/docs/source/about/setup.rst
+++ b/docs/source/about/setup.rst
@@ -43,8 +43,8 @@ Install
       sunshine_{arch}.flatpak                      12.0.0           525.60.13         50;52;60;61;62;70;75;80;86;90
       sunshine-debian-bookworm-{arch}.deb          12.0.0           525.60.13         50;52;60;61;62;70;75;80;86;90
       sunshine-debian-bullseye-{arch}.deb          11.8.0           450.80.02         35;50;52;60;61;62;70;75;80;86;90
-      sunshine-fedora-38-{arch}.rpm                unavailable      unavailable       none
-      sunshine-fedora-39-{arch}.rpm                unavailable      unavailable       none
+      sunshine-fedora-38-{arch}.rpm                12.4.0           525.60.13         50;52;60;61;62;70;75;80;86;90
+      sunshine-fedora-39-{arch}.rpm                12.4.0           525.60.13         50;52;60;61;62;70;75;80;86;90
       sunshine-ubuntu-20.04-{arch}.deb             11.8.0           450.80.02         35;50;52;60;61;62;70;75;80;86;90
       sunshine-ubuntu-22.04-{arch}.deb             11.8.0           450.80.02         35;50;52;60;61;62;70;75;80;86;90
       ===========================================  ==============   ==============    ================================


### PR DESCRIPTION
## Description
* Let Fedora 38/39 build with Cuda 12.4 which allows gcc13

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
