### PR TITLE
Linux: measure encoding time per frame (intended for AMD users)

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1274,7 +1274,11 @@ namespace video {
     auto &vps = session.vps;
 
     // send the frame to the encoder
+    auto start = std::chrono::steady_clock::now();
     auto ret = avcodec_send_frame(ctx.get(), frame);
+    auto end = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> elapsed = end - start;
+    BOOST_LOG(debug) << "Frame number, encoding time (ms): "sv << frame_nr << ", " << elapsed.count();
     if (ret < 0) {
       char err_str[AV_ERROR_MAX_STRING_SIZE] { 0 };
       BOOST_LOG(error) << "Could not send a frame for encoding: "sv << av_make_error_string(err_str, AV_ERROR_MAX_STRING_SIZE, ret);


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This commit adds detailed debug output measuring the exact time it takes to encode each video frame. It is intended to diagnose issues with AMD encoding in Linux (via ffmpeg and VA-API). Its usefulness for other encoders might be limited and the output is rather verbose. Thus it might not be adequate for merging as-is, but it would be **very helpful to have pre-built binaries available** for users that want to investigate the current situation and maybe even participate in reporting the issue(s) upstream.

Example output:
```
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 771, 3.10952                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 772, 2.95359                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 773, 3.1174                                                         
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 774, 3.0117                                                         
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 775, 5.73846                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 776, 5.64102                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 777, 5.68458                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 778, 5.64336                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 779, 5.79077                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 780, 3.03185                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 781, 3.35225                                                        
[2024:04:13:21:21:13]: Debug: Frame number, encoding time (ms): 782, 3.01634                                                        
```
A `.csv` file for easier analysis can be created using the following command:
```
grep "encoding time" .config/sunshine/sunshine.log | awk '{print $(NF-1)$NF}' > sunshine.csv
```

There are two reports/discussions about very similar, if not identical, problems with AMD under Linux:
https://github.com/LizardByte/Sunshine/discussions/2193 (RDNA2 cards)
The commit is obviously based on @kodemeister 's idea/code.
https://github.com/LizardByte/Sunshine/discussions/2348 (RDNA3 cards)

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
