### PR TITLE
Fix log message for Periodic Ping

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -893,7 +893,7 @@ namespace stream {
   void
   controlBroadcastThread(control_server_t *server) {
     server->map(packetTypes[IDX_PERIODIC_PING], [](session_t *session, const std::string_view &payload) {
-      BOOST_LOG(verbose) << "type [IDX_START_A]"sv;
+      BOOST_LOG(verbose) << "type [IDX_PERIODIC_PING]"sv;
     });
 
     server->map(packetTypes[IDX_START_A], [&](session_t *session, const std::string_view &payload) {


### PR DESCRIPTION
## Description
Currently the log message for Periodic Ping displays wrong packet type. This change fix the log message to show correct packet type.


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Fix bug: [2537](https://github.com/LizardByte/Sunshine/issues/2537)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
- [x] I want maintainers to keep my branch updated
