### PR TITLE
fix(brew): remove v prefix from version number

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -521,8 +521,10 @@ jobs:
             if [ "${{ matrix.release }}" == "true" ]; then
               # we will publish the formula with the release tag
               tag="${{ needs.setup_release.outputs.release_tag }}"
+              version="${{ needs.setup_release.outputs.release_version }}"
             else
               tag="${{ github.ref_name }}"
+              version="0.0.${{ github.run_number }}"
             fi
           else
             echo "This is a PR event"
@@ -531,6 +533,7 @@ jobs:
             branch="${{ github.event.pull_request.head.ref }}"
             default_branch="${{ github.event.pull_request.head.repo.default_branch }}"
             tag="${{ github.event.pull_request.head.ref }}"
+            version="0.0.${{ github.event.number }}"
           fi
           echo "Branch: ${branch}"
           echo "Clone URL: ${clone_url}"
@@ -540,6 +543,7 @@ jobs:
           cd build
           cmake \
             -DBUILD_VERSION="${build_version}" \
+            -DFORMULA_VERSION="${version}" \
             -DGITHUB_BRANCH="${branch}" \
             -DGITHUB_COMMIT="${commit}" \
             -DGITHUB_CLONE_URL="${clone_url}" \

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -5,7 +5,7 @@ class @PROJECT_NAME@ < Formula
   homepage "@PROJECT_HOMEPAGE_URL@"
   url "@GITHUB_CLONE_URL@",
     tag: "@GITHUB_TAG@"
-  version "@BUILD_VERSION@"
+  version "@FORMULA_VERSION@"
   license all_of: ["GPL-3.0-only"]
   head "@GITHUB_CLONE_URL@", branch: "@GITHUB_DEFAULT_BRANCH@"
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`version` in brew formula cannot have a `v` prefix.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
