### PR TITLE
ci: fix codeql prebuild steps for unix OSes

### DIFF
--- a/.codeql-prebuild-cpp-Linux.sh
+++ b/.codeql-prebuild-cpp-Linux.sh
@@ -1,4 +1,5 @@
 # install dependencies for C++ analysis
+set -e
 
 sudo apt-get update -y
 sudo apt-get install -y \
@@ -59,7 +60,7 @@ sudo rm /root/cuda.run
 mkdir -p build
 cd build || exit 1
 cmake -G "Unix Makefiles" ..
-mingw32-make -j"$(nproc)"
+make -j"$(nproc)"
 
 # skip autobuild
 echo "skip_autobuild=true" >> "$GITHUB_OUTPUT"

--- a/.codeql-prebuild-cpp-Windows.sh
+++ b/.codeql-prebuild-cpp-Windows.sh
@@ -1,4 +1,5 @@
 # install dependencies for C++ analysis
+set -e
 
 # update pacman
 pacman --noconfirm -Suy
@@ -6,7 +7,6 @@ pacman --noconfirm -Suy
 # install dependencies
 pacman --noconfirm -S \
   base-devel \
-  cmake \
   diffutils \
   gcc \
   git \

--- a/.codeql-prebuild-cpp-macOS.sh
+++ b/.codeql-prebuild-cpp-macOS.sh
@@ -1,4 +1,5 @@
 # install dependencies for C++ analysis
+set -e
 
 # install dependencies
 brew install \
@@ -13,7 +14,7 @@ brew install \
 mkdir -p build
 cd build || exit 1
 cmake -G "Unix Makefiles" ..
-mingw32-make -j"$(sysctl -n hw.logicalcpu)"
+make -j"$(sysctl -n hw.logicalcpu)"
 
 # skip autobuild
 echo "skip_autobuild=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use the correct make command for CodeQL
- Make sure prebuild fails, as needed


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
