### PR TITLE
fix(linux): add frame processing latency and logging improvements

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -115,6 +115,10 @@ namespace audio {
     opus_multistream_encoder_ctl(opus.get(), OPUS_SET_BITRATE(stream->bitrate));
     opus_multistream_encoder_ctl(opus.get(), OPUS_SET_VBR(0));
 
+    BOOST_LOG(info) << "Opus initialized: "sv << stream->sampleRate / 1000 << " kHz, "sv
+                    << stream->channelCount << " channels, "sv
+                    << stream->bitrate / 1000 << " kbps (total), LOWDELAY"sv;
+
     auto frame_size = config.packetDuration * stream->sampleRate / 1000;
     while (auto sample = samples->pop()) {
       buffer_t packet { 1400 };

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1685,7 +1685,9 @@ namespace platf {
         if (!fb->handles[0]) {
           BOOST_LOG(error) << "Couldn't get handle for DRM Framebuffer ["sv << plane->fb_id << "]: Probably not permitted"sv;
           BOOST_LOG((window_system != window_system_e::X11 || config::video.capture == "kms") ? fatal : error)
-            << "You must run [sudo setcap cap_sys_admin+p $(readlink -f $(which sunshine))] for KMS display capture to work!"sv;
+            << "You must run [sudo setcap cap_sys_admin+p $(readlink -f $(which sunshine))] for KMS display capture to work!\n"sv
+            << "If you installed from AppImage or Flatpak, please refer to the official documentation:\n"sv
+            << "https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/setup.html#install"sv;
           break;
         }
 

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -371,7 +371,7 @@ namespace va {
       return -1;
     }
 
-    BOOST_LOG(debug) << "vaapi vendor: "sv << vaQueryVendorString(display.get());
+    BOOST_LOG(info) << "vaapi vendor: "sv << vaQueryVendorString(display.get());
 
     *hw_device_buf = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_VAAPI);
     auto ctx = (AVHWDeviceContext *) (*hw_device_buf)->data;

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -679,6 +679,7 @@ namespace platf {
       }
       else {
         auto img_cookie = xcb::shm_get_image_unchecked(xcb.get(), display->root, offset_x, offset_y, width, height, ~0, XCB_IMAGE_FORMAT_Z_PIXMAP, seg, 0);
+        auto frame_timestamp = std::chrono::steady_clock::now();
 
         xcb_img_t img_reply { xcb::shm_get_image_reply(xcb.get(), img_cookie, nullptr) };
         if (!img_reply) {
@@ -691,6 +692,7 @@ namespace platf {
         }
 
         std::copy_n((std::uint8_t *) data.data, frame_size(), img_out->data);
+        img_out->frame_timestamp = frame_timestamp;
 
         if (cursor) {
           blend_cursor(shm_xdisplay.get(), *img_out, offset_x, offset_y);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1294,6 +1294,10 @@ namespace video {
         return ret;
       }
 
+      if (av_packet->flags & AV_PKT_FLAG_KEY) {
+        BOOST_LOG(debug) << "Frame "sv << frame_nr << ": IDR Keyframe (AV_FRAME_FLAG_KEY)"sv;
+      }
+
       if ((frame->flags & AV_FRAME_FLAG_KEY) && !(av_packet->flags & AV_PKT_FLAG_KEY)) {
         BOOST_LOG(error) << "Encoder did not produce IDR frame when requested!"sv;
       }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR collects a few minor improvements to the Linux logging code. It allows for easier troubleshooting. Here are the commit messages (with minor edits):
1.
```
    Logging (Linux): emit basic GPU info at loglevel info
    
    On multi-GPU systems it's useful to have essential
    GPU info in Sunshine's log at the default 'info'
    loglevel.
    
    In particular, if x11grab was used in combination with
    VA-API encoding, there was no indication at all about
    the currently used GPU.
```
2.
```
    Logging(Linux): log IDR frames at loglevel debug
    
    IDR frames seem to be related to the occasional DATA_SHARDS_MAX
    warnings observed by some AMD users.
```
3.
```
Linux/x11grab: add frame processing latency
    
    This commit populates the img->frame_timestamp field, so that
    Moonlight is now capable of showing the "Host processing latency"
    in its statistics overlay.
    
    It's a complement to PR #2273 which missed the codepath for
    shm_attr_t::snapshot().
```
4.
```
    Logging(Linux/KMS): emit short note about AppImage/Flatpak
    
    The setcap command won't work for AppImage and Flatpak packages.
    Refer the user to the official documentation for further
    instructions.
```
5.
```
Logging/Opus: add basic stream info at loglevel 'info'
    
    Previously no information at all was logged about the used codec.
```
Example:
```
[2024:05:11:13:56:49]: Info: Setting default sink to: [sink-sunshine-stereo]
[2024:05:11:13:56:49]: Info: Found default monitor by name: sink-sunshine-stereo.monitor
[2024:05:11:13:56:49]: Info: Opus initialized: 48 kHz, 2 channels, 512 kbps (total), LOWDELAY
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
improves upon #2273

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
