### PR TITLE
fix(homebrew): use tag instead of branch in formula

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -493,8 +493,10 @@ jobs:
             os_name: "macos"
           - os_version: "latest"
             os_name: "ubuntu"
+          - os_version: "latest"  # this job will only configure the formula for release, no validation
+            os_name: "ubuntu"
             release: true
-    name: Homebrew (${{ matrix.os_name }}-${{ matrix.os_version }})
+    name: Homebrew (${{ matrix.os_name }}-${{ matrix.os_version }}${{ matrix.release == true && ' (Release)' || '' }})
     runs-on: ${{ matrix.os_name }}-${{ matrix.os_version }}
 
     steps:
@@ -515,14 +517,23 @@ jobs:
             clone_url=${{ github.event.repository.clone_url }}
             branch="${{ github.ref_name }}"
             default_branch="${{ github.event.repository.default_branch }}"
+
+            if [ "${{ matrix.release }}" == "true" ]; then
+              # we will publish the formula with the release tag
+              tag="${{ needs.setup_release.outputs.release_tag }}"
+            else
+              tag="${{ github.sha }}"
+            fi
           else
             echo "This is a PR event"
             clone_url=${{ github.event.pull_request.head.repo.clone_url }}
             branch="${{ github.event.pull_request.head.ref }}"
             default_branch="${{ github.event.pull_request.head.repo.default_branch }}"
+            tag="${{ github.event.pull_request.head.ref }}"
           fi
           echo "Branch: ${branch}"
           echo "Clone URL: ${clone_url}"
+          echo "Tag: ${tag}"
 
           mkdir build
           cd build
@@ -532,6 +543,7 @@ jobs:
             -DGITHUB_COMMIT="${commit}" \
             -DGITHUB_CLONE_URL="${clone_url}" \
             -DGITHUB_DEFAULT_BRANCH="${default_branch}" \
+            -DGITHUB_TAG="${tag}" \
             -DSUNSHINE_CONFIGURE_HOMEBREW=ON \
             -DSUNSHINE_CONFIGURE_ONLY=ON \
             ..
@@ -552,7 +564,9 @@ jobs:
           path: homebrew/
 
       - name: Setup Xvfb
-        if: ${{ runner.os == 'Linux' }}
+        if: |
+          matrix.release != true &&
+          runner.os == 'Linux'
         run: |
           sudo apt-get update -y
           sudo apt-get install -y \
@@ -564,6 +578,8 @@ jobs:
           echo "DISPLAY=${DISPLAY}" >> $GITHUB_ENV
 
       - name: Validate Homebrew Formula
+        if: |
+          matrix.release != true
         uses: LizardByte/homebrew-release-action@v2024.612.21058
         with:
           formula_file: ${{ github.workspace }}/homebrew/sunshine.rb

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -4,7 +4,7 @@ class @PROJECT_NAME@ < Formula
   desc "@PROJECT_DESCRIPTION@"
   homepage "@PROJECT_HOMEPAGE_URL@"
   url "@GITHUB_CLONE_URL@",
-    tag: "@GITHUB_BRANCH@"
+    tag: "@GITHUB_TAG@"
   version "@PROJECT_VERSION@"
   license all_of: ["GPL-3.0-only"]
   head "@GITHUB_CLONE_URL@", branch: "@GITHUB_DEFAULT_BRANCH@"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Publish a homebrew formula with the release tag instead of the branch name. The tag doesn't exist when the formula is validated, so the validation will be skipped for this job.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
