### PR TITLE
fix(logging): add logging namespace and create logging::init method

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1184,7 +1184,7 @@ namespace config {
       auto line = argv[x];
 
       if (line == "--help"sv) {
-        print_help(*argv);
+        logging::print_help(*argv);
         return 1;
       }
 #ifdef _WIN32
@@ -1204,7 +1204,7 @@ namespace config {
           break;
         }
         if (apply_flags(line + 1)) {
-          print_help(*argv);
+          logging::print_help(*argv);
           return -1;
         }
       }
@@ -1218,7 +1218,7 @@ namespace config {
         else {
           TUPLE_EL(var, 1, parse_option(line, line_end));
           if (!var) {
-            print_help(*argv);
+            logging::print_help(*argv);
             return -1;
           }
 

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -87,12 +87,12 @@ namespace args {
    *
    * EXAMPLES:
    * ```cpp
-   * print_help("sunshine", 0, nullptr);
+   * help("sunshine", 0, nullptr);
    * ```
    */
   int
   help(const char *name, int argc, char *argv[]) {
-    print_help(name);
+    logging::print_help(name);
     return 0;
   }
 
@@ -109,7 +109,7 @@ namespace args {
    */
   int
   version(const char *name, int argc, char *argv[]) {
-    std::cout << PROJECT_NAME << " version: v" << PROJECT_VER << std::endl;
+    // version was already logged at startup
     return 0;
   }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -4,9 +4,11 @@
  */
 
 // standard includes
+#include <fstream>
 #include <iostream>
 
 // lib includes
+#include <boost/core/null_deleter.hpp>
 #include <boost/log/attributes/clock.hpp>
 #include <boost/log/common.hpp>
 #include <boost/log/expressions.hpp>
@@ -15,6 +17,10 @@
 
 // local includes
 #include "logging.h"
+
+extern "C" {
+#include <libavutil/log.h>
+}
 
 using namespace std::literals;
 
@@ -29,45 +35,182 @@ bl::sources::severity_logger<int> warning(3);  // Strange events
 bl::sources::severity_logger<int> error(4);  // Recoverable errors
 bl::sources::severity_logger<int> fatal(5);  // Unrecoverable errors
 
-/**
- * @brief Flush the log.
- *
- * EXAMPLES:
- * ```cpp
- * log_flush();
- * ```
- */
-void
-log_flush() {
-  sink->flush();
-}
+BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", int)
 
-/**
- * @brief Print help to stdout.
- * @param name The name of the program.
- *
- * EXAMPLES:
- * ```cpp
- * print_help("sunshine");
- * ```
- */
-void
-print_help(const char *name) {
-  std::cout
-    << "Usage: "sv << name << " [options] [/path/to/configuration_file] [--cmd]"sv << std::endl
-    << "    Any configurable option can be overwritten with: \"name=value\""sv << std::endl
-    << std::endl
-    << "    Note: The configuration will be created if it doesn't exist."sv << std::endl
-    << std::endl
-    << "    --help                    | print help"sv << std::endl
-    << "    --creds username password | set user credentials for the Web manager"sv << std::endl
-    << "    --version                 | print the version of sunshine"sv << std::endl
-    << std::endl
-    << "    flags"sv << std::endl
-    << "        -0 | Read PIN from stdin"sv << std::endl
-    << "        -1 | Do not load previously saved state and do retain any state after shutdown"sv << std::endl
-    << "           | Effectively starting as if for the first time without overwriting any pairings with your devices"sv << std::endl
-    << "        -2 | Force replacement of headers in video stream"sv << std::endl
-    << "        -p | Enable/Disable UPnP"sv << std::endl
-    << std::endl;
-}
+namespace logging {
+  /**
+   * @brief A destructor that restores the initial state.
+   */
+  deinit_t::~deinit_t() {
+    deinit();
+  }
+
+  /**
+   * @brief Deinitialize the logging system.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * deinit();
+   * ```
+   */
+  void
+  deinit() {
+    log_flush();
+    bl::core::get()->remove_sink(sink);
+    sink.reset();
+  }
+
+  /**
+   * @brief Initialize the logging system.
+   * @param min_log_level The minimum log level to output.
+   * @param log_file The log file to write to.
+   * @returns A deinit_t object that will deinitialize the logging system when it goes out of scope.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * log_init(2, "sunshine.log");
+   * ```
+   */
+  [[nodiscard]] std::unique_ptr<deinit_t>
+  init(int min_log_level, const std::string &log_file) {
+    if (sink) {
+      // Deinitialize the logging system before reinitializing it. This can probably only ever be hit in tests.
+      deinit();
+    }
+
+    setup_av_logging(min_log_level);
+
+    sink = boost::make_shared<text_sink>();
+
+    boost::shared_ptr<std::ostream> stream { &std::cout, boost::null_deleter() };
+    sink->locked_backend()->add_stream(stream);
+    sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(log_file));
+    sink->set_filter(severity >= min_log_level);
+
+    sink->set_formatter([](const bl::record_view &view, bl::formatting_ostream &os) {
+      constexpr const char *message = "Message";
+      constexpr const char *severity = "Severity";
+      constexpr int DATE_BUFFER_SIZE = 21 + 2 + 1;  // Full string plus ": \0"
+
+      auto log_level = view.attribute_values()[severity].extract<int>().get();
+
+      std::string_view log_type;
+      switch (log_level) {
+        case 0:
+          log_type = "Verbose: "sv;
+          break;
+        case 1:
+          log_type = "Debug: "sv;
+          break;
+        case 2:
+          log_type = "Info: "sv;
+          break;
+        case 3:
+          log_type = "Warning: "sv;
+          break;
+        case 4:
+          log_type = "Error: "sv;
+          break;
+        case 5:
+          log_type = "Fatal: "sv;
+          break;
+      };
+
+      char _date[DATE_BUFFER_SIZE];
+      std::time_t t = std::time(nullptr);
+      strftime(_date, DATE_BUFFER_SIZE, "[%Y:%m:%d:%H:%M:%S]: ", std::localtime(&t));
+
+      os << _date << log_type << view.attribute_values()[message].extract<std::string>();
+    });
+
+    // Flush after each log record to ensure log file contents on disk isn't stale.
+    // This is particularly important when running from a Windows service.
+    sink->locked_backend()->auto_flush(true);
+
+    bl::core::get()->add_sink(sink);
+    return std::make_unique<deinit_t>();
+  }
+
+  /**
+   * @brief Setup AV logging.
+   * @param min_log_level The log level.
+   */
+  void
+  setup_av_logging(int min_log_level) {
+    if (min_log_level >= 1) {
+      av_log_set_level(AV_LOG_QUIET);
+    }
+    else {
+      av_log_set_level(AV_LOG_DEBUG);
+    }
+    av_log_set_callback([](void *ptr, int level, const char *fmt, va_list vl) {
+      static int print_prefix = 1;
+      char buffer[1024];
+
+      av_log_format_line(ptr, level, fmt, vl, buffer, sizeof(buffer), &print_prefix);
+      if (level <= AV_LOG_ERROR) {
+        // We print AV_LOG_FATAL at the error level. FFmpeg prints things as fatal that
+        // are expected in some cases, such as lack of codec support or similar things.
+        BOOST_LOG(error) << buffer;
+      }
+      else if (level <= AV_LOG_WARNING) {
+        BOOST_LOG(warning) << buffer;
+      }
+      else if (level <= AV_LOG_INFO) {
+        BOOST_LOG(info) << buffer;
+      }
+      else if (level <= AV_LOG_VERBOSE) {
+        // AV_LOG_VERBOSE is less verbose than AV_LOG_DEBUG
+        BOOST_LOG(debug) << buffer;
+      }
+      else {
+        BOOST_LOG(verbose) << buffer;
+      }
+    });
+  }
+
+  /**
+   * @brief Flush the log.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * log_flush();
+   * ```
+   */
+  void
+  log_flush() {
+    if (sink) {
+      sink->flush();
+    }
+  }
+
+  /**
+   * @brief Print help to stdout.
+   * @param name The name of the program.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * print_help("sunshine");
+   * ```
+   */
+  void
+  print_help(const char *name) {
+    std::cout
+      << "Usage: "sv << name << " [options] [/path/to/configuration_file] [--cmd]"sv << std::endl
+      << "    Any configurable option can be overwritten with: \"name=value\""sv << std::endl
+      << std::endl
+      << "    Note: The configuration will be created if it doesn't exist."sv << std::endl
+      << std::endl
+      << "    --help                    | print help"sv << std::endl
+      << "    --creds username password | set user credentials for the Web manager"sv << std::endl
+      << "    --version                 | print the version of sunshine"sv << std::endl
+      << std::endl
+      << "    flags"sv << std::endl
+      << "        -0 | Read PIN from stdin"sv << std::endl
+      << "        -1 | Do not load previously saved state and do retain any state after shutdown"sv << std::endl
+      << "           | Effectively starting as if for the first time without overwriting any pairings with your devices"sv << std::endl
+      << "        -2 | Force replacement of headers in video stream"sv << std::endl
+      << "        -p | Enable/Disable UPnP"sv << std::endl
+      << std::endl;
+  }
+}  // namespace logging

--- a/src/logging.h
+++ b/src/logging.h
@@ -10,7 +10,6 @@
 #include <boost/log/common.hpp>
 #include <boost/log/sinks.hpp>
 
-extern boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> sink;
 using text_sink = boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>;
 
 extern boost::log::sources::severity_logger<int> verbose;
@@ -20,8 +19,20 @@ extern boost::log::sources::severity_logger<int> warning;
 extern boost::log::sources::severity_logger<int> error;
 extern boost::log::sources::severity_logger<int> fatal;
 
-// functions
-void
-log_flush();
-void
-print_help(const char *name);
+namespace logging {
+  class deinit_t {
+  public:
+    ~deinit_t();
+  };
+
+  void
+  deinit();
+  [[nodiscard]] std::unique_ptr<deinit_t>
+  init(int min_log_level, const std::string &log_file);
+  void
+  setup_av_logging(int min_log_level);
+  void
+  log_flush();
+  void
+  print_help(const char *name);
+}  // namespace logging

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1814,7 +1814,7 @@ namespace stream {
       // The alternative is that Sunshine can never start another session until it's manually restarted.
       auto task = []() {
         BOOST_LOG(fatal) << "Hang detected! Session failed to terminate in 10 seconds."sv;
-        log_flush();
+        logging::log_flush();
         lifetime::debug_trap();
       };
       auto force_kill = task_pool.pushDelayed(task, 10s).task_id;

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file tests/test_logging.cpp
+ * @brief Test src/logging.*.
+ */
+#include <fstream>
+
+#include <src/logging.h>
+
+#include <tests/conftest.cpp>
+
+class LoggerInitTest: public virtual BaseTest, public ::testing::WithParamInterface<int> {
+protected:
+  void
+  SetUp() override {
+    BaseTest::SetUp();
+  }
+
+  void
+  TearDown() override {
+    BaseTest::TearDown();
+  }
+};
+INSTANTIATE_TEST_SUITE_P(
+  LogLevel,
+  LoggerInitTest,
+  ::testing::Values(
+    0,
+    1,
+    2,
+    3,
+    4,
+    5));
+TEST_P(LoggerInitTest, InitLogging) {
+  int logLevel = GetParam();
+  std::string logFilePath = "test_log_" + std::to_string(logLevel) + ".log";
+
+  // deinit the BaseTest logger
+  BaseTest::deinit_guard.reset();
+
+  auto log_deinit = logging::init(logLevel, logFilePath);
+  if (!log_deinit) {
+    FAIL() << "Failed to initialize logging";
+  }
+}
+
+TEST(LogFlushTest, CheckLogFile) {
+  // Write a log message
+  BOOST_LOG(info) << "Test message";
+
+  // Call log_flush
+  logging::log_flush();
+
+  // Check the contents of the log file
+  std::ifstream log_file("test.log");
+  std::string line;
+  bool found = false;
+  while (std::getline(log_file, line)) {
+    if (line.find("Test message") != std::string::npos) {
+      found = true;
+      break;
+    }
+  }
+
+  EXPECT_TRUE(found);
+}
+
+TEST(PrintHelpTest, CheckOutput) {
+  std::string name = "test";
+  logging::print_help(name.c_str());
+
+  std::string output = cout_buffer.str();
+
+  EXPECT_NE(output.find("Usage: " + name), std::string::npos);
+  EXPECT_NE(output.find("--help"), std::string::npos);
+}

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -21,10 +21,6 @@ protected:
     bool isEncoderValid;
     isEncoderValid = video::validate_encoder(*encoder, false);
 
-    // todo: av logging is not redirected to boost so it will be visible whether the test passes or fails
-    // move this code to logging
-    // https://github.com/LizardByte/Sunshine/blob/5606840c8983b714a0e442c42d887a49807715e1/src/main.cpp#L118
-
     if (!isEncoderValid) {
       // if encoder is software fail, otherwise skip
       if (encoder == &video::software && std::string(TESTS_SOFTWARE_ENCODER_UNAVAILABLE) == "fail") {
@@ -49,7 +45,6 @@ INSTANTIATE_TEST_SUITE_P(
   EncoderVariants,
   EncoderTest,
   ::testing::Values(
-// todo: all encoders crash on windows, probably due to platf not being initialized (which also crashes)
 #if !defined(__APPLE__)
     std::make_tuple(video::nvenc.name, &video::nvenc),
 #endif


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Boost logs are captured in unit tests, and it was discovered that some encoder logging messages were not captured. This PR moves more (and hopefully all) logging setup to a `logging::init` method.

Example test output prior to this PR:
```txt
[ RUN      ] EncoderVariants/EncoderTest.ValidateEncoder/2
[libx264 @ 0x55d3f87659c0] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
[libx264 @ 0x55d3f87659c0] profile High, level 4.2, 4:2:0, 8-bit
[libx264 @ 0x55d3f87659c0] frame I:1     Avg QP:31.00  size:  1203
[libx264 @ 0x55d3f87659c0] mb I  I16..4: 99.9%  0.0%  0.0%
[libx264 @ 0x55d3f87659c0] 8x8 transform intra:0.0%
[libx264 @ 0x55d3f87659c0] coded y,uvDC,uvAC intra: 0.0% 0.0% 0.0%
[libx264 @ 0x55d3f87659c0] i16 v,h,dc,p: 97%  0%  3%  0%
[libx264 @ 0x55d3f87659c0] i8 v,h,dc,ddl,ddr,vr,hd,vl,hu:  0%  0% 75% 12%  0%  0%  0%  0% 12%
[libx264 @ 0x55d3f87659c0] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu:  0%  0% 100%  0%  0%  0%  0%  0%  0%
[libx264 @ 0x55d3f87659c0] i8c dc,h,v,p: 100%  0%  0%  0%
[libx264 @ 0x55d3f87659c0] kb/s:577.44
[       OK ] EncoderVariants/EncoderTest.ValidateEncoder/2 (69 ms)
```

Todo:

- [x] Fix crash on macOS tests
  - macports on macOS-14 passed, first attempt?
  - homebrew on macOS-12 passed, second attempt?
  - all others failed
- [x] Fix random crash on debian? https://github.com/LizardByte/Sunshine/actions/runs/8495130331/job/23271087984#step:10:6156
- [x] add some unit tests around logging


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
