### PR TITLE
fix(linux/input): battery values conversion

### DIFF
--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -258,7 +258,9 @@ namespace platf::gamepad {
           state = inputtino::PS5Joypad::BATTERY_FULL;
           break;
       }
-      std::get<inputtino::PS5Joypad>(*gamepad->joypad).set_battery(state, battery.percentage);
+      // Battery values in Moonlight are in the range [0, 0xFF (255)]
+      // Inputtino expects them as a percentage [0, 100]
+      std::get<inputtino::PS5Joypad>(*gamepad->joypad).set_battery(state, battery.percentage / 2.55);
     }
   }
 


### PR DESCRIPTION
## Description
A quick fix after this report https://github.com/LizardByte/Sunshine/pull/2606#issuecomment-2171961026

What is happening there is that the Moonlight Switch client doesn't support battery, in absence of a value the virtual pad state defaults to `0` which causes the pad to be seen with 0% battery.  

I've done two things:
 - set the default in inputtino to be `CHARGED`/`100%` so that we avoid annoying notifications for clients that don't report that value
 - adjusted the battery raw values, Moonlight sends them in the range `[0, 255]` whilst inputtino expects a percentage value `[0, 100]`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
