### PR TITLE
build(linux/fedora): Reenable Cuda support by building with gcc-12

### DIFF
--- a/docker/fedora-40.dockerfile
+++ b/docker/fedora-40.dockerfile
@@ -121,8 +121,6 @@ RUN <<_MAKE
 set -e
 cmake \
   -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
-  -DTESTS_ENABLE_PYTHON_TESTS=OFF \
-  -DSUNSHINE_BUILD_TESTS=OFF \
   -DBUILD_WERROR=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
@@ -138,15 +136,15 @@ cpack -G RPM
 _MAKE
 
 # run tests
-#WORKDIR /build/sunshine/build/tests
+WORKDIR /build/sunshine/build/tests
 # hadolint ignore=SC1091
-#RUN <<_TEST
-##!/bin/bash
-#set -e
-#export DISPLAY=:1
-#Xvfb ${DISPLAY} -screen 0 1024x768x24 &
-#./test_sunshine --gtest_color=yes
-#_TEST
+RUN <<_TEST
+#!/bin/bash
+set -e
+export DISPLAY=:1
+Xvfb ${DISPLAY} -screen 0 1024x768x24 &
+./test_sunshine --gtest_color=yes
+_TEST
 
 FROM scratch AS artifacts
 ARG BASE


### PR DESCRIPTION
## Description
Reenable cuda again by compiling it using [cuda-gcc-c++](https://negativo17.org/cuda-with-unsupported-gcc-versions/)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated


Duplicates #2649 