### PR TITLE
ci: fix coverage ignore directories

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -500,8 +500,8 @@ jobs:
         run: |
           ${{ steps.python.outputs.python-path }} -m pip install gcovr
           ${{ steps.python.outputs.python-path }} -m gcovr -r .. \
-            --exclude ../tests/ \
-            --exclude ../third-party/ \
+            --exclude '.*tests/.*' \
+            --exclude '.*tests/.*' \
             --xml-pretty \
             -o coverage.xml
 
@@ -823,8 +823,8 @@ jobs:
           cd ${build_dir}
           ${{ steps.python.outputs.python-path }} -m pip install gcovr
           sudo ${{ steps.python.outputs.python-path }} -m gcovr -r ../${dir} \
-            --exclude ../${dir}/tests/ \
-            --exclude ../${dir}/third-party/ \
+            --exclude '.*${dir}/tests/.*' \
+            --exclude '.*${dir}/third-party/.*' \
             --gcov-object-directory $(pwd) \
             --verbose \
             --xml-pretty \
@@ -1063,8 +1063,8 @@ jobs:
         run: |
           ${{ steps.python-path.outputs.python-path }} -m pip install gcovr
           ${{ steps.python-path.outputs.python-path }} -m gcovr -r .. \
-            --exclude ../tests/ \
-            --exclude ../third-party/ \
+            --exclude '.*tests/.*' \
+            --exclude '.*tests/.*' \
             --xml-pretty \
             -o coverage.xml
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,7 @@ comment:
   layout: "diff, flags, files"
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
+
+ignore:
+  - "tests"
+  - "third-party"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Some fixes for excluding coverage directories as discovered in https://github.com/LizardByte/tray/pull/13


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
