### PR TITLE
feat: add outgoing bandwidth to network config

### DIFF
--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -883,6 +883,22 @@ keybindings
 
       ping_timeout = 10000
 
+`outgoing_bandwidth <https://localhost:47990/config/#outgoing_bandwidth>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   Bandwidth limitation in bytes/second to manually deal with local network throttling when the host has a greater data rate than the stream.
+   Note: for unlimited bandwidth use 0
+   Example: 1Gbps = 125000000 MBps
+
+**Default**
+   ``0``
+
+**Example**
+   .. code-block:: text
+
+      outgoing_bandwidth = 0
+
 `Config Files <https://localhost:47990/config/#files>`__
 --------------------------------------------------------
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -390,6 +390,7 @@ namespace config {
 
     APPS_JSON_PATH,
 
+    0,  // outgoing_bandwidth
     20,  // fecPercentage
     1,  // channels
 
@@ -1052,6 +1053,9 @@ namespace config {
     int_between_f(vars, "wan_encryption_mode", stream.wan_encryption_mode, { 0, 2 });
 
     path_f(vars, "file_apps", stream.file_apps);
+
+    int_between_f(vars, "outgoing_bandwidth", to, { 0, std::numeric_limits<int>::max() });
+
     int_between_f(vars, "fec_percentage", stream.fec_percentage, { 1, 255 });
 
     map_int_int_f(vars, "keybindings"s, input.keybindings);

--- a/src/config.h
+++ b/src/config.h
@@ -91,6 +91,10 @@ namespace config {
 
     std::string file_apps;
 
+    // Bandwidth limitation in bytes/second to manually deal with network throttling
+    // 0 mean unlimited
+    std::uint32_t outgoing_bandwidth;
+
     int fec_percentage;
 
     // max unique instances of video and audio streams

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -196,7 +196,7 @@ namespace net {
   }
 
   host_t
-  host_create(af_e af, ENetAddress &addr, std::size_t peers, std::uint16_t port) {
+  host_create(af_e af, ENetAddress &addr, std::size_t peers, std::uint16_t port, std::uint32_t outgoing_bandwidth) {
     static std::once_flag enet_init_flag;
     std::call_once(enet_init_flag, []() {
       enet_initialize();
@@ -206,7 +206,7 @@ namespace net {
     enet_address_set_host(&addr, any_addr.data());
     enet_address_set_port(&addr, port);
 
-    auto host = host_t { enet_host_create(af == IPV4 ? AF_INET : AF_INET6, &addr, peers, 0, 0, 0) };
+    auto host = host_t { enet_host_create(af == IPV4 ? AF_INET : AF_INET6, &addr, peers, 0, 0, outgoing_bandwidth) };
 
     // Enable opportunistic QoS tagging (automatically disables if the network appears to drop tagged packets)
     enet_socket_set_option(host->socket, ENET_SOCKOPT_QOS, 1);

--- a/src/network.h
+++ b/src/network.h
@@ -44,7 +44,7 @@ namespace net {
   from_address(const std::string_view &view);
 
   host_t
-  host_create(af_e af, ENetAddress &addr, std::size_t peers, std::uint16_t port);
+  host_create(af_e af, ENetAddress &addr, std::size_t peers, std::uint16_t port, std::uint32_t outgoing_bandwidth);
 
   /**
    * @brief Returns the `af_e` enum value for the `address_family` config option value.

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -268,7 +268,7 @@ namespace stream {
   public:
     int
     bind(net::af_e address_family, std::uint16_t port) {
-      _host = net::host_create(address_family, _addr, config::stream.channels, port);
+      _host = net::host_create(address_family, _addr, config::stream.channels, port, config::stream.outgoing_bandwidth);
 
       return !(bool) _host;
     }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -604,6 +604,13 @@
           <div class="form-text">{{ $t('config.ping_timeout_desc') }}</div>
         </div>
 
+        <!-- Outgoing Bandwidth -->
+        <div class="mb-3">
+          <label for="outgoing_bandwidth" class="form-label">{{ $t('config.outgoing_bandwidth') }}</label>
+          <input type="text" class="form-control" id="outgoing_bandwidth" placeholder="0" v-model="config.outgoing_bandwidth" />
+          <div class="form-text">{{ $t('config.outgoing_bandwidth_desc') }}</div>
+        </div>
+
       </div>
 
       <!-- Files Tab -->
@@ -1146,6 +1153,7 @@
               "lan_encryption_mode": 0,
               "wan_encryption_mode": 1,
               "ping_timeout": 10000,
+              "outgoing_bandwidth":0,
             },
           },
           {

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -243,6 +243,8 @@
     "origin_web_ui_allowed_lan": "Only those in LAN may access Web UI",
     "origin_web_ui_allowed_pc": "Only localhost may access Web UI",
     "origin_web_ui_allowed_wan": "Anyone may access Web UI",
+    "outgoing_bandwidth": "Outgoing Bandwidth",
+    "outgoing_bandwidth_desc": "Bandwidth limitation in bytes/second to manually deal with local network throttling when the host has a greater data rate than the stream. Note: for unlimited bandwidth use 0",
     "output_name_desc_unix": "During Sunshine startup, you should see the list of detected displays. Note: You need to use the id value inside the parenthesis.",
     "output_name_desc_win": "Manually specify a display to use for capture. If unset, the primary display is captured. Note: If you specified a GPU above, this display must be connected to that GPU. The appropriate values can be found using the following command:",
     "output_name_unix": "Display number",


### PR DESCRIPTION
## Description
There is a problem with bandwidth when the host are using a greater connection data rate than the stream machine.
In my case it's my computer(the host) which is using a 2.5Gbps ethernet connection to my switch and my Android box(the stream machine) which has a 1Gbps ethernet connection.
The current usage of ENet in Sunshine don't allow a good handle of that case, I'm not even sure that could be handle correctly easily. I'm definitely not a Network expert but that seems to be difficult topic to automatically handle this behavior.
But manually we could set a limit of outgoing bandwidth which should resolve the issue when Sunshine is sending to much data and we loose most of it.

### Screenshot
TODO

### Issues Fixed or Closed
- Resolves #1074 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
