### PR TITLE
ci(linux): refactor linux build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -325,8 +325,8 @@ jobs:
           sudo apt-get install -y \
             build-essential \
             cmake \
-            gcc-11 \
-            g++-11 \
+            gcc-10 \
+            g++-10 \
             libayatana-appindicator3-dev \
             libavdevice-dev \
             libboost-filesystem-dev \
@@ -362,11 +362,11 @@ jobs:
           # Update gcc alias
           # https://stackoverflow.com/a/70653945/11214013
           sudo update-alternatives --install \
-            /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-11 \
-            --slave /usr/bin/gcov gcov /usr/bin/gcov-11 \
-            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 \
-            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11
+            /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-10 \
+            --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
+            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10
 
       - name: Build Linux
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,7 +165,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
-          remove-docker-images: 'false'
+          remove-docker-images: 'true'
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -291,61 +291,48 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
-          remove-docker-images: 'false'
+          remove-docker-images: 'true'
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      - name: Install wget
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            wget
+
+      - name: Install CUDA
+        env:
+          CUDA_VERSION: 11.8.0
+          CUDA_BUILD: 520.61.05
+        timeout-minutes: 4
+        run: |
+          url_base="https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/local_installers"
+          url="${url_base}/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux.run"
+          sudo wget -q -O /root/cuda.run ${url}
+          sudo chmod a+x /root/cuda.run
+          sudo /root/cuda.run --silent --toolkit --toolkitpath=/usr/local/cuda --no-opengl-libs --no-man-page --no-drm
+          sudo rm /root/cuda.run
+
       - name: Setup Dependencies Linux
         run: |
+          # allow newer gcc
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-
-          if [[ ${{ matrix.dist }} == "18.04" ]]; then
-            # Ubuntu 18.04 packages
-            sudo add-apt-repository ppa:savoury1/boost-defaults-1.71 -y
-
-            sudo apt-get update -y
-            sudo apt-get install -y \
-              libboost-filesystem1.71-dev \
-              libboost-locale1.71-dev \
-              libboost-log1.71-dev \
-              libboost-regex1.71-dev \
-              libboost-program-options1.71-dev
-
-            # Install cmake
-            wget https://cmake.org/files/v3.22/cmake-3.22.2-linux-x86_64.sh
-            chmod +x cmake-3.22.2-linux-x86_64.sh
-            mkdir /opt/cmake
-            ./cmake-3.22.2-linux-x86_64.sh --prefix=/opt/cmake --skip-license
-            ln --force --symbolic /opt/cmake/bin/cmake /usr/local/bin/cmake
-            cmake --version
-
-            # install newer tar from focal... appimagelint fails on 18.04 without this
-            echo "original tar version"
-            tar --version
-            wget -O tar.deb http://security.ubuntu.com/ubuntu/pool/main/t/tar/tar_1.30+dfsg-7ubuntu0.20.04.3_amd64.deb
-            sudo apt-get -y install -f ./tar.deb
-            echo "new tar version"
-            tar --version
-          else
-            # Ubuntu 20.04+ packages
-            sudo apt-get update -y
-            sudo apt-get install -y \
-              cmake \
-              libboost-filesystem-dev \
-              libboost-locale-dev \
-              libboost-log-dev \
-              libboost-program-options-dev
-          fi
 
           sudo apt-get install -y \
             build-essential \
-            gcc-10 \
-            g++-10 \
+            cmake \
+            gcc-11 \
+            g++-11 \
             libayatana-appindicator3-dev \
             libavdevice-dev \
+            libboost-filesystem-dev \
+            libboost-locale-dev \
+            libboost-log-dev \
+            libboost-program-options-dev \
             libcap-dev \
             libcurl4-openssl-dev \
             libdrm-dev \
@@ -366,8 +353,7 @@ jobs:
             libxcb1-dev \
             libxfixes-dev \
             libxrandr-dev \
-            libxtst-dev \
-            wget
+            libxtst-dev
 
           # clean apt cache
           sudo apt-get clean
@@ -376,26 +362,21 @@ jobs:
           # Update gcc alias
           # https://stackoverflow.com/a/70653945/11214013
           sudo update-alternatives --install \
-            /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-10 \
-            --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
-            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10
-
-          # Install CUDA
-          sudo wget \
-            https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run \
-            --progress=bar:force:noscroll -q --show-progress -O /root/cuda.run
-          sudo chmod a+x /root/cuda.run
-          sudo /root/cuda.run --silent --toolkit --toolkitpath=/usr --no-opengl-libs --no-man-page --no-drm
-          sudo rm /root/cuda.run
+            /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-11 \
+            --slave /usr/bin/gcov gcov /usr/bin/gcov-11 \
+            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 \
+            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11
 
       - name: Build Linux
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           BUILD_VERSION: ${{ needs.check_changelog.outputs.next_version_bare }}
           COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        timeout-minutes: 5
         run: |
+          echo "nproc: $(nproc)"
+
           mkdir -p build
           mkdir -p artifacts
 
@@ -403,6 +384,7 @@ jobs:
           cmake \
             -DBUILD_WERROR=ON \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CUDA_COMPILER:PATH=/usr/local/cuda/bin/nvcc \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DSUNSHINE_ASSETS_DIR=share/sunshine \
             -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
@@ -412,20 +394,7 @@ jobs:
             -DSUNSHINE_ENABLE_CUDA=ON \
             ${{ matrix.EXTRA_ARGS }} \
             ..
-          make -j ${nproc}
-
-      - name: Package Linux - CPACK
-        # todo - this is no longer used
-        if: ${{ matrix.type == 'cpack' }}
-        working-directory: build
-        run: |
-          cpack -G DEB
-          mv ./cpack_artifacts/Sunshine.deb ../artifacts/sunshine-${{ matrix.dist }}.deb
-
-          if [[ ${{ matrix.dist }} == "20.04" ]]; then
-            cpack -G RPM
-            mv ./cpack_artifacts/Sunshine.rpm ../artifacts/sunshine.rpm
-          fi
+          make -j $(expr $(nproc) - 1)  # use all but one core
 
       - name: Set AppImage Version
         if: |
@@ -452,12 +421,12 @@ jobs:
 
           # AppImage
           # https://docs.appimage.org/packaging-guide/index.html
-          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
 
           # https://github.com/linuxdeploy/linuxdeploy-plugin-gtk
           sudo apt-get install libgtk-3-dev librsvg2-dev -y
-          wget https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
+          wget -q https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
           chmod +x linuxdeploy-plugin-gtk.sh
           export DEPLOY_GTK_VERSION=3
 
@@ -475,13 +444,16 @@ jobs:
           # permissions
           chmod +x ../artifacts/sunshine.AppImage
 
+      - name: Delete cuda
+        # free up space on the runner
+        run: |
+          sudo rm -rf /usr/local/cuda
+
       - name: Verify AppImage
         if: ${{ matrix.type == 'AppImage' }}
         run: |
           wget https://github.com/TheAssassin/appimagelint/releases/download/continuous/appimagelint-x86_64.AppImage
           chmod +x appimagelint-x86_64.AppImage
-
-          # rm -rf ~/.cache/appimagelint/
 
           ./appimagelint-x86_64.AppImage ./artifacts/sunshine.AppImage
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Attempt to improve AppImage build, and hopefully resolve runner out of space and/or memory issues.

- Moves CUDA install to the very beginning (after installing wget)
- Changes install directory of CUDA
- Deletes CUDA after AppImage is packaged
- Reduces `-j` arg of `make` command from 4 to 3
- Removes legacy Ubuntu 18.04 logic

I attempted to bump GCC from 10 to 11, but this introduced new warnings, and errors in the AppImage lint step. This might provide a hint for the existing warnings?

w/ GCC-11
```txt
appimagelint.cli[12510] [INFO] Checking AppImage ./artifacts/sunshine.AppImage
appimagelint.cli[12510] [INFO] Running check "GNU libc ABI check"
appimagelint.glibc_abi_check[12510] [INFO] detected required version for runtime: 2.14
appimagelint.glibc_abi_check[12510] [INFO] detected required version for payload: 2.30
appimagelint.cache[12510] [INFO] Fetching glibc version data for debian
appimagelint.setup[12510] [INFO] Fetching glibc package versions from Debian sources API
Warning: int.glibc_abi_check[12510] [WARNING] could not find version for oldstable, trying backports
Error: elint.glibc_abi_check[12510] [ERROR] could not find version for oldstable in backports either, aborting check
appimagelint.glibc_abi_check[12510] [INFO] [✖] AppImage can run on Debian oldstable (bullseye)
appimagelint.glibc_abi_check[12510] [INFO] [✔] AppImage can run on Debian stable (bookworm)
Warning: int.glibc_abi_check[12510] [WARNING] could not find version for testing, trying backports
Error: elint.glibc_abi_check[12510] [ERROR] could not find version for testing in backports either, aborting check
appimagelint.glibc_abi_check[12510] [INFO] [✖] AppImage can run on Debian testing (trixie)
appimagelint.glibc_abi_check[12510] [INFO] [✔] AppImage can run on Debian unstable (sid)
appimagelint.cache[12510] [INFO] Fetching glibc version data for ubuntu
appimagelint.setup[12510] [INFO] Fetching glibc package versions from Ubuntu FTP mirror
appimagelint.glibc_abi_check[12510] [INFO] [✔] AppImage can run on Ubuntu mantic
appimagelint.glibc_abi_check[12510] [INFO] [✔] AppImage can run on Ubuntu jammy
appimagelint.glibc_abi_check[12510] [INFO] [✔] AppImage can run on Ubuntu focal
appimagelint.glibc_abi_check[12510] [INFO] [✖] AppImage can run on Ubuntu bionic
appimagelint.glibc_abi_check[12510] [INFO] [✖] AppImage can run on Ubuntu xenial
appimagelint.glibc_abi_check[12510] [INFO] [✖] AppImage can run on Ubuntu trusty
appimagelint.cache[12510] [INFO] Fetching glibc version data for centos
appimagelint.setup[12510] [INFO] Fetching glibc package versions from CentOS mirror
appimagelint.glibc_abi_check[12510] [INFO] [✖] AppImage can run on CentOS 7
appimagelint.cli[12510] [INFO] Running check "GNU libstdc++ ABI check"
appimagelint.glibcxx_abi_check[12510] [INFO] detected required version for runtime: <none>
appimagelint.glibcxx_abi_check[12510] [INFO] detected required version for payload: 3.4.30
appimagelint.cache[12510] [INFO] Fetching glibcxx version data for debian
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-zxhotuxn.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-0eny1src.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-aa6lx2su.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-42eubsdd.tmp/out/
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Debian oldstable (bullseye)
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Debian stable (bookworm)
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Debian testing (trixie)
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Debian unstable (sid)
appimagelint.cache[12510] [INFO] Fetching glibcxx version data for ubuntu
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-i7jrb6c1.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-ruvtunsb.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-ccv2uqru.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-edu6w5_c.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-d5vjavkt.tmp/out/
Warning: int.gnu_lib_versions_symbols_finder[12510] [WARNING] no binaries found in /dev/shm/appimagelint-3swzt79h.tmp/out/
appimagelint.glibcxx_abi_check[12510] [INFO] [✔] AppImage can run on Ubuntu mantic
appimagelint.glibcxx_abi_check[12510] [INFO] [✔] AppImage can run on Ubuntu jammy
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Ubuntu focal
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Ubuntu bionic
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Ubuntu xenial
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on Ubuntu trusty
appimagelint.cache[12510] [INFO] Fetching glibcxx version data for centos
appimagelint.setup[12510] [INFO] Fetching libstdc++ package versions from CentOS mirror
appimagelint.glibcxx_abi_check[12510] [INFO] [✖] AppImage can run on CentOS 7
appimagelint.cli[12510] [INFO] Running check "Icons validity and location check"
appimagelint.icons_check[12510] [INFO] Extracting icon name from desktop file: /tmp/.mount_sunshi86qHCh/sunshine.desktop
appimagelint.icons_check[12510] [INFO] Checking resolution of icon: /tmp/.mount_sunshi86qHCh/sunshine.svg
appimagelint.icons_check[12510] [INFO] [✔] Valid icon in AppDir root
appimagelint.icons_check[12510] [INFO] Checking resolution of icon: /tmp/.mount_sunshi86qHCh/.DirIcon
appimagelint.icons_check[12510] [INFO] [✔] Valid icon file in .DirIcon
appimagelint.icons_check[12510] [INFO] Checking resolution of icon: /tmp/.mount_sunshi86qHCh/usr/share/icons/hicolor/256x256/apps/sunshine.png
appimagelint.icons_check[12510] [INFO] Checking resolution of icon: /tmp/.mount_sunshi86qHCh/usr/share/icons/hicolor/scalable/apps/sunshine.svg
Warning: int.icons_check[12510] [WARNING] Icon found whose file name doesn't match the Icon= entry in desktop file: hicolor/scalable/status/sunshine-locked.svg
Warning: int.icons_check[12510] [WARNING] Icon found whose file name doesn't match the Icon= entry in desktop file: hicolor/scalable/status/sunshine-pausing.svg
Warning: int.icons_check[12510] [WARNING] Icon found whose file name doesn't match the Icon= entry in desktop file: hicolor/scalable/status/sunshine-playing.svg
Warning: int.icons_check[12510] [WARNING] Icon found whose file name doesn't match the Icon= entry in desktop file: hicolor/scalable/status/sunshine-tray.svg
appimagelint.icons_check[12510] [INFO] [✔] Other integration icons valid
appimagelint.cli[12510] [INFO] Running check "Desktop files existence and validity"
appimagelint.desktop_files[12510] [INFO] Checking desktop files in root directory
appimagelint.desktop_files[12510] [INFO] [✔] Exactly one desktop file in AppDir root
appimagelint.desktop_files[12510] [INFO] Checking desktop file /tmp/.mount_sunshi8ugNZL/sunshine.desktop with desktop-file-validate
/tmp/.mount_sunshi8ugNZL/sunshine.desktop: hint: value "AudioVideo;Network;RemoteAccess;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
appimagelint.desktop_files[12510] [INFO] Checking desktop file /tmp/.mount_sunshi8ugNZL/usr/share/applications/sunshine.desktop with desktop-file-validate
/tmp/.mount_sunshi8ugNZL/usr/share/applications/sunshine.desktop: hint: value "AudioVideo;Network;RemoteAccess;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
appimagelint.desktop_files[12510] [INFO] [✔] All desktop files in AppDir are valid
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
