### PR TITLE
build(cmake): copy asset files to build dir

### DIFF
--- a/cmake/packaging/common.cmake
+++ b/cmake/packaging/common.cmake
@@ -12,10 +12,18 @@ set(CPACK_PACKAGE_ICON ${PROJECT_SOURCE_DIR}/sunshine.png)
 set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}")
 set(CPACK_STRIP_FILES YES)
 
-#install common assets
+# install common assets
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/"
         DESTINATION "${SUNSHINE_ASSETS_DIR}"
         PATTERN "web" EXCLUDE)
+# copy assets to build directory, for running without install
+file(GLOB_RECURSE ALL_ASSETS
+        RELATIVE "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/" "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/*")
+list(FILTER ALL_ASSETS EXCLUDE REGEX "^web/.*$")  # Filter out the web directory
+foreach(asset ${ALL_ASSETS})  # Copy assets to build directory, excluding the web directory
+    file(COPY "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/${asset}"
+            DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/assets")
+endforeach()
 
 # install built vite assets
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/assets/web"

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -2,6 +2,9 @@
 
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/assets/"
         DESTINATION "${SUNSHINE_ASSETS_DIR}")
+# copy assets to build directory, for running without install
+file(COPY "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/assets/"
+        DESTINATION "${CMAKE_BINARY_DIR}/assets")
 if(${SUNSHINE_BUILD_APPIMAGE} OR ${SUNSHINE_BUILD_FLATPAK})
     install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/60-sunshine.rules"
             DESTINATION "${SUNSHINE_ASSETS_DIR}/udev/rules.d")

--- a/cmake/packaging/macos.cmake
+++ b/cmake/packaging/macos.cmake
@@ -10,15 +10,16 @@ if(SUNSHINE_PACKAGE_MACOS)  # todo
     set(MAC_PREFIX "${CMAKE_PROJECT_NAME}.app/Contents")
     set(INSTALL_RUNTIME_DIR "${MAC_PREFIX}/MacOS")
 
-    install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/macos/assets/"
-            DESTINATION "${SUNSHINE_ASSETS_DIR}")
-
     install(TARGETS sunshine
             BUNDLE DESTINATION . COMPONENT Runtime
             RUNTIME DESTINATION ${INSTALL_RUNTIME_DIR} COMPONENT Runtime)
 else()
-    install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/macos/assets/"
-            DESTINATION "${SUNSHINE_ASSETS_DIR}")
     install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/macos/misc/uninstall_pkg.sh"
             DESTINATION "${SUNSHINE_ASSETS_DIR}")
 endif()
+
+install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/macos/assets/"
+        DESTINATION "${SUNSHINE_ASSETS_DIR}")
+# copy assets to build directory, for running without install
+file(COPY "${SUNSHINE_SOURCE_ASSETS_DIR}/macos/assets/"
+        DESTINATION "${CMAKE_BINARY_DIR}/assets")

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -39,6 +39,9 @@ install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/gamepad/"
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/assets/"
         DESTINATION "${SUNSHINE_ASSETS_DIR}"
         COMPONENT assets)
+# copy assets to build directory, for running without install
+file(COPY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/assets/"
+        DESTINATION "${CMAKE_BINARY_DIR}/assets")
 
 # set(CPACK_NSIS_MUI_HEADERIMAGE "") # TODO: image should be 150x57 bmp
 set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}\\\\sunshine.ico")


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR makes a change to the build process, where asset files are copied to the build directory, so that the generated binary can be run without an install. This is mostly to improve the development process, although some users have wanted to run Sunshine without an install in the past as well.

This uses the `file(COPY ...)` method which actually copies the files when running cmake, before the build.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
