### PR TITLE
fix(macos): fix broken streaming on MacOS

### DIFF
--- a/src/platform/macos/av_img_t.h
+++ b/src/platform/macos/av_img_t.h
@@ -10,43 +10,10 @@
 #include <CoreVideo/CoreVideo.h>
 
 namespace platf {
-  struct av_sample_buf_t {
-    explicit av_sample_buf_t(CMSampleBufferRef buf):
-        buf((CMSampleBufferRef) CFRetain(buf)) {}
-
-    ~av_sample_buf_t() {
-      CFRelease(buf);
-    }
-
-    CMSampleBufferRef buf;
-  };
-
-  struct av_pixel_buf_t {
-    explicit av_pixel_buf_t(CVPixelBufferRef buf):
-        buf((CVPixelBufferRef) CFRetain(buf)),
-        locked(false) {}
-
-    [[nodiscard]] uint8_t *
-    lock() const {
-      if (!locked) {
-        CVPixelBufferLockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
-      }
-      return (uint8_t *) CVPixelBufferGetBaseAddress(buf);
-    }
-
-    ~av_pixel_buf_t() {
-      if (locked) {
-        CVPixelBufferUnlockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
-      }
-      CFRelease(buf);
-    }
-
-    CVPixelBufferRef buf;
-    bool locked;
-  };
-
   struct av_img_t: public img_t {
-    std::shared_ptr<av_sample_buf_t> sample_buffer;
-    std::shared_ptr<av_pixel_buf_t> pixel_buffer;
+    CVPixelBufferRef pixel_buffer = nullptr;
+    CMSampleBufferRef sample_buffer = nullptr;
+
+    ~av_img_t();
   };
 }  // namespace platf

--- a/src/platform/macos/av_img_t.h
+++ b/src/platform/macos/av_img_t.h
@@ -10,10 +10,55 @@
 #include <CoreVideo/CoreVideo.h>
 
 namespace platf {
-  struct av_img_t: public img_t {
-    CVPixelBufferRef pixel_buffer = nullptr;
-    CMSampleBufferRef sample_buffer = nullptr;
+  struct av_sample_buf_t {
+    CMSampleBufferRef buf;
 
-    ~av_img_t();
+    explicit av_sample_buf_t(CMSampleBufferRef buf) : buf((CMSampleBufferRef) CFRetain(buf)) { }
+
+    ~av_sample_buf_t() {
+      if (buf != nullptr) {
+        CFRelease(buf);
+      }
+    }
+  };
+
+  struct av_pixel_buf_t {
+    CVPixelBufferRef buf;
+
+    // Constructor
+    explicit av_pixel_buf_t(CMSampleBufferRef sb) : buf(
+      CMSampleBufferGetImageBuffer(sb)
+    ) {
+      CVPixelBufferLockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
+    }
+
+    [[nodiscard]] uint8_t *
+    data() const {
+      return static_cast<uint8_t *>(CVPixelBufferGetBaseAddress(buf));
+    }
+
+    // Destructor
+    ~av_pixel_buf_t() {
+      if (buf != nullptr) {
+        CVPixelBufferUnlockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
+      }
+    }
+  };
+
+  struct av_img_t: img_t {
+    std::shared_ptr<av_sample_buf_t> sample_buffer;
+    std::shared_ptr<av_pixel_buf_t> pixel_buffer;
+  };
+
+  struct temp_retain_av_img_t {
+    std::shared_ptr<av_sample_buf_t> sample_buffer;
+    std::shared_ptr<av_pixel_buf_t> pixel_buffer;
+    uint8_t * data;
+
+    temp_retain_av_img_t(
+      std::shared_ptr<av_sample_buf_t> sb,
+      std::shared_ptr<av_pixel_buf_t> pb,
+      uint8_t * dt
+    ) : sample_buffer(std::move(sb)), pixel_buffer(std::move(pb)), data(dt) { }
   };
 }  // namespace platf

--- a/src/platform/macos/av_img_t.h
+++ b/src/platform/macos/av_img_t.h
@@ -54,7 +54,7 @@ namespace platf {
   struct temp_retain_av_img_t {
     std::shared_ptr<av_sample_buf_t> sample_buffer;
     std::shared_ptr<av_pixel_buf_t> pixel_buffer;
-    uint8_t * data;
+    uint8_t *data;
 
     temp_retain_av_img_t(
       std::shared_ptr<av_sample_buf_t> sb,

--- a/src/platform/macos/av_img_t.h
+++ b/src/platform/macos/av_img_t.h
@@ -13,7 +13,8 @@ namespace platf {
   struct av_sample_buf_t {
     CMSampleBufferRef buf;
 
-    explicit av_sample_buf_t(CMSampleBufferRef buf) : buf((CMSampleBufferRef) CFRetain(buf)) { }
+    explicit av_sample_buf_t(CMSampleBufferRef buf):
+        buf((CMSampleBufferRef) CFRetain(buf)) {}
 
     ~av_sample_buf_t() {
       if (buf != nullptr) {
@@ -26,9 +27,9 @@ namespace platf {
     CVPixelBufferRef buf;
 
     // Constructor
-    explicit av_pixel_buf_t(CMSampleBufferRef sb) : buf(
-      CMSampleBufferGetImageBuffer(sb)
-    ) {
+    explicit av_pixel_buf_t(CMSampleBufferRef sb):
+        buf(
+          CMSampleBufferGetImageBuffer(sb)) {
       CVPixelBufferLockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
     }
 
@@ -58,7 +59,8 @@ namespace platf {
     temp_retain_av_img_t(
       std::shared_ptr<av_sample_buf_t> sb,
       std::shared_ptr<av_pixel_buf_t> pb,
-      uint8_t * dt
-    ) : sample_buffer(std::move(sb)), pixel_buffer(std::move(pb)), data(dt) { }
+      uint8_t *dt):
+        sample_buffer(std::move(sb)),
+        pixel_buffer(std::move(pb)), data(dt) {}
   };
 }  // namespace platf

--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -20,18 +20,6 @@ namespace fs = std::filesystem;
 namespace platf {
   using namespace std::literals;
 
-  av_img_t::~av_img_t() {
-    if (pixel_buffer != NULL) {
-      CVPixelBufferUnlockBaseAddress(pixel_buffer, 0);
-    }
-
-    if (sample_buffer != nullptr) {
-      CFRelease(sample_buffer);
-    }
-
-    data = nullptr;
-  }
-
   struct av_display_t: public display_t {
     AVVideo *av_capture {};
     CGDirectDisplayID display_id {};
@@ -43,10 +31,8 @@ namespace platf {
     capture_e
     capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
       auto signal = [av_capture capture:^(CMSampleBufferRef sampleBuffer) {
-        CFRetain(sampleBuffer);
-
-        CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
-        CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+        auto new_sample_buffer = std::make_shared<av_sample_buf_t>(sampleBuffer);
+        auto new_pixel_buffer = std::make_shared<av_pixel_buf_t>(new_sample_buffer->buf);
 
         std::shared_ptr<img_t> img_out;
         if (!pull_free_image_cb(img_out)) {
@@ -56,20 +42,22 @@ namespace platf {
         }
         auto av_img = std::static_pointer_cast<av_img_t>(img_out);
 
-        if (av_img->pixel_buffer != nullptr)
-          CVPixelBufferUnlockBaseAddress(av_img->pixel_buffer, 0);
+        auto old_data_retainer = std::make_shared<temp_retain_av_img_t>(
+            av_img->sample_buffer,
+            av_img->pixel_buffer,
+            img_out->data
+        );
 
-        if (av_img->sample_buffer != nullptr)
-          CFRelease(av_img->sample_buffer);
+        av_img->sample_buffer = new_sample_buffer;
+        av_img->pixel_buffer = new_pixel_buffer;
+        img_out->data = new_pixel_buffer->data();
 
-        av_img->sample_buffer = sampleBuffer;
-        av_img->pixel_buffer = pixelBuffer;
-        img_out->data = (uint8_t *) CVPixelBufferGetBaseAddress(pixelBuffer);
-
-        img_out->width = (int) CVPixelBufferGetWidth(pixelBuffer);
-        img_out->height = (int) CVPixelBufferGetHeight(pixelBuffer);
-        img_out->row_pitch = (int) CVPixelBufferGetBytesPerRow(pixelBuffer);
+        img_out->width = (int) CVPixelBufferGetWidth(new_pixel_buffer->buf);
+        img_out->height = (int) CVPixelBufferGetHeight(new_pixel_buffer->buf);
+        img_out->row_pitch = (int) CVPixelBufferGetBytesPerRow(new_pixel_buffer->buf);
         img_out->pixel_pitch = img_out->row_pitch / img_out->width;
+
+        old_data_retainer = nullptr;
 
         if (!push_captured_image_cb(std::move(img_out), true)) {
           // got interrupt signal
@@ -114,29 +102,27 @@ namespace platf {
     int
     dummy_img(img_t *img) override {
       auto signal = [av_capture capture:^(CMSampleBufferRef sampleBuffer) {
+        auto new_sample_buffer = std::make_shared<av_sample_buf_t>(sampleBuffer);
+        auto new_pixel_buffer = std::make_shared<av_pixel_buf_t>(new_sample_buffer->buf);
+
         auto av_img = (av_img_t *) img;
 
-        CFRetain(sampleBuffer);
+        auto old_data_retainer = std::make_shared<temp_retain_av_img_t>(
+            av_img->sample_buffer,
+            av_img->pixel_buffer,
+            img->data
+        );
 
-        CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
-        CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+        av_img->sample_buffer = new_sample_buffer;
+        av_img->pixel_buffer = new_pixel_buffer;
+        img->data = new_pixel_buffer->data();
 
-        // XXX: next_img->img should be moved to a smart pointer with
-        // the CFRelease as custom deallocator
-        if (av_img->pixel_buffer != nullptr)
-          CVPixelBufferUnlockBaseAddress(((av_img_t *) img)->pixel_buffer, 0);
-
-        if (av_img->sample_buffer != nullptr)
-          CFRelease(av_img->sample_buffer);
-
-        av_img->sample_buffer = sampleBuffer;
-        av_img->pixel_buffer = pixelBuffer;
-        img->data = (uint8_t *) CVPixelBufferGetBaseAddress(pixelBuffer);
-
-        img->width = (int) CVPixelBufferGetWidth(pixelBuffer);
-        img->height = (int) CVPixelBufferGetHeight(pixelBuffer);
-        img->row_pitch = (int) CVPixelBufferGetBytesPerRow(pixelBuffer);
+        img->width = (int) CVPixelBufferGetWidth(new_pixel_buffer->buf);
+        img->height = (int) CVPixelBufferGetHeight(new_pixel_buffer->buf);
+        img->row_pitch = (int) CVPixelBufferGetBytesPerRow(new_pixel_buffer->buf);
         img->pixel_pitch = img->row_pitch / img->width;
+
+        old_data_retainer = nullptr;
 
         // returning false here stops capture backend
         return false;

--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -43,10 +43,9 @@ namespace platf {
         auto av_img = std::static_pointer_cast<av_img_t>(img_out);
 
         auto old_data_retainer = std::make_shared<temp_retain_av_img_t>(
-            av_img->sample_buffer,
-            av_img->pixel_buffer,
-            img_out->data
-        );
+          av_img->sample_buffer,
+          av_img->pixel_buffer,
+          img_out->data);
 
         av_img->sample_buffer = new_sample_buffer;
         av_img->pixel_buffer = new_pixel_buffer;
@@ -108,10 +107,9 @@ namespace platf {
         auto av_img = (av_img_t *) img;
 
         auto old_data_retainer = std::make_shared<temp_retain_av_img_t>(
-            av_img->sample_buffer,
-            av_img->pixel_buffer,
-            img->data
-        );
+          av_img->sample_buffer,
+          av_img->pixel_buffer,
+          img->data);
 
         av_img->sample_buffer = new_sample_buffer;
         av_img->pixel_buffer = new_pixel_buffer;

--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -66,7 +66,6 @@ namespace platf {
         av_img->pixel_buffer = pixelBuffer;
         img_out->data = (uint8_t *) CVPixelBufferGetBaseAddress(pixelBuffer);
 
-
         img_out->width = (int) CVPixelBufferGetWidth(pixelBuffer);
         img_out->height = (int) CVPixelBufferGetHeight(pixelBuffer);
         img_out->row_pitch = (int) CVPixelBufferGetBytesPerRow(pixelBuffer);
@@ -133,7 +132,6 @@ namespace platf {
         av_img->sample_buffer = sampleBuffer;
         av_img->pixel_buffer = pixelBuffer;
         img->data = (uint8_t *) CVPixelBufferGetBaseAddress(pixelBuffer);
-
 
         img->width = (int) CVPixelBufferGetWidth(pixelBuffer);
         img->height = (int) CVPixelBufferGetHeight(pixelBuffer);

--- a/src/platform/macos/nv12_zero_device.cpp
+++ b/src/platform/macos/nv12_zero_device.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "src/platform/macos/nv12_zero_device.h"
+#include "src/platform/macos/av_img_t.h"
 
 #include "src/video.h"
 
@@ -24,6 +25,8 @@ namespace platf {
     CVPixelBufferRelease((CVPixelBufferRef) data);
   }
 
+  util::safe_ptr<AVFrame, free_frame> av_frame;
+
   int
   nv12_zero_device::convert(platf::img_t &img) {
     auto *av_img = (av_img_t *) &img;
@@ -36,10 +39,10 @@ namespace platf {
     //
     // The presence of the AVBufferRef allows FFmpeg to simply add a reference to the buffer
     // rather than having to perform a deep copy of the data buffers in avcodec_send_frame().
-    av_frame->buf[0] = av_buffer_create((uint8_t *) CFRetain(av_img->pixel_buffer->buf), 0, free_buffer, nullptr, 0);
+    av_frame->buf[0] = av_buffer_create((uint8_t *) CFRetain(av_img->pixel_buffer), 0, free_buffer, nullptr, 0);
 
     // Place a CVPixelBufferRef at data[3] as required by AV_PIX_FMT_VIDEOTOOLBOX
-    av_frame->data[3] = (uint8_t *) av_img->pixel_buffer->buf;
+    av_frame->data[3] = (uint8_t *) av_img->pixel_buffer;
 
     return 0;
   }

--- a/src/platform/macos/nv12_zero_device.cpp
+++ b/src/platform/macos/nv12_zero_device.cpp
@@ -4,8 +4,8 @@
  */
 #include <utility>
 
-#include "src/platform/macos/nv12_zero_device.h"
 #include "src/platform/macos/av_img_t.h"
+#include "src/platform/macos/nv12_zero_device.h"
 
 #include "src/video.h"
 

--- a/src/platform/macos/nv12_zero_device.cpp
+++ b/src/platform/macos/nv12_zero_device.cpp
@@ -39,10 +39,10 @@ namespace platf {
     //
     // The presence of the AVBufferRef allows FFmpeg to simply add a reference to the buffer
     // rather than having to perform a deep copy of the data buffers in avcodec_send_frame().
-    av_frame->buf[0] = av_buffer_create((uint8_t *) CFRetain(av_img->pixel_buffer), 0, free_buffer, nullptr, 0);
+    av_frame->buf[0] = av_buffer_create((uint8_t *) CFRetain(av_img->pixel_buffer->buf), 0, free_buffer, nullptr, 0);
 
     // Place a CVPixelBufferRef at data[3] as required by AV_PIX_FMT_VIDEOTOOLBOX
-    av_frame->data[3] = (uint8_t *) av_img->pixel_buffer;
+    av_frame->data[3] = (uint8_t *) av_img->pixel_buffer->buf;
 
     return 0;
   }

--- a/src/platform/macos/nv12_zero_device.h
+++ b/src/platform/macos/nv12_zero_device.h
@@ -5,13 +5,8 @@
 #pragma once
 
 #include "src/platform/common.h"
-#include "src/platform/macos/av_img_t.h"
-
-struct AVFrame;
 
 namespace platf {
-  void
-  free_frame(AVFrame *frame);
 
   class nv12_zero_device: public avcodec_encode_device_t {
     // display holds a pointer to an av_video object. Since the namespaces of AVFoundation
@@ -32,9 +27,6 @@ namespace platf {
     convert(img_t &img) override;
     int
     set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) override;
-
-  private:
-    util::safe_ptr<AVFrame, free_frame> av_frame;
   };
 
 }  // namespace platf

--- a/src/platform/macos/nv12_zero_device.h
+++ b/src/platform/macos/nv12_zero_device.h
@@ -6,7 +6,11 @@
 
 #include "src/platform/common.h"
 
+struct AVFrame;
+
 namespace platf {
+  void
+  free_frame(AVFrame *frame);
 
   class nv12_zero_device: public avcodec_encode_device_t {
     // display holds a pointer to an av_video object. Since the namespaces of AVFoundation
@@ -27,6 +31,9 @@ namespace platf {
     convert(img_t &img) override;
     int
     set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx) override;
+
+  private:
+    util::safe_ptr<AVFrame, free_frame> av_frame;
   };
 
 }  // namespace platf

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1451,7 +1451,17 @@ namespace video {
         }
       }
 
-      ctx->flags |= (AV_CODEC_FLAG_CLOSED_GOP | AV_CODEC_FLAG_LOW_DELAY);
+      // VideoToolbox Codecs, both h264 and hvec, don't support FLAG_LOW_DELAY
+      // if FLAG_LOW_DELAY is set, avcodec_open2 fails.
+      // Also, we forcefully reset the flags to avoid clash on reuse of AVCodecContext
+      if (strstr(codec->name, "videotoolbox") != nullptr) {
+        ctx->flags = 0;
+        ctx->flags |= AV_CODEC_FLAG_CLOSED_GOP;
+      } else {
+        ctx->flags = 0;
+        ctx->flags |= AV_CODEC_FLAG_CLOSED_GOP | AV_CODEC_FLAG_LOW_DELAY;
+      }
+
       ctx->flags2 |= AV_CODEC_FLAG2_FAST;
 
       auto avcodec_colorspace = avcodec_colorspace_from_sunshine_colorspace(colorspace);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1631,8 +1631,8 @@ namespace video {
 
         if (!video_format.fallback_options.empty() && retries == 0) {
           BOOST_LOG(info)
-            << "Retrying with fallback configuration options for ["sv << video_format.name << "] after error: "sv
-            << av_make_error_string(err_str, AV_ERROR_MAX_STRING_SIZE, status);
+          << "Retrying without AV_CODEC_FLAG_LOW_DELAY for ["sv << video_format.name << "] after error: "sv
+          << av_make_error_string(first_err, AV_ERROR_MAX_STRING_SIZE, firt_status);
 
           continue;
         }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1612,8 +1612,8 @@ namespace video {
         char first_err[AV_ERROR_MAX_STRING_SIZE] { 0 };
 
         BOOST_LOG(info)
-            << "Retrying without AV_CODEC_FLAG_LOW_DELAY for ["sv << video_format.name << "] after error: "sv
-            << av_make_error_string(first_err, AV_ERROR_MAX_STRING_SIZE, firt_status);
+          << "Retrying without AV_CODEC_FLAG_LOW_DELAY for ["sv << video_format.name << "] after error: "sv
+          << av_make_error_string(first_err, AV_ERROR_MAX_STRING_SIZE, firt_status);
 
         // On some devices, both h264 and hvec codecs, don't support FLAG_LOW_DELAY
         // if FLAG_LOW_DELAY is set, avcodec_open2 fails. So we retry all codecs once without this flag.
@@ -1631,8 +1631,8 @@ namespace video {
 
         if (!video_format.fallback_options.empty() && retries == 0) {
           BOOST_LOG(info)
-          << "Retrying without AV_CODEC_FLAG_LOW_DELAY for ["sv << video_format.name << "] after error: "sv
-          << av_make_error_string(first_err, AV_ERROR_MAX_STRING_SIZE, firt_status);
+            << "Retrying with fallback configuration options for ["sv << video_format.name << "] after error: "sv
+            << av_make_error_string(err_str, AV_ERROR_MAX_STRING_SIZE, status);
 
           continue;
         }


### PR DESCRIPTION
## Description
I have a MacOS 14.4 running with a AMD RX 570, and noticed the mentioned issues, so after discovering version 0.19.1 was working (thanks to @VasylBaran), I decided to try narrowing down the issue.

#### Solution
~~Partially reverts `e535706a09f1849d2799fd72e889e4d7182f7fe5`, this commit changes `av_img_t` and how it retains/release the frame buffers, which breaks something with how the frame is available to the encoder when needed and creates the mentioned issues.~~

~~If someone could help me out fixing `av_img_t` without reverting the structure, I would gladly improve this solution. Or if you have even another solution, I can pull and run here on my hardware.~~

Fixes `av_img_t` usage and related structs, while retaining it until the next `av_img_t` is correctly configured. This slightly changes how it retains/release the frame buffers, allowing the frame to be available to the encoder when needed and avoids the mentioned issues.

Quoting my discovery journey from [#2272](https://github.com/LizardByte/Sunshine/issues/2272#issuecomment-2085248789):

> First it was in commit `036aa2e470cf72e63f036b6b4ec23446a4fdf140`, it freed the frame too soon in `video.cpp:1735`, so the encoder failed, then `eed27d3` broken macOS for a while. It then was fixed in `a29d2e11ea4b46590dab0ea97586bbc5152a8c7a`, which worked if I reverted `036aa2e` changes after line 1735, but got broken again in the next commit... After poking around a bit, found out that now the culprit was mostly `e535706a09f1849d2799fd72e889e4d7182f7fe5`, this commit changes `av_img_t` and how it retains/release the frame buffers, which again, breaks something with how the frame is available to the encoder when needed.
> 
> So after trying to fix the retain/release cycle of this change without success, I decided to just revert the necessary changes, taking care to not remove newer unrelated changes, and it's now working for me even with the `nightly` branch. 



### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed
- Fixes #2272
- Fixes #2347

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
