### PR TITLE
fix(cmake): add hints for openssl find_package

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -13,7 +13,7 @@ add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/enet")
 add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/Simple-Web-Server")
 
 # common dependencies
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL REQUIRED HINTS "/opt/homebrew/opt/openssl" "/usr/local/opt/openssl")  # hints are for macOS
 find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 pkg_check_modules(CURL REQUIRED libcurl)

--- a/docs/source/building/macos.rst
+++ b/docs/source/building/macos.rst
@@ -21,23 +21,6 @@ Install Requirements
 
       brew install cmake doxygen graphviz icu4c miniupnpc node openssl@3 opus pkg-config python@3.11
 
-If there are issues with an SSL header that is not found:
-   .. tab:: Intel
-
-      .. code-block:: bash
-
-         pushd /usr/local/include
-         ln -s ../opt/openssl/include/openssl .
-         popd
-
-   .. tab:: Apple Silicon
-
-      .. code-block:: bash
-
-         pushd /opt/homebrew/include
-         ln -s ../opt/openssl/include/openssl .
-         popd
-
 Build
 -----
 .. attention:: Ensure you are in the build directory created during the clone step earlier before continuing.


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add hints for finding openssl. This should solve the link errors than can occur on macOS for openssl.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #2482


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
