### PR TITLE
Fix(linux/fedora39) patch system headers so build succeeds with cuda

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# ensure dockerfiles are checked out with LF line endings
+Dockerfile text eol=lf
+*.dockerfile text eol=lf

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -81,6 +81,13 @@ cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
 cuda_suffix=""
 if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
   cuda_suffix="_sbsa"
+
+  # patch headers https://bugs.launchpad.net/ubuntu/+source/mumax3/+bug/2032624
+  sed -i 's/__Float32x4_t/int/g' /usr/include/bits/math-vector.h
+  sed -i 's/__Float64x2_t/int/g' /usr/include/bits/math-vector.h
+  sed -i 's/__SVFloat32_t/float/g' /usr/include/bits/math-vector.h
+  sed -i 's/__SVFloat64_t/float/g' /usr/include/bits/math-vector.h
+  sed -i 's/__SVBool_t/int/g' /usr/include/bits/math-vector.h
 fi
 url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
 echo "cuda url: ${url}"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix for Fedora 39 arm64 build with CUDA.

Also, add a `.gitattributes` file to ensure dockerfiles are checked out with correct line endings.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
