### PR TITLE
Fix crashes in config migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.22.2] - 2024-03-15
+**Fixed**
+- (Tray/Windows) Fix broken system tray icon on some systems
+- (Linux) Fix crash when XDG_CONFIG_HOME or CONFIGURATION_DIRECTORY are set
+- (Linux) Fix config migration across filesystems and with non-existent parent directories
+
 ## [0.22.1] - 2024-03-13
 **Breaking**
 - (ArchLinux) Drop support for standalone PKGBUILD files. Use the binary Arch package or install via AUR instead.
@@ -759,3 +765,4 @@ settings. In v0.17.0, games now run under your user account without elevated pri
 [0.21.0]: https://github.com/LizardByte/Sunshine/releases/tag/v0.21.0
 [0.22.0]: https://github.com/LizardByte/Sunshine/releases/tag/v0.22.0
 [0.22.1]: https://github.com/LizardByte/Sunshine/releases/tag/v0.22.1
+[0.22.2]: https://github.com/LizardByte/Sunshine/releases/tag/v0.22.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.18)
 # todo - set this conditionally
 
 # todo - set version to 0.0.0 once confident in automated versioning
-project(Sunshine VERSION 0.22.1
+project(Sunshine VERSION 0.22.2
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://app.lizardbyte.dev/Sunshine")
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -10,6 +10,7 @@
 
 // standard includes
 #include <fstream>
+#include <iostream>
 
 // lib includes
 #include <arpa/inet.h>
@@ -98,6 +99,11 @@ namespace platf {
     return ifaddr_t { p };
   }
 
+  /**
+   * @brief Performs migration if necessary, then returns the appdata directory.
+   * @details This is used for the log directory, so it cannot invoke Boost logging!
+   * @return The path of the appdata directory that should be used.
+   */
   fs::path
   appdata() {
     bool found = false;
@@ -136,15 +142,18 @@ namespace platf {
       fs::path old_config_path = fs::path(homedir) / ".config/sunshine"sv;
       if (old_config_path != config_path && fs::exists(old_config_path)) {
         if (!fs::exists(config_path)) {
-          BOOST_LOG(info) << "Migrating config from "sv << old_config_path << " to "sv << config_path;
+          std::cout << "Migrating config from "sv << old_config_path << " to "sv << config_path << std::endl;
           std::error_code ec;
           fs::rename(old_config_path, config_path, ec);
           if (ec) {
+            std::cerr << "Migration failed: " << ec.message() << std::endl;
             return old_config_path;
           }
         }
         else {
-          BOOST_LOG(warning) << "Config exists in both "sv << old_config_path << " and "sv << config_path << ", using "sv << config_path << "... it is recommended to remove "sv << old_config_path;
+          // We cannot use Boost logging because it hasn't been initialized yet!
+          std::cerr << "Config exists in both "sv << old_config_path << " and "sv << config_path << ". Using "sv << config_path << " for config" << std::endl;
+          std::cerr << "It is recommended to remove "sv << old_config_path << std::endl;
         }
       }
     }

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -104,6 +104,7 @@ namespace platf {
     bool migrate_config = true;
     const char *dir;
     const char *homedir;
+    const char *migrate_envvar;
     fs::path config_path;
 
     // Get the home directory
@@ -130,7 +131,8 @@ namespace platf {
     }
 
     // migrate from the old config location if necessary
-    if (migrate_config && found && getenv("SUNSHINE_MIGRATE_CONFIG") == "1"sv) {
+    migrate_envvar = getenv("SUNSHINE_MIGRATE_CONFIG");
+    if (migrate_config && found && migrate_envvar && strcmp(migrate_envvar, "1") == 0) {
       fs::path old_config_path = fs::path(homedir) / ".config/sunshine"sv;
       if (old_config_path != config_path && fs::exists(old_config_path)) {
         if (!fs::exists(config_path)) {


### PR DESCRIPTION
## Description
This should be the fix for the crash during config migration that was reported on Discord and https://github.com/LizardByte/Sunshine/commit/a2785baf0aa7202bceecd975b1aa2d8798d2378a#commitcomment-139806889

@KuleRucket can you give this a try and see if it resolves the issue for you?

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
