### PR TITLE
fix: make version update check more robust

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -211,6 +211,7 @@ jobs:
           then
             echo "This is a PUSH event"
             branch=${{ github.ref_name }}
+            build_version=${{ needs.check_changelog.outputs.next_version }}
             commit=${{ github.sha }}
             clone_url=${{ github.event.repository.clone_url }}
           else
@@ -227,6 +228,7 @@ jobs:
 
           cd build
           cmake -DGITHUB_CLONE_URL=${clone_url} \
+            -DBUILD_VERSION=${build_version} \
             -DGITHUB_BRANCH=${branch} \
             -DGITHUB_COMMIT=${commit} \
             -DSUNSHINE_CONFIGURE_FLATPAK_MAN=ON \
@@ -377,7 +379,7 @@ jobs:
       - name: Build Linux
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
-          BUILD_VERSION: ${{ needs.check_changelog.outputs.next_version_bare }}
+          BUILD_VERSION: ${{ needs.check_changelog.outputs.next_version }}
           COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         timeout-minutes: 5
         run: |
@@ -565,13 +567,16 @@ jobs:
           if [ -z "$branch" ]
           then
             echo "This is a PUSH event"
+            build_version=${{ needs.check_changelog.outputs.next_version }}
             clone_url=${{ github.event.repository.clone_url }}
             branch="${{ github.ref_name }}"
+            commit=${{ github.sha }}
             default_branch="${{ github.event.repository.default_branch }}"
           else
             echo "This is a PR event"
             clone_url=${{ github.event.pull_request.head.repo.clone_url }}
             branch="${{ github.event.pull_request.head.ref }}"
+            commit=${{ github.event.pull_request.head.sha }}
             default_branch="${{ github.event.pull_request.head.repo.default_branch }}"
           fi
           echo "Branch: ${branch}"
@@ -580,7 +585,9 @@ jobs:
           mkdir build
           cd build
           cmake \
+            -DBUILD_VERSION="${build_version}" \
             -DGITHUB_BRANCH="${branch}" \
+            -DGITHUB_COMMIT="${commit}" \
             -DGITHUB_CLONE_URL="${clone_url}" \
             -DGITHUB_DEFAULT_BRANCH="${default_branch}" \
             -DSUNSHINE_CONFIGURE_HOMEBREW=ON \
@@ -678,6 +685,8 @@ jobs:
           if [ -z "$branch" ]
           then
             echo "This is a PUSH event"
+            branch="${{ github.ref_name }}"
+            build_version=${{ needs.check_changelog.outputs.next_version }}
             commit=${{ github.sha }}
             clone_url=${{ github.event.repository.clone_url }}
           else
@@ -691,6 +700,8 @@ jobs:
           mkdir build
           cd build
           cmake \
+            -DBUILD_VERSION=${build_version} \
+            -DGITHUB_BRANCH=${branch} \
             -DGITHUB_COMMIT=${commit} \
             -DGITHUB_CLONE_URL=${clone_url} \
             -DSUNSHINE_CONFIGURE_PORTFILE=ON \
@@ -1024,7 +1035,7 @@ jobs:
         shell: msys2 {0}
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
-          BUILD_VERSION: ${{ needs.check_changelog.outputs.next_version_bare }}
+          BUILD_VERSION: ${{ needs.check_changelog.outputs.next_version }}
           COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           mkdir build

--- a/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
+++ b/packaging/linux/flatpak/dev.lizardbyte.sunshine.yml
@@ -329,6 +329,9 @@ modules:
       build-args:
         - --share=network
       env:
+        BUILD_VERSION: "@BUILD_VERSION@"
+        BRANCH: "@GITHUB_BRANCH@"
+        COMMIT: "@GITHUB_COMMIT@"
         npm_config_nodedir: /usr/lib/sdk/node18
         NPM_CONFIG_LOGLEVEL: info
     config-opts:

--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -51,6 +51,10 @@ configure.args           -DBUILD_WERROR=ON \
                          -DCMAKE_INSTALL_PREFIX=${prefix} \
                          -DSUNSHINE_ASSETS_DIR=etc/sunshine/assets
 
+configure.env-append     BRANCH=@GITHUB_BRANCH@
+configure.env-append     BUILD_VERSION=@BUILD_VERSION@
+configure.env-append     COMMIT=@GITHUB_COMMIT@
+
 startupitem.create       yes
 startupitem.executable   "${prefix}/bin/{$name}"
 startupitem.location     LaunchDaemons

--- a/packaging/macos/sunshine.rb
+++ b/packaging/macos/sunshine.rb
@@ -19,6 +19,10 @@ class @PROJECT_NAME@ < Formula
   depends_on "opus"
 
   def install
+    ENV["BRANCH"] = "@GITHUB_BRANCH@"
+    ENV["BUILD_VERSION"] = "@BUILD_VERSION@"
+    ENV["COMMIT"] = "@GITHUB_COMMIT@"
+
     args = %W[
       -DBUILD_WERROR=ON
       -DCMAKE_INSTALL_PREFIX=#{prefix}

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -112,10 +112,16 @@
       stableBuildAvailable() {
         // If we can't get versions, return false
         if (!this.githubVersion || !this.version) return false;
+
         // Get the GitHub version tag
-        let v = this.githubVersion.name;
+        let v_github = this.githubVersion.name;
         // If the version starts with a v, remove it
-        if (v.indexOf("v") === 0) v = v.substring(1);
+        if (v_github.indexOf("v") === 0) v_github = v_github.substring(1);
+
+        // Get the current version
+        let v_this = this.version;
+        // If the version starts with a v, remove it
+        if (v_this.indexOf("v") === 0) v_this = v_this.substring(1);
 
         // if nightly or dirty, we do an additional check to make sure it's an actual upgrade.
         if (this.buildVersionIsNightly || this.buildVersionIsDirty) {
@@ -124,7 +130,7 @@
         }
 
         // return true if the version is different, otherwise false
-        return v !== this.version;
+        return v_github !== v_this;
       },
       nightlyBuildAvailable() {
         // Verify nightly data is available and the build version is not stable


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use BUILD_VERSION for flatpak, Portfile, and homebrew builds
- Use version with `v` prefix for all builds
- More robust version comparison in web ui


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #2406 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
