### PR TITLE
build(deps): remove libavdevice

### DIFF
--- a/docker/clion-toolchain.dockerfile
+++ b/docker/clion-toolchain.dockerfile
@@ -33,7 +33,6 @@ apt-get install -y --no-install-recommends \
   git \
   graphviz \
   libayatana-appindicator3-dev \
-  libavdevice-dev \
   libboost-filesystem-dev=1.74.* \
   libboost-locale-dev=1.74.* \
   libboost-log-dev=1.74.* \

--- a/docker/debian-bookworm.dockerfile
+++ b/docker/debian-bookworm.dockerfile
@@ -35,7 +35,6 @@ apt-get install -y --no-install-recommends \
   doxygen \
   git \
   graphviz \
-  libavdevice-dev \
   libayatana-appindicator3-dev \
   libboost-filesystem-dev=1.74.* \
   libboost-locale-dev=1.74.* \

--- a/docker/debian-bullseye.dockerfile
+++ b/docker/debian-bullseye.dockerfile
@@ -36,7 +36,6 @@ apt-get install -y --no-install-recommends \
   doxygen \
   git \
   graphviz \
-  libavdevice-dev \
   libayatana-appindicator3-dev \
   libboost-filesystem-dev=1.74.* \
   libboost-locale-dev=1.74.* \

--- a/docker/ubuntu-22.04.dockerfile
+++ b/docker/ubuntu-22.04.dockerfile
@@ -36,7 +36,6 @@ apt-get install -y --no-install-recommends \
   doxygen \
   git \
   graphviz \
-  libavdevice-dev \
   libayatana-appindicator3-dev \
   libboost-filesystem-dev=1.74.* \
   libboost-locale-dev=1.74.* \

--- a/docs/source/building/linux.rst
+++ b/docs/source/building/linux.rst
@@ -15,7 +15,6 @@ Install Requirements
       sudo apt update && sudo apt install \
           build-essential \
           cmake \
-          libavdevice-dev \
           libayatana-appindicator3-dev \
           libboost-filesystem-dev \
           libboost-locale-dev \
@@ -98,7 +97,6 @@ Install Requirements
           build-essential \
           cmake \
           libappindicator3-dev \
-          libavdevice-dev \
           libboost-filesystem-dev \
           libboost-locale-dev \
           libboost-log-dev \
@@ -140,7 +138,6 @@ Install Requirements
           gcc-11 \
           g++-11 \
           libappindicator3-dev \
-          libavdevice-dev \
           libboost-filesystem-dev \
           libboost-locale-dev \
           libboost-log-dev \


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Remove `libavdevice-dev` which was a left over from when we used packaged ffmpeg, it is not needed when using pre-compiled ffmpeg.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
