### PR TITLE
ci(macos): automatically determine default branch for homebrew formula

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -562,10 +562,12 @@ jobs:
             echo "This is a PUSH event"
             clone_url=${{ github.event.repository.clone_url }}
             branch="${{ github.ref_name }}"
+            default_branch="${{ github.event.repository.default_branch }}"
           else
             echo "This is a PR event"
             clone_url=${{ github.event.pull_request.head.repo.clone_url }}
             branch="${{ github.event.pull_request.head.ref }}"
+            default_branch="${{ github.event.pull_request.head.repo.default_branch }}"
           fi
           echo "Branch: ${branch}"
           echo "Clone URL: ${clone_url}"
@@ -575,6 +577,7 @@ jobs:
           cmake \
             -DGITHUB_BRANCH="${branch}" \
             -DGITHUB_CLONE_URL="${clone_url}" \
+            -DGITHUB_DEFAULT_BRANCH="${default_branch}" \
             -DSUNSHINE_CONFIGURE_HOMEBREW=ON \
             -DSUNSHINE_CONFIGURE_ONLY=ON \
             ..

--- a/packaging/macos/sunshine.rb
+++ b/packaging/macos/sunshine.rb
@@ -7,7 +7,7 @@ class @PROJECT_NAME@ < Formula
     tag: "@GITHUB_BRANCH@"
   version "@PROJECT_VERSION@"
   license all_of: ["GPL-3.0-only"]
-  head "@GITHUB_CLONE_URL@", branch: "nightly"
+  head "@GITHUB_CLONE_URL@", branch: "@GITHUB_DEFAULT_BRANCH@"
 
   depends_on "boost" => :build
   depends_on "cmake" => :build


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
PRs with a default branch other than `nightly` would fail the audit of the homebrew formula. This PR modifies the behavior so the default branch is determined automatically.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
