### PR TITLE
build(cmake): build web-ui target with cmd instead of bash on windows

### DIFF
--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -3,6 +3,18 @@
 
 add_executable(sunshine ${SUNSHINE_TARGET_FILES})
 
+# Homebrew build fails the vite build if we set these environment variables
+# this block must be before the platform specific code
+if(${SUNSHINE_BUILD_HOMEBREW})
+    set(NPM_SOURCE_ASSETS_DIR "")
+    set(NPM_ASSETS_DIR "")
+    set(NPM_BUILD_HOMEBREW "true")
+else()
+    set(NPM_SOURCE_ASSETS_DIR ${SUNSHINE_SOURCE_ASSETS_DIR})
+    set(NPM_ASSETS_DIR ${CMAKE_BINARY_DIR})
+    set(NPM_BUILD_HOMEBREW "")
+endif()
+
 # platform specific target definitions
 if(WIN32)
     include(${CMAKE_MODULE_PATH}/targets/windows.cmake)
@@ -36,23 +48,6 @@ if(CUDA_INHERIT_COMPILE_OPTIONS)
 endif()
 
 target_compile_options(sunshine PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>;$<$<COMPILE_LANGUAGE:CUDA>:${SUNSHINE_COMPILE_OPTIONS_CUDA};-std=c++17>)  # cmake-lint: disable=C0301
-
-# Homebrew build fails the vite build if we set these environment variables
-if(${SUNSHINE_BUILD_HOMEBREW})
-    set(NPM_SOURCE_ASSETS_DIR "")
-    set(NPM_ASSETS_DIR "")
-    set(NPM_BUILD_HOMEBREW "true")
-else()
-    set(NPM_SOURCE_ASSETS_DIR ${SUNSHINE_SOURCE_ASSETS_DIR})
-    set(NPM_ASSETS_DIR ${CMAKE_BINARY_DIR})
-    set(NPM_BUILD_HOMEBREW "")
-endif()
-
-#WebUI build
-add_custom_target(web-ui ALL
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        COMMENT "Installing NPM Dependencies and Building the Web UI"
-        COMMAND bash -c \"npm install && SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW} SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR} SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR} npm run build\") # cmake-lint: disable=C0301
 
 # tests
 if(BUILD_TESTS)

--- a/cmake/targets/unix.cmake
+++ b/cmake/targets/unix.cmake
@@ -1,2 +1,8 @@
 # unix specific target definitions
 # put anything here that applies to both linux and macos
+
+#WebUI build
+add_custom_target(web-ui ALL
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        COMMENT "Installing NPM Dependencies and Building the Web UI"
+        COMMAND bash -c \"npm install && SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW} SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR} SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR} npm run build\")  # cmake-lint: disable=C0301

--- a/cmake/targets/windows.cmake
+++ b/cmake/targets/windows.cmake
@@ -4,3 +4,9 @@ set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
 find_library(ZLIB ZLIB1)
 list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
         Wtsapi32.lib)
+
+#WebUI build
+add_custom_target(web-ui ALL
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        COMMENT "Installing NPM Dependencies and Building the Web UI"
+        COMMAND cmd /C "npm install && set \"SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR}\" && set \"SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR}\" && npm run build")   # cmake-lint: disable=C0301


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
In some cases, the command using bash to build the web-ui would fail, such as:

- Using the web-ui configuration in CLion
- User doesn't have bash installed, for whatever reason


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
