### PR TITLE
Add the ability to force an IDR from the troubleshooting menu.

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1960,5 +1960,24 @@ namespace stream {
 
       return session;
     }
+
+    void
+    force_idr() {
+      BOOST_LOG(info) << "Forcing IDR on all sessions";
+      auto ref = broadcast.ref();
+      auto& sessions = ref->control_server._sessions;
+      auto lg = sessions.lock();
+      for (auto pos = std::begin(*sessions); pos != std::end(*sessions); ++pos) {
+        auto session_p = *pos;
+
+        // If a session is not established, it doesn't need an IDR
+        if (!session_p->control.peer) {
+          continue;
+        }
+
+        // Cause the IDR
+        session_p->video.idr_events->raise(true);
+      }
+    }
   }  // namespace session
 }  // namespace stream

--- a/src/stream.h
+++ b/src/stream.h
@@ -50,5 +50,7 @@ namespace stream {
     join(session_t &session);
     state_e
     state(session_t &session);
+    void
+    force_idr();
   }  // namespace session
 }  // namespace stream

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -367,7 +367,11 @@
     "unpair_all": "Unpair All",
     "unpair_all_desc": "Remove all your paired devices",
     "unpair_all_error": "Error while unpairing",
-    "unpair_all_success": "Unpair Successful!"
+    "unpair_all_success": "Unpair Successful!",
+    "force_idr": "Force IDR",
+    "force_idr_desc": "If colour distortions happen, and the stream doesn't recover, this button should fix the issue.",
+    "force_idr_error": "Error while forcing IDR",
+    "force_idr_success": "Force IDR successful!"
   },
   "welcome": {
     "confirm_password": "Confirm password",

--- a/src_assets/common/assets/web/troubleshooting.html
+++ b/src_assets/common/assets/web/troubleshooting.html
@@ -94,6 +94,25 @@
         </div>
       </div>
     </div>
+    <!-- Force IDR -->
+    <div class="card p-2 my-4">
+      <div class="card-body">
+        <h2 id="force_idr">{{ $t('troubleshooting.force_idr') }}</h2>
+        <br>
+        <p>{{ $t('troubleshooting.force_idr_desc') }}</p>
+        <div class="alert alert-success" v-if="forceIDRStatus === true">
+          {{ $t('troubleshooting.force_idr_success') }}
+        </div>
+        <div class="alert alert-danger" v-if="forceIDRStatus === false">
+          {{ $t('troubleshooting.force_idr_error') }}
+        </div>
+        <div>
+          <button class="btn btn-danger" :disabled="forceIDRPressed" @click="forceIDR">
+            {{ $t('troubleshooting.force_idr') }}
+          </button>
+        </div>
+      </div>
+    </div>
     <!-- Logs -->
     <div class="card p-2 my-4">
       <div class="card-body">
@@ -127,6 +146,8 @@
           closeAppStatus: null,
           unpairAllPressed: false,
           unpairAllStatus: null,
+          forceIDRPressed: false,
+          forceIDRStatus: null,
           restartPressed: false,
           logs: 'Loading...',
           logFilter: null,
@@ -179,6 +200,18 @@
               this.unpairAllStatus = r.status.toString() === "true";
               setTimeout(() => {
                 this.unpairAllStatus = null;
+              }, 5000);
+            });
+        },
+        forceIDR() {
+          this.forceIDRPressed = true;
+          fetch("/api/clients/force-idr", { method: "POST" })
+            .then((r) => r.json())
+            .then((r) => {
+              this.forceIDRPressed = false;
+              this.forceIDRStatus = r.status.toString() === "true";
+              setTimeout(() => {
+                this.forceIDRStatus = null;
               }, 5000);
             });
         },


### PR DESCRIPTION
## Description

Adds the ability to force an IDR from the troubleshooting menu.
    
Sometimes, devices are simply receiving video, and are not in locations which are amiable to retrieval.
    
For example, a device mounted on one's head, even if within an openable shell, is awkward to retrieve.
    
In these situations, higher resolutions and higher bitrates are often used, which leaves little room for any error correction or recovery; and the current mechanisms used for these can fail anyway. (Usual symptoms are the entire stream turning green, or inconsistent, blocky brightness issues.)
    
In this case, it's required that there is an easy way to manually recover the stream.
    
While using the web UI is theoretically suboptimal for this, the exposure of a way to do this over HTTP allows hooking up whatever controls a more technical user feels are necessary. (A mechanism to automatically send IDRs at a fixed rate was considered, but ultimately I decided this would likely be rejected due to the continuous hitching this would produce in the output for anyone who actually used the feature.)
    
It is also possible that in some situations, a user may simply not wish to interrupt the flow of a stream; for example, when using Sunshine/Moonlight as part of a home theatre setup.
    
In this case, they can press the button on the web UI and playback can continue more-or-less uninterrupted.

### Screenshot
![2024-04-03_12-44](https://github.com/LizardByte/Sunshine/assets/22304167/e3877684-7734-4d55-a287-ba36eab88d21)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
