### PR TITLE
fix(linux): Arch requires library at runtime

### DIFF
--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -13,6 +13,7 @@ install=sunshine.install
 depends=('avahi'
          'boost-libs'
          'curl'
+         'libappindicator-gtk3'
          'libayatana-appindicator'
          'libcap'
          'libdrm'


### PR DESCRIPTION
## Description
On my Archlinux system, the package builds correctly, but without including the libappindicator-gtk3 dependency, it fails to launch at runtime with the following error message:

```/usr/bin/sunshine: error while loading shared libraries: libappindicator3.so.1: cannot open shared object file: No such file or directory```

This patch adds the required library as a dependency for runtime.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
