### PR TITLE
Improve frametiming for linux capture

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "src/logging.h"
+#include "src/stat_trackers.h"
 #include "src/thread_safe.h"
 #include "src/utility.h"
 #include "src/video_colorspace.h"
@@ -499,6 +500,10 @@ namespace platf {
     int env_width, env_height;
 
     int width, height;
+
+  protected:
+    // collect capture timing data (at loglevel debug)
+    stat_trackers::min_max_avg_tracker<double> sleep_overshoot_tracker;
   };
 
   class mic_t {

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <string>
 
+#include "src/config.h"
 #include "src/logging.h"
 #include "src/stat_trackers.h"
 #include "src/thread_safe.h"
@@ -19,6 +20,8 @@
 extern "C" {
 #include <moonlight-common-c/src/Limelight.h>
 }
+
+using namespace std::literals;
 
 struct sockaddr;
 struct AVFrame;
@@ -504,6 +507,18 @@ namespace platf {
   protected:
     // collect capture timing data (at loglevel debug)
     stat_trackers::min_max_avg_tracker<double> sleep_overshoot_tracker;
+    void
+    log_sleep_overshoot(std::chrono::nanoseconds overshoot_ns) {
+      if (config::sunshine.min_log_level <= 1) {
+        // Print sleep overshoot stats to debug log every 20 seconds
+        auto print_info = [&](double min_overshoot, double max_overshoot, double avg_overshoot) {
+          auto f = stat_trackers::one_digit_after_decimal();
+          BOOST_LOG(debug) << "Sleep overshoot (min/max/avg): " << f % min_overshoot << "ms/" << f % max_overshoot << "ms/" << f % avg_overshoot << "ms";
+        };
+        // std::chrono::nanoseconds overshoot_ns = std::chrono::steady_clock::now() - next_frame;
+        sleep_overshoot_tracker.collect_and_callback_on_interval(overshoot_ns.count() / 1000000., print_info, 20s);
+      }
+    }
   };
 
   class mic_t {

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -809,7 +809,10 @@ namespace cuda {
             std::this_thread::sleep_for(1ns);
             now = std::chrono::steady_clock::now();
           }
-          next_frame = now + delay;
+          next_frame += delay;
+          if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+            next_frame = now + delay;
+          }
 
           std::shared_ptr<platf::img_t> img_out;
           auto status = snapshot(pull_free_image_cb, img_out, 150ms, *cursor);

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -803,11 +803,7 @@ namespace cuda {
         while (true) {
           auto now = std::chrono::steady_clock::now();
           if (next_frame > now) {
-            std::this_thread::sleep_for((next_frame - now) / 3 * 2);
-          }
-          while (next_frame > now) {
-            std::this_thread::sleep_for(1ns);
-            now = std::chrono::steady_clock::now();
+            std::this_thread::sleep_for(next_frame - now);
           }
           next_frame += delay;
           if (next_frame < now) {  // some major slowdown happened; we couldn't keep up

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -800,11 +800,17 @@ namespace cuda {
           handle.reset();
         });
 
+        sleep_overshoot_tracker.reset();
+
         while (true) {
           auto now = std::chrono::steady_clock::now();
           if (next_frame > now) {
             std::this_thread::sleep_for(next_frame - now);
           }
+          now = std::chrono::steady_clock::now();
+          std::chrono::nanoseconds overshoot_ns = now - next_frame;
+          log_sleep_overshoot(overshoot_ns);
+
           next_frame += delay;
           if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
             next_frame = now + delay;

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1193,12 +1193,18 @@ namespace platf {
       capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
         auto next_frame = std::chrono::steady_clock::now();
 
+        sleep_overshoot_tracker.reset();
+
         while (true) {
           auto now = std::chrono::steady_clock::now();
 
           if (next_frame > now) {
             std::this_thread::sleep_for(next_frame - now);
           }
+          now = std::chrono::steady_clock::now();
+          std::chrono::nanoseconds overshoot_ns = now - next_frame;
+          log_sleep_overshoot(overshoot_ns);
+
           next_frame += delay;
           if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
             next_frame = now + delay;
@@ -1419,16 +1425,9 @@ namespace platf {
           if (next_frame > now) {
             std::this_thread::sleep_for(next_frame - now);
           }
-
-          if (config::sunshine.min_log_level <= 1) {
-            // Print sleep overshoot stats to debug log every 20 seconds
-            auto print_info = [&](double min_overshoot, double max_overshoot, double avg_overshoot) {
-              auto f = stat_trackers::one_digit_after_decimal();
-              BOOST_LOG(debug) << "Sleep overshoot (min/max/avg): " << f % min_overshoot << "ms/" << f % max_overshoot << "ms/" << f % avg_overshoot << "ms";
-            };
-            std::chrono::nanoseconds overshoot_ns = std::chrono::steady_clock::now() - next_frame;
-            sleep_overshoot_tracker.collect_and_callback_on_interval(overshoot_ns.count() / 1000000., print_info, 20s);
-          }
+          now = std::chrono::steady_clock::now();
+          std::chrono::nanoseconds overshoot_ns = now - next_frame;
+          log_sleep_overshoot(overshoot_ns);
 
           next_frame += delay;
           if (next_frame < now) {  // some major slowdown happened; we couldn't keep up

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1197,11 +1197,7 @@ namespace platf {
           auto now = std::chrono::steady_clock::now();
 
           if (next_frame > now) {
-            std::this_thread::sleep_for((next_frame - now) / 3 * 2);
-          }
-          while (next_frame > now) {
-            std::this_thread::sleep_for(1ns);
-            now = std::chrono::steady_clock::now();
+            std::this_thread::sleep_for(next_frame - now);
           }
           next_frame += delay;
           if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
@@ -1421,11 +1417,7 @@ namespace platf {
           auto now = std::chrono::steady_clock::now();
 
           if (next_frame > now) {
-            std::this_thread::sleep_for((next_frame - now) / 3 * 2);
-          }
-          while (next_frame > now) {
-            std::this_thread::sleep_for(1ns);
-            now = std::chrono::steady_clock::now();
+            std::this_thread::sleep_for(next_frame - now);
           }
 
           if (config::sunshine.min_log_level <= 1) {

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1203,7 +1203,10 @@ namespace platf {
             std::this_thread::sleep_for(1ns);
             now = std::chrono::steady_clock::now();
           }
-          next_frame = now + delay;
+          next_frame += delay;
+          if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+            next_frame = now + delay;
+          }
 
           std::shared_ptr<platf::img_t> img_out;
           auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);
@@ -1422,7 +1425,10 @@ namespace platf {
             std::this_thread::sleep_for(1ns);
             now = std::chrono::steady_clock::now();
           }
-          next_frame = now + delay;
+          next_frame += delay;
+          if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+            next_frame = now + delay;
+          }
 
           std::shared_ptr<platf::img_t> img_out;
           auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -129,12 +129,18 @@ namespace wl {
     capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
       auto next_frame = std::chrono::steady_clock::now();
 
+      sleep_overshoot_tracker.reset();
+
       while (true) {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
           std::this_thread::sleep_for(next_frame - now);
         }
+        now = std::chrono::steady_clock::now();
+        std::chrono::nanoseconds overshoot_ns = now - next_frame;
+        log_sleep_overshoot(overshoot_ns);
+
         next_frame += delay;
         if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
           next_frame = now + delay;
@@ -259,12 +265,18 @@ namespace wl {
     capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
       auto next_frame = std::chrono::steady_clock::now();
 
+      sleep_overshoot_tracker.reset();
+
       while (true) {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
           std::this_thread::sleep_for(next_frame - now);
         }
+        now = std::chrono::steady_clock::now();
+        std::chrono::nanoseconds overshoot_ns = now - next_frame;
+        log_sleep_overshoot(overshoot_ns);
+
         next_frame += delay;
         if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
           next_frame = now + delay;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -133,12 +133,12 @@ namespace wl {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
-          std::this_thread::sleep_for((next_frame - now) / 3 * 2);
+          std::this_thread::sleep_for(next_frame - now);
         }
-        while (next_frame > now) {
-          now = std::chrono::steady_clock::now();
+        next_frame += delay;
+        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+          next_frame = now + delay;
         }
-        next_frame = now + delay;
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);
@@ -263,12 +263,12 @@ namespace wl {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
-          std::this_thread::sleep_for((next_frame - now) / 3 * 2);
+          std::this_thread::sleep_for(next_frame - now);
         }
-        while (next_frame > now) {
-          now = std::chrono::steady_clock::now();
+        next_frame += delay;
+        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+          next_frame = now + delay;
         }
-        next_frame = now + delay;
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -491,7 +491,10 @@ namespace platf {
           std::this_thread::sleep_for(1ns);
           now = std::chrono::steady_clock::now();
         }
-        next_frame = now + delay;
+        next_frame += delay;
+        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+          next_frame = now + delay;
+        }
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);
@@ -632,7 +635,10 @@ namespace platf {
           std::this_thread::sleep_for(1ns);
           now = std::chrono::steady_clock::now();
         }
-        next_frame = now + delay;
+        next_frame += delay;
+        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+          next_frame = now + delay;
+        }
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -481,12 +481,18 @@ namespace platf {
     capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
       auto next_frame = std::chrono::steady_clock::now();
 
+      sleep_overshoot_tracker.reset();
+
       while (true) {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
           std::this_thread::sleep_for(next_frame - now);
         }
+        now = std::chrono::steady_clock::now();
+        std::chrono::nanoseconds overshoot_ns = now - next_frame;
+        log_sleep_overshoot(overshoot_ns);
+
         next_frame += delay;
         if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
           next_frame = now + delay;
@@ -621,12 +627,18 @@ namespace platf {
     capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
       auto next_frame = std::chrono::steady_clock::now();
 
+      sleep_overshoot_tracker.reset();
+
       while (true) {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
           std::this_thread::sleep_for(next_frame - now);
         }
+        now = std::chrono::steady_clock::now();
+        std::chrono::nanoseconds overshoot_ns = now - next_frame;
+        log_sleep_overshoot(overshoot_ns);
+
         next_frame += delay;
         if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
           next_frame = now + delay;

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -485,11 +485,7 @@ namespace platf {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
-          std::this_thread::sleep_for((next_frame - now) / 3 * 2);
-        }
-        while (next_frame > now) {
-          std::this_thread::sleep_for(1ns);
-          now = std::chrono::steady_clock::now();
+          std::this_thread::sleep_for(next_frame - now);
         }
         next_frame += delay;
         if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
@@ -629,11 +625,7 @@ namespace platf {
         auto now = std::chrono::steady_clock::now();
 
         if (next_frame > now) {
-          std::this_thread::sleep_for((next_frame - now) / 3 * 2);
-        }
-        while (next_frame > now) {
-          std::this_thread::sleep_for(1ns);
-          now = std::chrono::steady_clock::now();
+          std::this_thread::sleep_for(next_frame - now);
         }
         next_frame += delay;
         if (next_frame < now) {  // some major slowdown happened; we couldn't keep up


### PR DESCRIPTION

## Description
<!--- Please include a summary of the changes. --->
This commit computes the time of the next screen capture based on the current frame's theoretical time point instead of the actual capture time. This should be slightly more precise and lead to better frame timing.

I made the same change in three parts of the codebase:
- twice in `kmsgrab.cpp` (`display_ram_t` and `display_vram_t`). IIUC these correspond to capture to system RAM for software encoding and capture to VRAM for hardware encoding respectively. Please correct me if I'm wrong; I did not try to understand the whole pipeline.
- once in `x11grab.cpp` which presented the same issue.

At this point I did only preliminary testing of the kmsgrab & VA-API case on an AMD 6650. The results were very encouraging with a precise 60.0 Hz instead of the previous average of 59.94 Hz. (See #2286 for details.) I'll vary my testing over the next few days and report back. Any feedback and review is welcome, of course.

If I'm not mistaken this fix should benefit all Linux users with the exception of NvFBC configurations.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
Fixes #2286 
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
