### PR TITLE
fix(ui): web ui now always loads default locale on errors

### DIFF
--- a/src_assets/common/assets/web/locale.js
+++ b/src_assets/common/assets/web/locale.js
@@ -4,8 +4,15 @@ import {createI18n} from "vue-i18n";
 import en from './public/assets/locale/en.json'
 
 export default async function() {
-    let r = await (await fetch("/api/configLocale")).json();
-    let locale = r.locale ?? "en";
+    let locale = "en";
+    await fetch("/api/configLocale")
+        .then((response) => response.json())
+        .then((json) => {
+            if (json.locale) locale = json.locale;
+        })
+        .catch((error) => {
+            console.error("Failed to get locale config", error);
+        });
     document.querySelector('html').setAttribute('lang', locale);
     let messages = {
         en


### PR DESCRIPTION
## Description
[Bazzite](https://bazzite.gg/) has some issues with sunshine where at the time of writing the web ui will not load.
`/api/configLocale` Returns an xml error report.

Bazzite uses a custom build from https://copr.fedorainfracloud.org/coprs/matte-schwartz/sunshine .

**I could not reproduce the error on base Fedora 39 with the current nightly build.**

The fix includes a `catch` so the default will always be loaded and the app will not crash and be more future-proof.
Also made it a bit more readable.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
No issue just PR


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
