### PR TITLE
feat(ui): list available displays with `select`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1036,7 +1036,6 @@ jobs:
             mingw-w64-x86_64-curl
             mingw-w64-x86_64-graphviz
             mingw-w64-x86_64-miniupnpc
-            mingw-w64-x86_64-nlohmann-json
             mingw-w64-x86_64-nodejs
             mingw-w64-x86_64-nsis
             mingw-w64-x86_64-onevpl

--- a/.gitmodules
+++ b/.gitmodules
@@ -54,3 +54,6 @@
 	path = third-party/wlr-protocols
 	url = https://gitlab.freedesktop.org/wlroots/wlr-protocols
 	branch = master
+[submodule "third-party/nlohmann_json"]
+	path = third-party/nlohmann_json
+	url = https://github.com/nlohmann/json

--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -56,6 +56,7 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/src/RtspParser.c"
         "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/src/Video.h"
         "${CMAKE_SOURCE_DIR}/third-party/tray/tray.h"
+        "${CMAKE_SOURCE_DIR}/src/display_device/dd.h"
         "${CMAKE_SOURCE_DIR}/src/upnp.cpp"
         "${CMAKE_SOURCE_DIR}/src/upnp.h"
         "${CMAKE_SOURCE_DIR}/src/cbs.cpp"
@@ -138,4 +139,5 @@ list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
         ${Boost_LIBRARIES}
         ${OPENSSL_LIBRARIES}
         ${CURL_LIBRARIES}
+        ${JSON_LIBRARIES}
         ${PLATFORM_LIBRARIES})

--- a/cmake/compile_definitions/macos.cmake
+++ b/cmake/compile_definitions/macos.cmake
@@ -39,6 +39,7 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/macos/av_video.h"
         "${CMAKE_SOURCE_DIR}/src/platform/macos/av_video.m"
         "${CMAKE_SOURCE_DIR}/src/platform/macos/display.mm"
+        "${CMAKE_SOURCE_DIR}/src/platform/macos/display_options.mm"
         "${CMAKE_SOURCE_DIR}/src/platform/macos/input.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/macos/microphone.mm"
         "${CMAKE_SOURCE_DIR}/src/platform/macos/misc.mm"

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -74,7 +74,6 @@ list(PREPEND PLATFORM_LIBRARIES
         avrt
         iphlpapi
         shlwapi
-        PkgConfig::NLOHMANN_JSON
         ${CURL_STATIC_LIBRARIES})
 
 if(SUNSHINE_ENABLE_TRAY)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -19,6 +19,15 @@ pkg_check_modules(CURL REQUIRED libcurl)
 pkg_check_modules(MINIUPNP miniupnpc REQUIRED)
 include_directories(SYSTEM ${MINIUPNP_INCLUDE_DIRS})
 
+# nlohmann_json
+if(SUNSHINE_SYSTEM_NLOHMANN_JSON)
+    pkg_check_modules(NLOHMANN_JSON nlohmann_json>=3.9.0 REQUIRED IMPORTED_TARGET)
+    set(JSON_LIBRARIES PkgConfig::NLOHMANN_JSON)
+else()
+    add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/nlohmann_json")
+    set(JSON_LIBRARIES nlohmann_json::nlohmann_json)
+endif()
+
 # ffmpeg pre-compiled binaries
 if(WIN32)
     if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")

--- a/cmake/dependencies/windows.cmake
+++ b/cmake/dependencies/windows.cmake
@@ -2,6 +2,3 @@
 
 set(Boost_USE_STATIC_LIBS ON)  # cmake-lint: disable=C0103
 find_package(Boost 1.71.0 COMPONENTS locale log filesystem program_options REQUIRED)
-
-# nlohmann_json
-pkg_check_modules(NLOHMANN_JSON nlohmann_json REQUIRED IMPORTED_TARGET)

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -13,6 +13,7 @@ option(SUNSHINE_CONFIGURE_ONLY "Configure special files only, then exit." OFF)
 option(SUNSHINE_ENABLE_TRAY "Enable system tray icon. This option will be ignored on macOS." ON)
 option(SUNSHINE_REQUIRE_TRAY "Require system tray icon. Fail the build if tray requirements are not met." ON)
 
+option(SUNSHINE_SYSTEM_NLOHMANN_JSON "Use system installation of nlohmann_json rather than the submodule." OFF)
 option(SUNSHINE_SYSTEM_WAYLAND_PROTOCOLS "Use system installation of wayland-protocols rather than the submodule." OFF)
 
 option(CUDA_INHERIT_COMPILE_OPTIONS

--- a/docs/source/building/windows.rst
+++ b/docs/source/building/windows.rst
@@ -28,7 +28,6 @@ Install dependencies:
         mingw-w64-x86_64-curl \
         mingw-w64-x86_64-graphviz \
         mingw-w64-x86_64-miniupnpc \
-        mingw-w64-x86_64-nlohmann-json \
         mingw-w64-x86_64-nodejs \
         mingw-w64-x86_64-onevpl \
         mingw-w64-x86_64-openssl \

--- a/docs/source/source_code/source_code.rst
+++ b/docs/source/source_code/source_code.rst
@@ -63,6 +63,13 @@ Source
    src/*
 
 .. toctree::
+   :caption: src/display_device
+   :maxdepth: 1
+   :glob:
+
+   src/display_device/*
+
+.. toctree::
    :caption: src/platform
    :maxdepth: 1
    :glob:

--- a/src/config.h
+++ b/src/config.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "nvenc/nvenc_config.h"
+#include "display_device/dd.h"
 
 namespace config {
   struct video_t {
@@ -82,11 +83,7 @@ namespace config {
     bool install_steam_drivers;
   };
 
-  struct display_options_t {
-    int id;
-    std::string name;
-    bool is_primary_display;
-  };
+
 
   constexpr int ENCRYPTION_MODE_NEVER = 0;  // Never use video encryption, even if the client supports it
   constexpr int ENCRYPTION_MODE_OPPORTUNISTIC = 1;  // Use video encryption if available, but stream without it if not supported

--- a/src/config.h
+++ b/src/config.h
@@ -82,6 +82,12 @@ namespace config {
     bool install_steam_drivers;
   };
 
+  struct display_options_t {
+    int id;
+    std::string name;
+    bool is_primary_display;
+  };
+
   constexpr int ENCRYPTION_MODE_NEVER = 0;  // Never use video encryption, even if the client supports it
   constexpr int ENCRYPTION_MODE_OPPORTUNISTIC = 1;  // Use video encryption if available, but stream without it if not supported
   constexpr int ENCRYPTION_MODE_MANDATORY = 2;  // Always use video encryption and refuse clients that can't encrypt

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -543,6 +543,16 @@ namespace confighttp {
     outputTree.put("platform", SUNSHINE_PLATFORM);
     outputTree.put("version", PROJECT_VER);
 
+    pt::ptree displays;
+    for (const auto &[id, name, is_primary_display] : platf::display_options()) {
+      pt::ptree display_value;
+      display_value.put("id", id);
+      display_value.put("name", name);
+      display_value.put("is_primary", is_primary_display);
+      displays.push_front(std::make_pair(std::to_string(id), display_value));
+    }
+    outputTree.push_back(std::make_pair("displays", displays));
+
     auto vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
 
     for (auto &[name, value] : vars) {

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -26,6 +26,8 @@
 #include <Simple-Web-Server/server_https.hpp>
 #include <boost/asio/ssl/context_base.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include "config.h"
 #include "confighttp.h"
 #include "crypto.h"

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -554,10 +554,11 @@ namespace confighttp {
     outputTree.push_back(std::make_pair("displays", displays));
 
     auto vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
-
+    pt::ptree config_file;
     for (auto &[name, value] : vars) {
-      outputTree.put(std::move(name), std::move(value));
+      config_file.put(std::move(name), std::move(value));
     }
+    outputTree.push_back(std::make_pair("config_file", config_file));
   }
 
   void

--- a/src/display_device/dd.h
+++ b/src/display_device/dd.h
@@ -17,6 +17,92 @@
 #include <nlohmann/json.hpp>
 
 namespace dd {
+
+  enum class device_state_e {
+    inactive,
+    active,
+    primary /**< Primary state is also implicitly active. */
+  };
+
+  /**
+   * @brief The device's HDR state in the operating system.
+   */
+  enum class hdr_state_e {
+    unknown, /**< HDR state could not be retrieved from the OS (even if the display supports it). */
+    disabled,
+    enabled
+  };
+
+  /**
+  * @brief Display's origin position.
+  * @note Display origin may vary given the compositor running.
+  */
+  struct origin_t {
+    int x;
+    int y;
+
+    [[nodiscard]] bool is_primary() const {
+      return this->x == 0 && this->y == 0;
+    }
+    // For JSON serialization
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(origin_t, x, y)
+  };
+
+  struct resolution_t {
+    unsigned int width;
+    unsigned int height;
+    double scale_factor;
+
+    // For JSON serialization
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(resolution_t, width, height, scale_factor)
+  };
+
+  /**
+   * @brief Display's refresh rate.
+   * @note Floating point is stored in a "numerator/denominator" form.
+   */
+  struct refresh_rate_t {
+    unsigned int numerator;
+    unsigned int denominator;
+
+    // For JSON serialization
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(refresh_rate_t, numerator, denominator)
+  };
+
+  /**
+   * @brief Display's mode (resolution + refresh rate).
+   * @see resolution_t
+   * @see refresh_rate_t
+   */
+  struct mode_t {
+    resolution_t resolution;
+    refresh_rate_t refresh_rate;
+
+    // For JSON serialization
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(mode_t, resolution, refresh_rate)
+  };
+
+
   namespace options {
+    struct current_settings_t {
+      origin_t origin;
+      mode_t mode;
+
+      [[nodiscard]] bool is_primary() const {
+        return origin.is_primary();
+      }
+
+      // For JSON serialization
+      NLOHMANN_DEFINE_TYPE_INTRUSIVE(current_settings_t, origin, mode)
+    };
+
+    struct info_t {
+      std::string id;
+      std::string friendly_name;
+      current_settings_t current_settings;
+
+      // For JSON serialization
+      NLOHMANN_DEFINE_TYPE_INTRUSIVE(info_t, id, friendly_name, current_settings)
+    };
   }
 }

--- a/src/display_device/dd.h
+++ b/src/display_device/dd.h
@@ -1,0 +1,22 @@
+/**
+ * @file src/display_device/dd.h
+ * @brief todo this file may not exist in the future,
+ * todo        and we only import <libdisplaydevice/display_device.h> instead, avoiding duplication
+ */
+
+#pragma once
+
+#include <bitset>
+#include <chrono>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// lib includes
+#include <nlohmann/json.hpp>
+
+namespace dd {
+  namespace options {
+  }
+}

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -578,7 +578,7 @@ namespace platf {
   std::vector<std::string>
   display_names(mem_type_e hwdevice_type);
 
-  std::vector<config::display_options_t>
+  std::vector<dd::options::info_t>
   display_options();
 
   /**

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -578,6 +578,9 @@ namespace platf {
   std::vector<std::string>
   display_names(mem_type_e hwdevice_type);
 
+  std::vector<config::display_options_t>
+  display_options();
+
   /**
    * @brief Returns if GPUs/drivers have changed since the last call to this function.
    * @return `true` if a change has occurred or if it is unknown whether a change occurred.

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -1049,4 +1049,36 @@ namespace platf {
 
     return display_names;
   }
+
+  std::vector<config::display_options_t>
+  nvfbc_display_options() {
+    if (cuda::init() || cuda::nvfbc::init()) {
+      return {};
+    }
+
+    std::vector<config::display_options_t> display_options;
+
+    auto handle = cuda::nvfbc::handle_t::make();
+    if (!handle) {
+      return {};
+    }
+
+    auto status_params = handle->status();
+    if (!status_params) {
+      return {};
+    }
+
+    for (auto x = 0; x < status_params->dwOutputNum; ++x) {
+      auto &output = status_params->outputs[x];
+      std::string name = output.name;
+      auto option = config::display_options_t {
+        x,
+        name + ",  dwID: " + std::to_string(output.dwId),
+        false // TODO: Find proper way of doing it, found no way of checking for primary display myself
+      };
+      display_options.emplace_back(option);
+    }
+
+    return display_options;
+  }
 }  // namespace platf

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -777,6 +777,8 @@ namespace platf {
 #ifdef SUNSHINE_BUILD_CUDA
   std::vector<std::string>
   nvfbc_display_names();
+  std::vector<config::display_options_t>
+  nvfbc_display_options();
   std::shared_ptr<display_t>
   nvfbc_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
 
@@ -789,6 +791,8 @@ namespace platf {
 #ifdef SUNSHINE_BUILD_WAYLAND
   std::vector<std::string>
   wl_display_names();
+  std::vector<config::display_options_t>
+  wl_display_options();
   std::shared_ptr<display_t>
   wl_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
 
@@ -801,6 +805,8 @@ namespace platf {
 #ifdef SUNSHINE_BUILD_DRM
   std::vector<std::string>
   kms_display_names(mem_type_e hwdevice_type);
+  std::vector<config::display_options_t>
+  kms_display_options();
   std::shared_ptr<display_t>
   kms_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
 
@@ -813,6 +819,8 @@ namespace platf {
 #ifdef SUNSHINE_BUILD_X11
   std::vector<std::string>
   x11_display_names();
+  std::vector<config::display_options_t>
+  x11_display_options();
   std::shared_ptr<display_t>
   x11_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
 
@@ -837,6 +845,23 @@ namespace platf {
 #ifdef SUNSHINE_BUILD_X11
     if (sources[source::X11]) return x11_display_names();
 #endif
+    return {};
+  }
+
+  std::vector<config::display_options_t>
+  display_options() {
+    #ifdef SUNSHINE_BUILD_CUDA
+    if (sources[source::NVFBC]) return nvfbc_display_options();
+    #endif
+    #ifdef SUNSHINE_BUILD_WAYLAND
+    if (sources[source::WAYLAND]) return wl_display_options();
+    #endif
+    #ifdef SUNSHINE_BUILD_DRM
+    if (sources[source::KMS]) return kms_display_options();
+    #endif
+    #ifdef SUNSHINE_BUILD_X11
+    if (sources[source::X11]) return x11_display_options();
+    #endif
     return {};
   }
 

--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -191,6 +191,30 @@ namespace platf {
     return display_names;
   }
 
+  std::vector<config::display_options_t>
+  display_options() {
+    __block std::vector<config::display_options_t> display_options;
+
+    auto display_array = [AVVideo displayNames];
+
+    auto main_display_id = CGMainDisplayID();
+    display_options.reserve([display_array count]);
+
+    [display_array enumerateObjectsUsingBlock:^(NSDictionary *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
+      NSNumber *display_id = obj[@"id"];
+      NSString *name = obj[@"displayName"];
+
+      auto option = config::display_options_t {
+          [display_id intValue],
+          name.UTF8String,
+          main_display_id == [display_id unsignedIntValue]
+      };
+      display_options.emplace_back(option);
+    }];
+
+    return display_options;
+  }
+
   /**
    * @brief Returns if GPUs/drivers have changed since the last call to this function.
    * @return `true` if a change has occurred or if it is unknown whether a change occurred.

--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -191,30 +191,6 @@ namespace platf {
     return display_names;
   }
 
-  std::vector<config::display_options_t>
-  display_options() {
-    __block std::vector<config::display_options_t> display_options;
-
-    auto display_array = [AVVideo displayNames];
-
-    auto main_display_id = CGMainDisplayID();
-    display_options.reserve([display_array count]);
-
-    [display_array enumerateObjectsUsingBlock:^(NSDictionary *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-      NSNumber *display_id = obj[@"id"];
-      NSString *name = obj[@"displayName"];
-
-      auto option = config::display_options_t {
-          [display_id intValue],
-          name.UTF8String,
-          main_display_id == [display_id unsignedIntValue]
-      };
-      display_options.emplace_back(option);
-    }];
-
-    return display_options;
-  }
-
   /**
    * @brief Returns if GPUs/drivers have changed since the last call to this function.
    * @return `true` if a change has occurred or if it is unknown whether a change occurred.

--- a/src/platform/macos/display_options.mm
+++ b/src/platform/macos/display_options.mm
@@ -1,0 +1,83 @@
+/**
+ * @file src/platform/macos/display_options.mm
+ * @brief todo
+ */
+#include "src/platform/common.h"
+#include "src/platform/macos/av_video.h"
+
+#include "src/config.h"
+#include "src/logging.h"
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <CoreGraphics/CGDirectDisplay.h>
+
+namespace fs = std::filesystem;
+
+namespace platf {
+  using namespace std::literals;
+
+  dd::options::info_t
+  display_mode(NSArray<NSScreen *>* screens, CGDirectDisplayID displayID) {
+    auto id = [NSNumber numberWithUnsignedInt:displayID];
+    for (NSScreen *screen in screens) {
+      if (screen.deviceDescription[@"NSScreenNumber"] == id) {
+        NSRect frame = screen.frame;
+        auto origin = dd::origin_t {
+          int(frame.origin.x),
+          int(frame.origin.y)
+        };
+        auto resolution = dd::resolution_t {
+          uint32_t(frame.size.width),
+          uint32_t(frame.size.height),
+          screen.backingScaleFactor
+        };
+
+        //auto minimumFramesPerSecond = uint32_t(screen.minimumFramesPerSecond);
+        //double displayUpdateGranularity = screen.displayUpdateGranularity;
+        auto refresh_rate = dd::refresh_rate_t {
+            uint32_t(screen.maximumFramesPerSecond),
+            0
+        };
+        auto current_mode = dd::mode_t {
+          resolution,
+          refresh_rate
+        };
+        auto settings = dd::options::current_settings_t {
+          origin,
+          current_mode
+        };
+        auto info = dd::options::info_t {
+          [id stringValue].UTF8String,
+          screen.localizedName.UTF8String,
+          settings
+        };
+        return info;
+      }
+    }
+
+    return {};
+  }
+
+  std::vector<dd::options::info_t>
+  display_options() {
+    CGDirectDisplayID active_displays[kMaxDisplays];
+    uint32_t count;
+    if (CGGetActiveDisplayList(kMaxDisplays, active_displays, &count) != kCGErrorSuccess) {
+      return {};
+    }
+
+    std::vector<dd::options::info_t> display_options;
+
+    display_options.reserve(count);
+
+    auto screens = [NSScreen screens];
+
+    for (uint32_t i = 0; i < count; i++) {
+      display_options.emplace_back(
+        platf::display_mode(screens, active_displays[i])
+      );
+    }
+
+    return display_options;
+  }
+}  // namespace platf

--- a/src/platform/macos/display_options.mm
+++ b/src/platform/macos/display_options.mm
@@ -36,7 +36,7 @@ namespace platf {
         //double displayUpdateGranularity = screen.displayUpdateGranularity;
         auto refresh_rate = dd::refresh_rate_t {
             uint32_t(screen.maximumFramesPerSecond),
-            0
+            1
         };
         auto current_mode = dd::mode_t {
           resolution,

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -57,6 +57,7 @@
         :platform="platform"
         :resolutions="resolutions"
         :fps="fps"
+        :displays="displays"
       >
       </audio-video>
 
@@ -136,6 +137,7 @@
         config: null,
         fps: [],
         resolutions: [],
+        displays: [],
         currentTab: "general",
         global_prep_cmd: [],
         tabs: [ // TODO: Move the options to each Component instead, encapsulate.
@@ -290,6 +292,7 @@
         .then((r) => {
           this.config = r;
           this.platform = this.config.platform;
+          this.displays = this.config.displays;
 
           var app = document.getElementById("app");
           if (this.platform === "windows") {

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -132,12 +132,12 @@
     data() {
       return {
         platform: "",
+        displays: [],
         saved: false,
         restarted: false,
         config: null,
         fps: [],
         resolutions: [],
-        displays: [],
         currentTab: "general",
         global_prep_cmd: [],
         tabs: [ // TODO: Move the options to each Component instead, encapsulate.
@@ -290,9 +290,9 @@
       fetch("/api/config")
         .then((r) => r.json())
         .then((r) => {
-          this.config = r;
-          this.platform = this.config.platform;
-          this.displays = this.config.displays;
+          this.config = r.config_file;
+          this.platform = r.platform;
+          this.displays = r.displays;
 
           var app = document.getElementById("app");
           if (this.platform === "windows") {
@@ -311,12 +311,7 @@
             });
           }
 
-          // remove values we don't want in the config file
-          delete this.config.platform;
-          delete this.config.status;
-          delete this.config.version;
-
-          // TODO: let each tab's Component handle it's own data instead of doing it here
+         // TODO: let each tab's Component handle it's own data instead of doing it here
 
           // Populate default values from tabs options
           this.tabs.forEach(tab => {

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {ref} from 'vue'
+import {reactive, ref} from 'vue'
 import {$tp} from '../../platform-i18n'
 import PlatformLayout from '../../PlatformLayout.vue'
 import AdapterNameSelector from './audiovideo/AdapterNameSelector.vue'
@@ -16,7 +16,7 @@ const props = defineProps([
   'displays'
 ])
 
-const config = ref(props.config)
+const config = reactive(props.config)
 </script>
 
 <template>

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -13,6 +13,7 @@ const props = defineProps([
   'config',
   'resolutions',
   'fps',
+  'displays'
 ])
 
 const config = ref(props.config)
@@ -72,9 +73,10 @@ const config = ref(props.config)
         :config="config"
     />
 
-    <LegacyDisplayOutputSelector
+    <NewDisplayOutputSelector
       :platform="platform"
       :config="config"
+      :displays="displays"
     />
 
     <!-- Display Modes -->

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/LegacyDisplayOutputSelector.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/LegacyDisplayOutputSelector.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import {reactive, ref} from 'vue'
 import { $tp } from '../../../platform-i18n'
 import PlatformLayout from '../../../PlatformLayout.vue'
 
@@ -8,7 +8,7 @@ const props = defineProps([
   'config'
 ])
 
-const config = ref(props.config)
+const config = reactive(props.config)
 const outputNamePlaceholder = (props.platform === 'windows') ? '\\.\DISPLAY1' : '0'
 </script>
 

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/NewDisplayOutputSelector.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/NewDisplayOutputSelector.vue
@@ -1,27 +1,31 @@
 <script setup>
-import {computed, ref} from 'vue'
+import { reactive, ref } from 'vue'
 import { $tp } from '../../../platform-i18n'
 import PlatformLayout from '../../../PlatformLayout.vue'
-import LegacyDisplayOutputSelector from "./LegacyDisplayOutputSelector.vue";
+import LegacyDisplayOutputSelector from './LegacyDisplayOutputSelector.vue'
 
-const props = defineProps([
-  'platform',
-  'config',
-  'displays'
-])
+const props = defineProps({
+  platform: String,
+  config: Object,
+  displays: Array
+})
 
-const config = ref(props.config)
-const outputNamePlaceholder = (props.platform === 'windows') ? '{de9bb7e2-186e-505b-9e93-f48793333810}' : '4531345'
+const config = reactive(props.config)
 
-const selectedDisplay = computed(() => getSelected(config.output_name))
+const selectedDisplay = ref(getDisplaySelected(props.config.output_name))
 
-function getSelected(id) {
-  for (const display of props.displays) {
-    if (display.id === id) {
-      return display
+function getDisplaySelected(id) {
+  if (!id || !props.displays) { return null }
+  for (let i = 0; i < props.displays.length; i++) {
+    if (props.displays[i].id === id) {
+      return props.displays[i]
     }
   }
   return null
+}
+
+function updatedSelected(id) {
+  selectedDisplay.value = getDisplaySelected(id)
 }
 
 function isPrimary(display) {
@@ -43,31 +47,35 @@ function resolution(display) {
   />
 
   <div class="mb-3" v-if="displays">
-    <label for="output_name" class="form-label">{{ $tp('config.output_name') }}</label>
-    <select id="output_name" class="form-select" v-model="config.output_name">
+    <label for="output_name" class="form-label">{{ $tp('config.output_name', $t('config.output_name_linux')) }}</label>
+    <select id="output_name" class="form-select" v-model="config.output_name" v-on:change="updatedSelected(config.output_name)">
       <option value="">Default</option>
-      <option v-for="display in displays" :value="display.name">
-        {{ display.id }}: {{ display.name }} {{ resolution(display) }}<template v-if='isPrimary(display)'>, primary</template>
+      <option v-for="display in displays" :value="display.id">
+        {{ display.id }}: {{ display.friendly_name }} {{ resolution(display) }}<template v-if='isPrimary(display)'>, primary</template>
       </option>
     </select>
     <div class="form-text">
-      <p style="white-space: pre-line">{{ $tp('config.output_name_desc') }}</p>
       <PlatformLayout :platform="platform">
         <template #windows>
+          <p style="white-space: pre-line">{{ $tp('config.output_name_desc', $t('config.output_name_desc_linux')) }}</p>
           <b>&nbsp;&nbsp;&nbsp;&nbsp;DEVICE ID: {de9bb7e2-186e-505b-9e93-f48793333810}</b><br>
           <b>&nbsp;&nbsp;&nbsp;&nbsp;DISPLAY NAME: \\.\DISPLAY1</b><br>
           <b>&nbsp;&nbsp;&nbsp;&nbsp;FRIENDLY NAME: ROG PG279Q</b><br>
           <b>&nbsp;&nbsp;&nbsp;&nbsp;DEVICE STATE: PRIMARY</b><br>
           <b>&nbsp;&nbsp;&nbsp;&nbsp;HDR STATE: UNKNOWN</b>
         </template>
+
         <template #linux>
         </template>
+
         <template #macos>
-          <template v-if="selectedDisplay">
+          <div v-if="selectedDisplay">
             <b>&nbsp;&nbsp;&nbsp;&nbsp;DEVICE ID: {{ selectedDisplay.id }}</b><br>
             <b>&nbsp;&nbsp;&nbsp;&nbsp;FRIENDLY NAME: {{ selectedDisplay.friendly_name }}</b><br>
-            <b>&nbsp;&nbsp;&nbsp;&nbsp;DEVICE STATE: {{ isPrimary(selectedDisplay) }}</b><br>
-          </template>
+            <b>&nbsp;&nbsp;&nbsp;&nbsp;PRIMARY DEVICE: {{ isPrimary(selectedDisplay) }}</b><br>
+            <b>&nbsp;&nbsp;&nbsp;&nbsp;RAW DEVICE DATA:</b><br>
+            <b>&nbsp;&nbsp;&nbsp;&nbsp;{{ JSON.stringify(selectedDisplay) }}</b><br>
+          </div>
         </template>
       </PlatformLayout>
     </div>

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/NewDisplayOutputSelector.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/NewDisplayOutputSelector.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { ref } from 'vue'
+import {computed, ref} from 'vue'
 import { $tp } from '../../../platform-i18n'
 import PlatformLayout from '../../../PlatformLayout.vue'
+import LegacyDisplayOutputSelector from "./LegacyDisplayOutputSelector.vue";
 
 const props = defineProps([
   'platform',
@@ -11,13 +12,44 @@ const props = defineProps([
 
 const config = ref(props.config)
 const outputNamePlaceholder = (props.platform === 'windows') ? '{de9bb7e2-186e-505b-9e93-f48793333810}' : '4531345'
+
+const selectedDisplay = computed(() => getSelected(config.output_name))
+
+function getSelected(id) {
+  for (const display of props.displays) {
+    if (display.id === id) {
+      return display
+    }
+  }
+  return null
+}
+
+function isPrimary(display) {
+  const origin = display.current_settings.origin
+  return origin.x === 0 && origin.y === 0;
+}
+
+function resolution(display) {
+  const resolution = display.current_settings.mode.resolution
+  return `${resolution.width}x${resolution.height}`;
+}
 </script>
 
 <template>
-  <div class="mb-3">
+  <LegacyDisplayOutputSelector
+      v-if="!displays || platform === 'linux'"
+      :platform="platform"
+      :config="config"
+  />
+
+  <div class="mb-3" v-if="displays">
     <label for="output_name" class="form-label">{{ $tp('config.output_name') }}</label>
-    <input type="text" class="form-control" id="output_name" :placeholder="outputNamePlaceholder"
-           v-model="config.output_name"/>
+    <select id="output_name" class="form-select" v-model="config.output_name">
+      <option value="">Default</option>
+      <option v-for="display in displays" :value="display.name">
+        {{ display.id }}: {{ display.name }} {{ resolution(display) }}<template v-if='isPrimary(display)'>, primary</template>
+      </option>
+    </select>
     <div class="form-text">
       <p style="white-space: pre-line">{{ $tp('config.output_name_desc') }}</p>
       <PlatformLayout :platform="platform">
@@ -31,6 +63,11 @@ const outputNamePlaceholder = (props.platform === 'windows') ? '{de9bb7e2-186e-5
         <template #linux>
         </template>
         <template #macos>
+          <template v-if="selectedDisplay">
+            <b>&nbsp;&nbsp;&nbsp;&nbsp;DEVICE ID: {{ selectedDisplay.id }}</b><br>
+            <b>&nbsp;&nbsp;&nbsp;&nbsp;FRIENDLY NAME: {{ selectedDisplay.friendly_name }}</b><br>
+            <b>&nbsp;&nbsp;&nbsp;&nbsp;DEVICE STATE: {{ isPrimary(selectedDisplay) }}</b><br>
+          </template>
         </template>
       </PlatformLayout>
     </div>


### PR DESCRIPTION
## Description
This is a PoC, and a proposal, for allowing the screen to be selected via a list, instead of having to search for an ID and write it down. Also, this PR doesn't cover it, but we could in the future, further improve it, and allow the client to request it and maybe remotely select the preferred display.

For this PR I took basically the same code from every `display_names()` and stripped it to just the basics, but keeping the check, fail-overs, and the same counting for IDs as the other methods use, so we have a 1:1 mapping. I took a bit more effort in some targets than others, but I focused in the targets I could build and run myself first.

All targets are implemented, but some probably will need some more work done, testers are really welcome.

I don't consider this as a breaking change, because:
 1. The select uses the same value as the text input used, so it won't break even if it had been set in the past;
 2. If for some reason, we fail to get a list, we fallback to the old text input, so if something breaks, the user can still use the old UI.
 
 
 ### Depends on
 - #2491 

#### Built and run so far
- [x] macOS Intel
- [ ] macOS Apple Silicon 
- [ ] x11 
- [ ] Windows
- [ ] kms
- [ ] Cuda
- [ ] Wl


### Screenshot
#### macOS
![Screenshot 2024-04-30 at 10 13 49](https://github.com/LizardByte/Sunshine/assets/4046170/e98b3687-0178-4368-a244-f4ce1fa74ffb)
#### Windows
![Screenshot 2024-04-30 at 20 03 48](https://github.com/LizardByte/Sunshine/assets/4046170/a9a290c2-5278-4c00-94e9-88df6e76c667)
#### Linux AppImage x11
![Screenshot 2024-04-30 at 22 51 04](https://github.com/LizardByte/Sunshine/assets/4046170/11b518e7-e556-468a-a7b5-082363f45fce)


## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. .github/...)

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
