### PR TITLE
Quote the path to sunshinesvc.exe when launching the termination helper

### DIFF
--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -145,8 +145,11 @@ bool
 RunTerminationHelper(HANDLE console_token, DWORD pid) {
   WCHAR module_path[MAX_PATH];
   GetModuleFileNameW(NULL, module_path, _countof(module_path));
-  std::wstring command { module_path };
+  std::wstring command;
 
+  command += L'"';
+  command += module_path;
+  command += L'"';
   command += L" --terminate " + std::to_wstring(pid);
 
   STARTUPINFOW startup_info = {};
@@ -157,7 +160,7 @@ RunTerminationHelper(HANDLE console_token, DWORD pid) {
   // This will allow us to attach to Sunshine's console and send it a Ctrl-C event.
   PROCESS_INFORMATION process_info;
   if (!CreateProcessAsUserW(console_token,
-        NULL,
+        module_path,
         (LPWSTR) command.c_str(),
         NULL,
         NULL,


### PR DESCRIPTION
## Description
The path to sunshinesvc.exe needs to be quoted because it probably contains spaces, otherwise `CreateProcess()` will run `C:\Program.exe` if it's present. Fortunately, `C:\` prohibits ordinary user writes, so this type of bug isn't exploitable unless the user has manually loosened ACLs on the system drive.

For good measure, let's just pass the path directly to `CreateProcess()` to avoid all the executable searching nonsense.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
