### PR TITLE
Autofocus PIN input on Web UI pin page

### DIFF
--- a/src_assets/common/assets/web/pin.html
+++ b/src_assets/common/assets/web/pin.html
@@ -11,7 +11,7 @@
     <h1 class="my-4">{{ $t('pin.pin_pairing') }}</h1>
     <form action="" class="form d-flex flex-column align-items-center" id="form">
       <div class="card flex-column d-flex p-4 mb-4">
-        <input type="text" pattern="\d*" placeholder="PIN" id="pin-input" class="form-control my-4" />
+        <input type="text" pattern="\d*" placeholder="PIN" autofocus id="pin-input" class="form-control my-4" />
         <button class="btn btn-primary">{{ $t('pin.send') }}</button>
       </div>
       <div class="alert alert-warning">


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

This makes it faster to input the PIN after clicking on the PIN notification on the desktop, since you no longer need to click the PIN input or focus on it by pressing Tab many times.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

![image](https://github.com/LizardByte/Sunshine/assets/180032/9548edad-138d-4ce7-a5a3-f6bccaac7451)

### Issues Fixed or Closed

N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
