### PR TITLE
fix(ci): use project version as brew tag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -505,6 +505,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set IS_PR Environment Variable
+        if: github.event_name == 'pull_request'
+        run: echo "IS_PR=1" >> $GITHUB_ENV
+
       - name: Configure formula
         run: |
           # variables for formula

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -510,6 +510,8 @@ jobs:
         run: echo "IS_PR=1" >> $GITHUB_ENV
 
       - name: Configure formula
+        env:
+          IS_PR: ${{ env.IS_PR }}
         run: |
           # variables for formula
           branch="${{ github.head_ref }}"
@@ -542,7 +544,7 @@ jobs:
             -DGITHUB_DEFAULT_BRANCH="${default_branch}" \
             -DSUNSHINE_CONFIGURE_HOMEBREW=ON \
             -DSUNSHINE_CONFIGURE_ONLY=ON \
-            -DIS_PR="1" \
+            -DIS_PR=${{ env.IS_PR }} \
             ..
           cd ..
 
@@ -574,6 +576,8 @@ jobs:
 
       - name: Validate Homebrew Formula
         uses: LizardByte/homebrew-release-action@v2024.612.21058
+        env:
+          IS_PR: ${{ env.IS_PR }}
         with:
           formula_file: ${{ github.workspace }}/homebrew/sunshine.rb
           git_email: ${{ secrets.GH_BOT_EMAIL }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -538,6 +538,7 @@ jobs:
             -DGITHUB_DEFAULT_BRANCH="${default_branch}" \
             -DSUNSHINE_CONFIGURE_HOMEBREW=ON \
             -DSUNSHINE_CONFIGURE_ONLY=ON \
+            -DIS_PR="1" \
             ..
           cd ..
 

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -4,7 +4,7 @@ class @PROJECT_NAME@ < Formula
   desc "@PROJECT_DESCRIPTION@"
   homepage "@PROJECT_HOMEPAGE_URL@"
   url "@GITHUB_CLONE_URL@",
-    tag: "@GITHUB_BRANCH@"
+    tag: "v@PROJECT_VERSION@"
   version "@PROJECT_VERSION@"
   license all_of: ["GPL-3.0-only"]
   head "@GITHUB_CLONE_URL@", branch: "@GITHUB_DEFAULT_BRANCH@"

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -6,21 +6,23 @@ class @PROJECT_NAME@ < Formula
   if ENV["IS_PR"] == "1"
     url "@GITHUB_CLONE_URL@", branch: "@GITHUB_BRANCH@", revision: "@GITHUB_COMMIT@"
   else
-    url "@GITHUB_CLONE_URL@", tag: "@GITHUB_TAG@"
+    url "@GITHUB_CLONE_URL@", branch: "@GITHUB_DEFAULT_BRANCH@", tag: "@BUILD_VERSION@"
   end
-  version "@PROJECT_VERSION@"
+  version "@BUILD_VERSION@"
   license all_of: ["GPL-3.0-only"]
   head "@GITHUB_CLONE_URL@", branch: "@GITHUB_DEFAULT_BRANCH@"
 
-  # https://docs.brew.sh/Brew-Livecheck#githublatest-strategy-block
-  livecheck do
-    url :stable
-    regex(/^v?(\d+\.\d+\.\d+)$/i)
-    strategy :github_latest do |json, regex|
-      match = json["tag_name"]&.match(regex)
-      next if match.blank?
+  if ENV["IS_PR"] != "1"
+    # https://docs.brew.sh/Brew-Livecheck#githublatest-strategy-block
+    livecheck do
+      url :stable
+      regex(/^v?(\d+\.\d+\.\d+)$/i)
+      strategy :github_latest do |json, regex|
+        match = json["tag_name"]&.match(regex)
+        next if match.blank?
 
-      match[1]
+        match[1]
+      end
     end
   end
 

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -3,8 +3,11 @@ require "language/node"
 class @PROJECT_NAME@ < Formula
   desc "@PROJECT_DESCRIPTION@"
   homepage "@PROJECT_HOMEPAGE_URL@"
-  url "@GITHUB_CLONE_URL@",
-    tag: "v@PROJECT_VERSION@"
+  if ENV["IS_PR"] == "1"
+    url "@GITHUB_CLONE_URL@", branch: "@GITHUB_BRANCH@", revision: "@GITHUB_COMMIT@"
+  else
+    url "@GITHUB_CLONE_URL@", tag: "@GITHUB_TAG@"
+  end
   version "@PROJECT_VERSION@"
   license all_of: ["GPL-3.0-only"]
   head "@GITHUB_CLONE_URL@", branch: "@GITHUB_DEFAULT_BRANCH@"


### PR DESCRIPTION
## Description
Uses project version instead of branch name as brew install tag. `master` isn't a valid git tag, so brew install wasn't working correctly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
