### PR TITLE
AppImage: add needed VA-API libraries (Intel & AMD)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -390,7 +390,12 @@ jobs:
           gh release download --archive=tar.gz --repo=intel/libva
           tar xzf libva-*.tar.gz && rm libva-*.tar.gz
           cd libva-*
-          ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --enable-x11 --without-legacy
+          ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu \
+            --enable-drm \
+            --enable-x11 \
+            --enable-glx \
+            --enable-wayland \
+            --without-legacy # emgd, nvctrl, fglrx
           make -j $(nproc)
           sudo make install
           cd .. && rm -rf libva-*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -349,10 +349,11 @@ jobs:
             libopus-dev \
             libpulse-dev \
             libssl-dev \
-            libva-dev \
             libvdpau-dev \
             libwayland-dev \
             libx11-dev \
+            libx11-xcb-dev \
+            libxcb-dri3-dev \
             libxcb-shm0-dev \
             libxcb-xfixes0-dev \
             libxcb1-dev \
@@ -379,6 +380,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Build latest libva
+        timeout-minutes: 5
+        run: |
+          echo "nproc: $(nproc)"
+
+          git clone https://github.com/intel/libva.git
+          cd libva
+          ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --enable-x11 --without-legacy
+          make -j $(expr $(nproc) - 1)  # use all but one core
+          sudo make install
 
       - name: Build Linux
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -326,6 +326,7 @@ jobs:
           # allow libfuse2 for appimage on 22.04
           sudo add-apt-repository universe
 
+          # libx11-xcb-dev and libxcb-dri3-dev are required for building libva
           sudo apt-get install -y \
             build-essential \
             cmake \
@@ -382,15 +383,17 @@ jobs:
           python-version: '3.11'
 
       - name: Build latest libva
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 5
         run: |
-          echo "nproc: $(nproc)"
-
-          git clone https://github.com/intel/libva.git
-          cd libva
+          gh release download --archive=tar.gz --repo=intel/libva
+          tar xzf libva-*.tar.gz && rm libva-*.tar.gz
+          cd libva-*
           ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --enable-x11 --without-legacy
-          make -j $(expr $(nproc) - 1)  # use all but one core
+          make -j $(nproc)
           sudo make install
+          cd .. && rm -rf libva-*
 
       - name: Build Linux
         env:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Currently VA-API encoding may/will fail when the AppImage is used. This seems to be because of a mismatch between the bundled `libva.so` and the system's `/usr/lib/*/dri/*_drv_video.so` driver libraries. ~~Since this is a rather important functionality the necessary libraries are now bundled in the AppImage itself in a relatively recent version.~~ This PR changes the AppImage build process in order to include a recent `libva` version. This should fix VA-API issues for Intel and AMD based systems. ~~I left out `nouveau_drv_video.so` since I'm somewhat skeptical of its encoding capabilities. (Please tell me if I'm wrong...)~~

I tested this PR on an older Intel-based laptop (Ubuntu 22.04, i965 driver) / on my main AMDGPU-based desktop. It's working fine for me.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
See #2409 (but does not fix it since Flatpak is untouched)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
