### PR TITLE
Fix crash when an absolute position event is received too early during connection setup

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -32,6 +32,11 @@ namespace input {
     float client_offsetX, client_offsetY;
 
     float scalar_inv;
+
+    explicit
+    operator bool() const {
+      return width != 0 && height != 0 && env_width != 0 && env_height != 0;
+    }
   };
 
   std::pair<float, float>

--- a/src/platform/linux/input.cpp
+++ b/src/platform/linux/input.cpp
@@ -587,8 +587,8 @@ namespace platf {
         weak_strong += data.rumble(tp);
       }
 
-      std::clamp<std::uint32_t>(weak_strong.first, 0, 0xFFFF);
-      std::clamp<std::uint32_t>(weak_strong.second, 0, 0xFFFF);
+      weak_strong.first = std::clamp<std::uint32_t>(weak_strong.first, 0, 0xFFFF);
+      weak_strong.second = std::clamp<std::uint32_t>(weak_strong.second, 0, 0xFFFF);
 
       old_rumble = weak_strong * gain / 0xFFFF;
       return old_rumble;


### PR DESCRIPTION
## Description
Fixes the issue described in #1905 by ignoring absolute input events until we've received a valid touchport from the display capture code. This prevents us from scaling client dimensions by 0 and invoking `std::clamp()` with invalid parameters (min > max).

I also included a fix for a bug caught by GCC 14 where `std::clamp()`'s result was discarded.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed
Closes #1905 
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
