### PR TITLE
fix(linux/x11): use config value for output_name

### DIFF
--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -797,7 +797,8 @@ namespace platf {
 
     BOOST_LOG(info) << "Detecting monitors"sv;
 
-    x11::xdisplay_t xdisplay { x11::OpenDisplay(nullptr) };
+    std::string display = config::video.output_name;  // get display name from config
+    x11::xdisplay_t xdisplay { x11::OpenDisplay(display.empty() ? nullptr : display.c_str()) };  // if config empty, nullptr will use the DISPLAY env var
     if (!xdisplay) {
       return {};
     }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When developing encoder fixtures for #1603, I noticed that X11 capture looks for the DISPLAY environment variable instead of using the config value.

I think if we got the value from the config it would make it so users don't have to set an ENV variable when trying to start Sunshine via SSH.

This is completely untested, so just leaving this here for anyone who wants to test.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
