### PR TITLE
Link to Setup docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,11 @@ Support
 Our support methods are listed in our
 `LizardByte Docs <https://lizardbyte.readthedocs.io/en/latest/about/support.html>`__.
 
+Installation
+------------
+
+See our `Setup page <https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/setup.html>`__ for steps on installing Sunshine for your operating system.
+
 Downloads
 ---------
 


### PR DESCRIPTION
## Description
It isn't clear how to install Sunshine on all operating systems just looking at the Downloads. macOS users, for instance, only see a Portfile, and won't know about the Homebrew package.

The documentation is mentioned at the top of the README, but it's easy to miss and there doesn't seem to be an easy way to get to the Sunshine-specific documentation from there.

A super-obvious "Installation" section that links to the Setup docs fixes this.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
