### PR TITLE
fix(macos): fix boost on macos

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -125,8 +125,8 @@ include_directories(
         "${CMAKE_SOURCE_DIR}/third-party/moonlight-common-c/enet/include"
         "${CMAKE_SOURCE_DIR}/third-party/nanors"
         "${CMAKE_SOURCE_DIR}/third-party/nanors/deps/obl"
-        ${Boost_INCLUDE_DIRS}
         ${FFMPEG_INCLUDE_DIRS}
+        ${Boost_INCLUDE_DIRS}  # has to be the last one or we runtime error on macOS ffmpeg encoder
 )
 
 list(APPEND SUNSHINE_EXTERNAL_LIBRARIES

--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -126,7 +126,7 @@ include_directories(
         "${CMAKE_SOURCE_DIR}/third-party/nanors"
         "${CMAKE_SOURCE_DIR}/third-party/nanors/deps/obl"
         ${FFMPEG_INCLUDE_DIRS}
-        ${Boost_INCLUDE_DIRS}  # has to be the last one or we runtime error on macOS ffmpeg encoder
+        ${Boost_INCLUDE_DIRS}  # has to be the last, or we get runtime error on macOS ffmpeg encoder
 )
 
 list(APPEND SUNSHINE_EXTERNAL_LIBRARIES

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -15,7 +15,11 @@ option(SUNSHINE_REQUIRE_TRAY "Require system tray icon. Fail the build if tray r
 
 option(SUNSHINE_SYSTEM_WAYLAND_PROTOCOLS "Use system installation of wayland-protocols rather than the submodule." OFF)
 
-option(BOOST_USE_STATIC "Use static boost libraries." ON)
+if(APPLE)
+    option(BOOST_USE_STATIC "Use static boost libraries." OFF)
+else()
+    option(BOOST_USE_STATIC "Use static boost libraries." ON)
+endif()
 
 option(CUDA_INHERIT_COMPILE_OPTIONS
         "When building CUDA code, inherit compile options from the the main project. You may want to disable this if

--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -46,7 +46,8 @@ depends_test             port:doxygen \
 
 configure.args           -DBUILD_WERROR=ON \
                          -DCMAKE_INSTALL_PREFIX=${prefix} \
-                         -DSUNSHINE_ASSETS_DIR=etc/sunshine/assets
+                         -DSUNSHINE_ASSETS_DIR=etc/sunshine/assets \
+                         -DBOOST_USE_STATIC=ON
 
 configure.env-append     BRANCH=@GITHUB_BRANCH@
 configure.env-append     BUILD_VERSION=@BUILD_VERSION@

--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -44,10 +44,10 @@ depends_lib              port:avahi \
 depends_test             port:doxygen \
                          port:graphviz
 
-configure.args           -DBUILD_WERROR=ON \
+configure.args           -DBOOST_USE_STATIC=ON \
+                         -DBUILD_WERROR=ON \
                          -DCMAKE_INSTALL_PREFIX=${prefix} \
-                         -DSUNSHINE_ASSETS_DIR=etc/sunshine/assets \
-                         -DBOOST_USE_STATIC=ON
+                         -DSUNSHINE_ASSETS_DIR=etc/sunshine/assets
 
 configure.env-append     BRANCH=@GITHUB_BRANCH@
 configure.env-append     BUILD_VERSION=@BUILD_VERSION@

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -21,17 +21,17 @@ class @PROJECT_NAME@ < Formula
     end
   end
 
-  option "without-dynamic-boost", "Statically link Boost libraries"  # default option
+  option "without-dynamic-boost", "Statically link Boost libraries" # default option
   option "with-dynamic-boost", "Dynamically link Boost libraries"
 
   depends_on "cmake" => :build
   depends_on "node" => :build
   depends_on "pkg-config" => :build
-  depends_on "icu4c" => :recommended
   depends_on "curl"
   depends_on "miniupnpc"
   depends_on "openssl"
   depends_on "opus"
+  depends_on "icu4c" => :recommended
 
   on_linux do
     depends_on "libcap"
@@ -80,9 +80,9 @@ class @PROJECT_NAME@ < Formula
         EOS
       end
       ENV.append "CXXFLAGS", "-I#{Formula["icu4c"].opt_include}"
-      icu4c_lib_path = "#{Formula["icu4c"].opt_lib}"
+      icu4c_lib_path = Formula["icu4c"].opt_lib.to_s
       ENV.append "LDFLAGS", "-L#{icu4c_lib_path}"
-      ENV["LIBRARY_PATH"] = "#{icu4c_lib_path}"
+      ENV["LIBRARY_PATH"] = icu4c_lib_path
       ohai "Linking against ICU libraries at: #{icu4c_lib_path}"
     else
       args << "-DBOOST_USE_STATIC=OFF"

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -21,9 +21,13 @@ class @PROJECT_NAME@ < Formula
     end
   end
 
+  option "without-dynamic-boost", "Statically link Boost libraries"  # default option
+  option "with-dynamic-boost", "Dynamically link Boost libraries"
+
   depends_on "cmake" => :build
   depends_on "node" => :build
   depends_on "pkg-config" => :build
+  depends_on "icu4c" => :recommended
   depends_on "curl"
   depends_on "miniupnpc"
   depends_on "openssl"
@@ -64,6 +68,27 @@ class @PROJECT_NAME@ < Formula
       -DSUNSHINE_ENABLE_TRAY=OFF
       -DTESTS_ENABLE_PYTHON_TESTS=OFF
     ]
+
+    if build.without? "dynamic-boost"
+      args << "-DBOOST_USE_STATIC=ON"
+      ohai "Statically linking Boost libraries"
+
+      unless Formula["icu4c"].any_version_installed?
+        odie <<~EOS
+          icu4c must be installed to link against static Boost libraries,
+          either install icu4c or use brew install sunshine --with-dynamic-boost instead
+        EOS
+      end
+      ENV.append "CXXFLAGS", "-I#{Formula["icu4c"].opt_include}"
+      icu4c_lib_path = "#{Formula["icu4c"].opt_lib}"
+      ENV.append "LDFLAGS", "-L#{icu4c_lib_path}"
+      ENV["LIBRARY_PATH"] = "#{icu4c_lib_path}"
+      ohai "Linking against ICU libraries at: #{icu4c_lib_path}"
+    else
+      args << "-DBOOST_USE_STATIC=OFF"
+      ohai "Dynamically linking Boost libraries"
+    end
+
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
 
     cd "build" do


### PR DESCRIPTION
## Description
macOS has some issues with Boost linking, this PR fixes the runtime error when statically linking boost, fixes the dynamic macOS build missing -licudata (icu4c) and improves brew installation options.

## Checklist
- [ ] Test macports installation
- [ ] Test brew installation
- [x] Test Clion build and run


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
