### PR TITLE
style: break lines more often, allow multiline params

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -42,7 +42,7 @@ BraceWrapping:
   IndentBraces: false
   SplitEmptyFunction: false
   SplitEmptyRecord: true
-BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
@@ -51,7 +51,7 @@ PenaltyBreakComment: 1
 PenaltyBreakString: 1
 PenaltyBreakFirstLessLess: 0
 PenaltyExcessCharacter: 1000000
-ColumnLimit: 80
+ColumnLimit: 120
 CompactNamespaces: false
 ContinuationIndentWidth: 2
 IndentCaseLabels: true

--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@
 # Generated from CLion C/C++ Code Style settings
 BasedOnStyle: LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: DontAlign
+AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveAssignments: None
 AlignEscapedNewlines: DontAlign
 AlignOperands: Align
@@ -42,11 +42,16 @@ BraceWrapping:
   IndentBraces: false
   SplitEmptyFunction: false
   SplitEmptyRecord: true
-BreakBeforeBinaryOperators: None
+BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
-ColumnLimit: 120
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 1
+PenaltyBreakString: 1
+PenaltyBreakFirstLessLess: 0
+PenaltyExcessCharacter: 1000000
+ColumnLimit: 80
 CompactNamespaces: false
 ContinuationIndentWidth: 2
 IndentCaseLabels: true


### PR DESCRIPTION
## Description
I propose those changes, so for example:

```cpp
  constexpr auto MAX_GAMEPADS = std::min(static_cast<std::size_t>(platf::MAX_GAMEPADS), sizeof(std::int16_t) * 8);
```

breaks instead like this:
```cpp
  constexpr auto MAX_GAMEPADS = std::min(
    static_cast<std::size_t>(platf::MAX_GAMEPADS), 
    sizeof(std::int16_t) * 8
  );
```

Also, ensures most places don't do:
```cpp
BOOST_LOG(debug)  << "--begin controller touch packet--"sv << std::endl
                  << "controllerNumber ["sv;
```

And do
```cpp
BOOST_LOG(debug) 
  << "--begin controller touch packet--"sv << std::endl
  << "controllerNumber ["sv;
```


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
