### PR TITLE
build(linux)!: disable arm64 builds for Fedora

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -189,7 +189,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.check_dockerfiles.outputs.matrix) }}
-    timeout-minutes: 480  # 8 hours
     name: Docker${{ matrix.tag }}
 
     steps:

--- a/docker/fedora-38.dockerfile
+++ b/docker/fedora-38.dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # artifacts: true
-# platforms: linux/amd64,linux/arm64/v8
+# platforms: linux/amd64
 # platforms_pr: linux/amd64
 # no-cache-filters: sunshine-base,artifacts,sunshine
 ARG BASE=fedora
@@ -32,9 +32,11 @@ dnf -y group install "Development Tools"
 dnf -y install \
   boost-devel-1.78.0* \
   cmake-3.27.* \
+  doxygen \
   gcc-13.2.* \
   gcc-c++-13.2.* \
   git \
+  graphviz \
   libappindicator-gtk3-devel \
   libcap-devel \
   libcurl-devel \
@@ -58,6 +60,7 @@ dnf -y install \
   openssl-devel \
   opus-devel \
   pulseaudio-libs-devel \
+  python3.10 \
   rpm-build \
   wget \
   which \
@@ -107,7 +110,6 @@ cmake \
   -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
-  -DTESTS_ENABLE_PYTHON_TESTS=OFF \
   -DSUNSHINE_ASSETS_DIR=share/sunshine \
   -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
   -DSUNSHINE_ENABLE_WAYLAND=ON \

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # artifacts: true
-# platforms: linux/amd64,linux/arm64/v8
+# platforms: linux/amd64
 # platforms_pr: linux/amd64
 # no-cache-filters: sunshine-base,artifacts,sunshine
 ARG BASE=fedora
@@ -32,9 +32,11 @@ dnf -y group install "Development Tools"
 dnf -y install \
   boost-devel-1.81.0* \
   cmake-3.27.* \
+  doxygen \
   gcc-13.2.* \
   gcc-c++-13.2.* \
   git \
+  graphviz \
   libappindicator-gtk3-devel \
   libcap-devel \
   libcurl-devel \
@@ -58,6 +60,7 @@ dnf -y install \
   openssl-devel \
   opus-devel \
   pulseaudio-libs-devel \
+  python3.11 \
   rpm-build \
   wget \
   which \
@@ -114,7 +117,6 @@ cmake \
   -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
-  -DTESTS_ENABLE_PYTHON_TESTS=OFF \
   -DSUNSHINE_ASSETS_DIR=share/sunshine \
   -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
   -DSUNSHINE_ENABLE_WAYLAND=ON \


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Temporarily disable arm64 builds for Fedora. The builds exceed the 6 hour time limit on GitHub hosted runners.

The plan is to move the Fedora builds over to Copr eventually.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
