### PR TITLE
Unify asset building and use find_program to find NPM

### DIFF
--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -49,11 +49,12 @@ else()
 endif()
 
 #WebUI build
+find_program(NPM npm REQUIRED)
 add_custom_target(web-ui ALL
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Installing NPM Dependencies and Building the Web UI"
-        COMMAND "$<$<BOOL:${WIN32}>:cmd;/C>" npm install
-        COMMAND "${CMAKE_COMMAND}" -E env "SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW}" "SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR}" "SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR}" "$<$<BOOL:${WIN32}>:cmd;/C>" npm run build  # cmake-lint: disable=C0301
+        COMMAND "$<$<BOOL:${WIN32}>:cmd;/C>" "${NPM}" install
+        COMMAND "${CMAKE_COMMAND}" -E env "SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW}" "SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR}" "SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR}" "$<$<BOOL:${WIN32}>:cmd;/C>" "${NPM}" run build  # cmake-lint: disable=C0301
         COMMAND_EXPAND_LISTS
         VERBATIM)
 

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -3,18 +3,6 @@
 
 add_executable(sunshine ${SUNSHINE_TARGET_FILES})
 
-# Homebrew build fails the vite build if we set these environment variables
-# this block must be before the platform specific code
-if(${SUNSHINE_BUILD_HOMEBREW})
-    set(NPM_SOURCE_ASSETS_DIR "")
-    set(NPM_ASSETS_DIR "")
-    set(NPM_BUILD_HOMEBREW "true")
-else()
-    set(NPM_SOURCE_ASSETS_DIR ${SUNSHINE_SOURCE_ASSETS_DIR})
-    set(NPM_ASSETS_DIR ${CMAKE_BINARY_DIR})
-    set(NPM_BUILD_HOMEBREW "")
-endif()
-
 # platform specific target definitions
 if(WIN32)
     include(${CMAKE_MODULE_PATH}/targets/windows.cmake)
@@ -48,6 +36,26 @@ if(CUDA_INHERIT_COMPILE_OPTIONS)
 endif()
 
 target_compile_options(sunshine PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>;$<$<COMPILE_LANGUAGE:CUDA>:${SUNSHINE_COMPILE_OPTIONS_CUDA};-std=c++17>)  # cmake-lint: disable=C0301
+
+# Homebrew build fails the vite build if we set these environment variables
+if(${SUNSHINE_BUILD_HOMEBREW})
+    set(NPM_SOURCE_ASSETS_DIR "")
+    set(NPM_ASSETS_DIR "")
+    set(NPM_BUILD_HOMEBREW "true")
+else()
+    set(NPM_SOURCE_ASSETS_DIR ${SUNSHINE_SOURCE_ASSETS_DIR})
+    set(NPM_ASSETS_DIR ${CMAKE_BINARY_DIR})
+    set(NPM_BUILD_HOMEBREW "")
+endif()
+
+#WebUI build
+add_custom_target(web-ui ALL
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        COMMENT "Installing NPM Dependencies and Building the Web UI"
+        COMMAND "$<$<BOOL:${WIN32}>:cmd;/C>" npm install
+        COMMAND "${CMAKE_COMMAND}" -E env "SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW}" "SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR}" "SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR}" "$<$<BOOL:${WIN32}>:cmd;/C>" npm run build  # cmake-lint: disable=C0301
+        COMMAND_EXPAND_LISTS
+        VERBATIM)
 
 # tests
 if(BUILD_TESTS)

--- a/cmake/targets/unix.cmake
+++ b/cmake/targets/unix.cmake
@@ -1,8 +1,2 @@
 # unix specific target definitions
 # put anything here that applies to both linux and macos
-
-#WebUI build
-add_custom_target(web-ui ALL
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        COMMENT "Installing NPM Dependencies and Building the Web UI"
-        COMMAND sh -c \"npm install && SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW} SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR} SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR} npm run build\")  # cmake-lint: disable=C0301

--- a/cmake/targets/windows.cmake
+++ b/cmake/targets/windows.cmake
@@ -4,9 +4,3 @@ set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
 find_library(ZLIB ZLIB1)
 list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
         Wtsapi32.lib)
-
-#WebUI build
-add_custom_target(web-ui ALL
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        COMMENT "Installing NPM Dependencies and Building the Web UI"
-        COMMAND cmd /C "npm install && set \"SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR}\" && set \"SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR}\" && npm run build")   # cmake-lint: disable=C0301


### PR DESCRIPTION
## Description
Firstly, this unifies the asset building by leveraging CMake's env command. `add_custom_target` can also accept multiple commands to be run in sequence. It isn't clear how quoting applies here, but I've tested it, and it seems to be behave as expected when spaces are present.

Secondly, this uses `find_program` to find NPM so it can be overridden. This is useful for Gentoo, which needs to be able to do entirely offline builds, because it can override this with `/bin/true` while shipping pre-compiled assets. Gentoo has tried to ship cached NPM modules instead, but it turns out these are very sensitive to the NPM version. I also tried swapping in Yarn, which handles caching better, but ran into other issues.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
