### PR TITLE
Populate host latency for kms/x11 grab

### DIFF
--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1069,7 +1069,7 @@ namespace platf {
       }
 
       inline capture_e
-      refresh(file_t *file, egl::surface_descriptor_t *sd) {
+      refresh(file_t *file, egl::surface_descriptor_t *sd, std::optional<std::chrono::steady_clock::time_point> &frame_timestamp) {
         // Check for a change in HDR metadata
         if (connector_id) {
           auto connector_props = card.connector_props(*connector_id);
@@ -1080,6 +1080,7 @@ namespace platf {
         }
 
         plane_t plane = drmModeGetPlane(card.fd.el, plane_id);
+        frame_timestamp = std::chrono::steady_clock::now();
 
         auto fb = card.fb(plane.get());
         if (!fb) {
@@ -1303,7 +1304,7 @@ namespace platf {
 
         egl::surface_descriptor_t sd;
 
-        auto status = refresh(fb_fd, &sd);
+        auto status = refresh(fb_fd, &sd, img_out->frame_timestamp);
         if (status != capture_e::ok) {
           return status;
         }
@@ -1456,7 +1457,7 @@ namespace platf {
         auto img = (egl::img_descriptor_t *) img_out.get();
         img->reset();
 
-        auto status = refresh(fb_fd, &img->sd);
+        auto status = refresh(fb_fd, &img->sd, img->frame_timestamp);
         if (status != capture_e::ok) {
           return status;
         }

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1304,7 +1304,8 @@ namespace platf {
 
         egl::surface_descriptor_t sd;
 
-        auto status = refresh(fb_fd, &sd, img_out->frame_timestamp);
+        std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
+        auto status = refresh(fb_fd, &sd, frame_timestamp);
         if (status != capture_e::ok) {
           return status;
         }
@@ -1330,6 +1331,8 @@ namespace platf {
         }
 
         gl::ctx.GetTextureSubImage(rgb->tex[0], 0, img_offset_x, img_offset_y, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
+
+        img_out->frame_timestamp = frame_timestamp;
 
         if (cursor && captured_cursor.visible) {
           blend_cursor(*img_out);

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -535,6 +535,7 @@ namespace platf {
       auto img = (x11_img_t *) img_out.get();
 
       XImage *x_img { x11::GetImage(xdisplay.get(), xwindow, offset_x, offset_y, width, height, AllPlanes, ZPixmap) };
+      img->frame_timestamp = std::chrono::steady_clock::now();
 
       img->width = x_img->width;
       img->height = x_img->height;


### PR DESCRIPTION
## Description
This PR populates the frame_timestamp at the point that the KMS and X11 capture is done. This allows Moonlight to show the host latency in the statistics like it does for Windows.

### Screenshot
![image](https://github.com/LizardByte/Sunshine/assets/737724/d8b93e2a-0a93-457b-9dbf-394a9022537d)


### Issues Fixed or Closed
n/a


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
