### PR TITLE
build(deps): use new ffmpeg build names

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -22,36 +22,27 @@ include_directories(SYSTEM ${MINIUPNP_INCLUDE_DIRS})
 # ffmpeg pre-compiled binaries
 if(NOT DEFINED FFMPEG_PREPARED_BINARIES)
     if(WIN32)
-        if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
-            message(FATAL_ERROR "Unsupported system processor:" ${CMAKE_SYSTEM_PROCESSOR})
-        endif()
         set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid vpl)
-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/windows-x86_64")
-    elseif(APPLE)
-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/macos-x86_64")
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-            set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/macos-aarch64")
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "powerpc")
-            message(FATAL_ERROR "PowerPC is not supported on macOS")
-        else()
-            message(FATAL_ERROR "Unsupported system processor:" ${CMAKE_SYSTEM_PROCESSOR})
-        endif()
-    elseif(UNIX)
+    elseif(UNIX AND NOT APPLE)
         set(FFMPEG_PLATFORM_LIBRARIES numa va va-drm va-x11 vdpau X11)
         if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
             list(APPEND FFMPEG_PLATFORM_LIBRARIES mfx)
-            set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-x86_64")
             set(CPACK_DEB_PLATFORM_PACKAGE_DEPENDS "libmfx1,")
             set(CPACK_RPM_PLATFORM_PACKAGE_REQUIRES "intel-mediasdk >= 22.3.0,")
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-            set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-aarch64")
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64")
-            set(FFMPEG_PREPARED_BINARIES "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/linux-powerpc64le")
-        else()
-            message(FATAL_ERROR "Unsupported system processor:" ${CMAKE_SYSTEM_PROCESSOR})
         endif()
     endif()
+    set(FFMPEG_PREPARED_BINARIES
+            "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+
+    # check if the directory exists
+    if(NOT EXISTS "${FFMPEG_PREPARED_BINARIES}")
+        message(FATAL_ERROR
+                "FFmpeg pre-compiled binaries not found at ${FFMPEG_PREPARED_BINARIES}. \
+                Please consider contributing to the LizardByte/build-deps repository. \
+                Optionally, you can use the FFMPEG_PREPARED_BINARIES option to specify the path to the \
+                system-installed FFmpeg libraries")
+    endif()
+
     if(EXISTS "${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a")
         set(HDR10_PLUS_LIBRARY
                 "${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a")


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
ffmpeg build names have changed in https://github.com/LizardByte/build-deps/pull/326


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
