### PR TITLE
build(macos): skip link of nonexistent directories

### DIFF
--- a/cmake/compile_definitions/macos.cmake
+++ b/cmake/compile_definitions/macos.cmake
@@ -2,9 +2,17 @@
 
 add_compile_definitions(SUNSHINE_PLATFORM="macos")
 
-link_directories(/opt/local/lib)
-link_directories(/usr/local/lib)
-link_directories(/opt/homebrew/lib)
+set(MACOS_LINK_DIRECTORIES
+        /opt/homebrew/lib
+        /opt/local/lib
+        /usr/local/lib)
+
+foreach(DIR ${MACOS_LINK_DIRECTORIES})
+    if(EXISTS ${DIR})
+        link_directories(${DIR})
+    endif()
+endforeach()
+
 ADD_DEFINITIONS(-DBOOST_LOG_DYN_LINK)
 
 list(APPEND SUNSHINE_EXTERNAL_LIBRARIES

--- a/cmake/compile_definitions/macos.cmake
+++ b/cmake/compile_definitions/macos.cmake
@@ -7,9 +7,9 @@ set(MACOS_LINK_DIRECTORIES
         /opt/local/lib
         /usr/local/lib)
 
-foreach(DIR ${MACOS_LINK_DIRECTORIES})
-    if(EXISTS ${DIR})
-        link_directories(${DIR})
+foreach(dir ${MACOS_LINK_DIRECTORIES})
+    if(EXISTS ${dir})
+        link_directories(${dir})
     endif()
 endforeach()
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Modify cmake to only `link_directories` that exist on macOS. This will remove "warnings" from the cmake logs.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
