### PR TITLE
Don't update tray icon after tray_exit() was called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - (Linux) Fix udev rules for uinput access not working until after reboot
 - (Linux) Fix wrong path in desktop files
 - (Tray) Cache icons to avoid possible DRM issues
+- (Tray) Fix attempt to update tray icon after it was destroyed
 - (Linux) Migrate old config files to new location if env SUNSHINE_MIGRATE_CONFIG=1 is set (automatically set for Flatpak)
 - (Linux/Fedora) Re-enable CUDA support and bump to 12.4.0
 

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -47,6 +47,8 @@ using namespace std::literals;
 
 // system_tray namespace
 namespace system_tray {
+  static std::atomic<bool> tray_initialized = false;
+
   /**
    * @brief Callback for opening the UI from the system tray.
    * @param item The tray menu item.
@@ -239,6 +241,7 @@ namespace system_tray {
       BOOST_LOG(info) << "System tray created"sv;
     }
 
+    tray_initialized = true;
     while (tray_loop(1) == 0) {
       BOOST_LOG(debug) << "System tray loop"sv;
     }
@@ -275,6 +278,7 @@ namespace system_tray {
    */
   int
   end_tray() {
+    tray_initialized = false;
     tray_exit();
     return 0;
   }
@@ -285,6 +289,10 @@ namespace system_tray {
    */
   void
   update_tray_playing(std::string app_name) {
+    if (!tray_initialized) {
+      return;
+    }
+
     tray.notification_title = NULL;
     tray.notification_text = NULL;
     tray.notification_cb = NULL;
@@ -307,6 +315,10 @@ namespace system_tray {
    */
   void
   update_tray_pausing(std::string app_name) {
+    if (!tray_initialized) {
+      return;
+    }
+
     tray.notification_title = NULL;
     tray.notification_text = NULL;
     tray.notification_cb = NULL;
@@ -329,6 +341,10 @@ namespace system_tray {
    */
   void
   update_tray_stopped(std::string app_name) {
+    if (!tray_initialized) {
+      return;
+    }
+
     tray.notification_title = NULL;
     tray.notification_text = NULL;
     tray.notification_cb = NULL;
@@ -350,6 +366,10 @@ namespace system_tray {
    */
   void
   update_tray_require_pin() {
+    if (!tray_initialized) {
+      return;
+    }
+
     tray.notification_title = NULL;
     tray.notification_text = NULL;
     tray.notification_cb = NULL;


### PR DESCRIPTION
## Description
Fixes the issue I saw with Sunshine hanging during termination with the main thread trying to reload a tray icon after `tray_exit()` was called:
```
14  ARM64EC 0000004f`35dfefa0 00007ffa`5b02349c     shell32!#SHPrivateExtractIcons+0x220
15  ARM64EC 0000004f`35dff240 00007ffa`5b023360     shell32!#ExtractIconExW+0x11c
16  ARM64EC 0000004f`35dff2b0 00007ffa`5b622a60     shell32!#ExtractIconExA+0x50
17  ARM64EC 0000004f`35dff4f0 00007ff7`81e595e0     shell32!$ientry_thunk$cdecl$i8$i8i8i8i8i8+0x28
18    AMD64 0000004f`35dff5a0 00007ff7`81e5984a     sunshine!_create_icon_info+0x30 [D:\a\Sunshine\Sunshine\third-party\tray\tray_windows.c @ 115] 
19    AMD64 0000004f`35dff620 00007ff7`81e59943     sunshine!_fetch_icon+0x5a [D:\a\Sunshine\Sunshine\third-party\tray\tray_windows.c @ 168] 
1a    AMD64 0000004f`35dff690 00007ff7`81e23fb7     sunshine!tray_update+0x53 [D:\a\Sunshine\Sunshine\third-party\tray\tray_windows.c @ 227] 
1b    AMD64 0000004f`35dff6e0 00007ff7`81e1aa03     sunshine!update_tray_stopped+0x87 [D:\a\Sunshine\Sunshine\src\system_tray.cpp @ 339] 
1c    AMD64 0000004f`35dff840 00007ff7`833608ae     sunshine!terminate+0x6b3 [D:\a\Sunshine\Sunshine\src\process.cpp @ 349] 
1d    AMD64 0000004f`35dff9b0 00007ff7`83533940     sunshine!~deinit_t+0x1e [D:\a\Sunshine\Sunshine\src\process.cpp @ 52] 
1e    AMD64 0000004f`35dff9e0 00007ff7`81da12ee     sunshine!main+0xb20 [D:\a\Sunshine\Sunshine\src\main.cpp @ 424] 
1f    AMD64 0000004f`35dffc30 00007ff7`81da1406     sunshine!__tmainCRTStartup+0x16e [C:\M\B\src\mingw-w64\mingw-w64-crt\crt\crtexe.c @ 268] 
20    AMD64 0000004f`35dffc80 00007ffa`5cf509bc     sunshine!mainCRTStartup+0x16 [C:\M\B\src\mingw-w64\mingw-w64-crt\crt\crtexe.c @ 190] 
21  ARM64EC 0000004f`35dffcb0 00007ffa`5cee7ba0     kernel32!$iexit_thunk$cdecl$i8$i8+0x1c
22  ARM64EC 0000004f`35dffce0 00007ffa`5e4fb8b8     kernel32!#BaseThreadInitThunk+0x30
23  ARM64EC 0000004f`35dffcf0 00000000`00000000     ntdll!#RtlUserThreadStart+0x48
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
