### PR TITLE
fix(file_handler): avoid writing extra newline character

### DIFF
--- a/src/file_handler.cpp
+++ b/src/file_handler.cpp
@@ -31,16 +31,7 @@ namespace file_handler {
     }
 
     std::ifstream in(path);
-
-    std::string input;
-    std::string base64_cert;
-
-    while (!in.eof()) {
-      std::getline(in, input);
-      base64_cert += input + '\n';
-    }
-
-    return base64_cert;
+    return std::string { (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>() };
   }
 
   /**

--- a/tests/unit/test_file_handler.cpp
+++ b/tests/unit/test_file_handler.cpp
@@ -6,14 +6,54 @@
 
 #include <tests/conftest.cpp>
 
-TEST(FileHandlerTests, WriteFileTest) {
-  EXPECT_EQ(file_handler::write_file("write_file_test.txt", "test"), 0);
+class FileHandlerTests: public virtual BaseTest, public ::testing::WithParamInterface<std::tuple<int, std::string>> {
+protected:
+  void
+  SetUp() override {
+    BaseTest::SetUp();
+  }
+
+  void
+  TearDown() override {
+    BaseTest::TearDown();
+  }
+};
+INSTANTIATE_TEST_SUITE_P(
+  TestFiles,
+  FileHandlerTests,
+  ::testing::Values(
+    std::make_tuple(0, ""),  // empty file
+    std::make_tuple(1, "a"),  // single character
+    std::make_tuple(2, "Mr. Blue Sky - Electric Light Orchestra"),  // single line
+    std::make_tuple(3, R"(
+Morning! Today's forecast calls for blue skies
+The sun is shining in the sky
+There ain't a cloud in sight
+It's stopped raining
+Everybody's in the play
+And don't you know, it's a beautiful new day
+Hey, hey, hey!
+Running down the avenue
+See how the sun shines brightly in the city
+All the streets where once was pity
+Mr. Blue Sky is living here today!
+Hey, hey, hey!
+    )")  // multi-line
+    ));
+
+TEST_P(FileHandlerTests, WriteFileTest) {
+  auto [fileNum, content] = GetParam();
+  std::string fileName = "write_file_test_" + std::to_string(fileNum) + ".txt";
+  EXPECT_EQ(file_handler::write_file(fileName.c_str(), content), 0);
 }
 
-TEST(FileHandlerTests, ReadFileTest) {
-  // read file from WriteFileTest
-  EXPECT_EQ(file_handler::read_file("write_file_test.txt"), "test\n");  // sunshine adds a newline
+TEST_P(FileHandlerTests, ReadFileTest) {
+  auto [fileNum, content] = GetParam();
+  std::string fileName = "write_file_test_" + std::to_string(fileNum) + ".txt";
+  EXPECT_EQ(file_handler::read_file(fileName.c_str()), content);
+}
 
+TEST(FileHandlerTests, ReadMissingFileTest) {
   // read missing file
   EXPECT_EQ(file_handler::read_file("non-existing-file.txt"), "");
 }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When developing unit tests in #1603, it was discovered that the `read_file` function would add an extra newline character.

Todo:
- [x] parametrize test to cover more cases


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
