### PR TITLE
ci: skip coverage upload if not in LizardByte org

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -507,7 +507,10 @@ jobs:
 
       - name: Upload coverage
         # any except canceled or skipped
-        if: always() && (steps.test_report.outcome == 'success')
+        if: >-
+          always() &&
+          (steps.test_report.outcome == 'success') &&
+          startsWith(github.repository, 'LizardByte/')
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
@@ -832,7 +835,10 @@ jobs:
 
       - name: Upload coverage
         # any except canceled or skipped
-        if: always() && (steps.test_report.outcome == 'success')
+        if: >-
+          always() &&
+          (steps.test_report.outcome == 'success') &&
+          startsWith(github.repository, 'LizardByte/')
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false  # todo: re-enable this when action is fixed
@@ -1070,7 +1076,10 @@ jobs:
 
       - name: Upload coverage
         # any except canceled or skipped
-        if: always() && (steps.test_report.outcome == 'success')
+        if: >-
+          always() &&
+          (steps.test_report.outcome == 'success') &&
+          startsWith(github.repository, 'LizardByte/')
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Skip coverage upload if not in LizardByte org, allowing contributors to run CI in their own fork more easily.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
