### PR TITLE
docs: use doxygen directly and drop breathe

### DIFF
--- a/.codeql-prebuild-cpp-Windows.sh
+++ b/.codeql-prebuild-cpp-Windows.sh
@@ -19,6 +19,7 @@ pacman -Syu --noconfirm --ignore=mingw-w64-ucrt-x86_64-curl \
   gcc \
   git \
   make \
+  mingw-w64-ucrt-x86_64-boost \
   mingw-w64-ucrt-x86_64-cmake \
   mingw-w64-ucrt-x86_64-cppwinrt \
   mingw-w64-ucrt-x86_64-graphviz \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -990,9 +990,11 @@ jobs:
 
           # install dependencies
           pacman -U --noconfirm mingw-w64-ucrt-x86_64-curl-8.8.0-1-any.pkg.tar.zst
-          pacman -Syu --noconfirm --ignore=mingw-w64-ucrt-x86_64-curl \
+          pacman -Syu --noconfirm \
+            --ignore=mingw-w64-ucrt-x86_64-curl \
             doxygen \
             git \
+            mingw-w64-ucrt-x86_64-boost \
             mingw-w64-ucrt-x86_64-cmake \
             mingw-w64-ucrt-x86_64-cppwinrt \
             mingw-w64-ucrt-x86_64-graphviz \

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 
 # Set the version of Python
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
   apt_packages:

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -61,13 +61,13 @@ PROJECT_BRIEF          = "Sunshine is a Gamestream host for Moonlight."
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = ../sunshine.png
+PROJECT_LOGO = ../sunshine.png
 
 # With the PROJECT_ICON tag one can specify an icon that is included in the tabs
 # when the HTML document is shown. Doxygen will copy the logo to the output
 # directory.
 
-PROJECT_ICON           =
+PROJECT_ICON = ../sunshine.ico
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -1328,7 +1328,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -1336,14 +1336,14 @@ GENERATE_HTML          = NO
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = doxyhtml
+HTML_OUTPUT = doxygen/doxyhtml
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).
 # The default value is: .html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FILE_EXTENSION    = .html
+HTML_FILE_EXTENSION     = .html
 
 # The HTML_HEADER tag can be used to specify a user-defined HTML header file for
 # each generated HTML page. If the tag is left blank doxygen will generate a
@@ -1426,7 +1426,7 @@ HTML_EXTRA_FILES       =
 # The default value is: AUTO_LIGHT.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE        = AUTO_LIGHT
+HTML_COLORSTYLE = TOGGLE
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
@@ -1553,7 +1553,7 @@ DOCSET_FEEDURL         =
 # The default value is: org.doxygen.Project.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_BUNDLE_ID = dev.lizardbyte.Sunshine
 
 # The DOCSET_PUBLISHER_ID tag specifies a string that should uniquely identify
 # the documentation publisher. This should be a reverse domain-name style
@@ -1561,13 +1561,13 @@ DOCSET_BUNDLE_ID       = org.doxygen.Project
 # The default value is: org.doxygen.Publisher.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_ID = dev.lizardbyte.Sunshine.documentation
 
 # The DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
 # The default value is: Publisher.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_PUBLISHER_NAME  = Publisher
+DOCSET_PUBLISHER_NAME = LizardByte
 
 # If the GENERATE_HTMLHELP tag is set to YES then doxygen generates three
 # additional HTML index files: index.hhp, index.hhc, and index.hhk. The
@@ -2278,7 +2278,9 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = YES
+# TODO: Sphinx/Breathe does not support Objective-C right now, so disable XML
+# https://github.com/breathe-doc/breathe/issues/129
+GENERATE_XML = NO
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2286,7 +2288,7 @@ GENERATE_XML           = YES
 # The default directory is: xml.
 # This tag requires that the tag GENERATE_XML is set to YES.
 
-XML_OUTPUT             = doxyxml
+XML_OUTPUT = doxygen/doxyxml
 
 # If the XML_PROGRAMLISTING tag is set to YES, doxygen will dump the program
 # listings (including syntax highlighting and cross-referencing information) to
@@ -2540,7 +2542,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = YES
+HAVE_DOT = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of
@@ -2550,7 +2552,8 @@ HAVE_DOT               = YES
 # Minimum value: 0, maximum value: 32, default value: 0.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_NUM_THREADS        = 0
+# TODO: On Windows, Doxygen hangs when creating dot graphs if this is set to 0
+DOT_NUM_THREADS = 1
 
 # DOT_COMMON_ATTR is common attributes for nodes, edges and labels of
 # subgraphs. When you want a differently looking font in the dot files that
@@ -2765,7 +2768,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.
@@ -2777,7 +2780,7 @@ DOT_IMAGE_FORMAT       = png
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INTERACTIVE_SVG        = NO
+INTERACTIVE_SVG = YES
 
 # The DOT_PATH tag can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-breathe==4.35.0
 furo==2024.5.6
 m2r2==0.3.3.post2
 rstcheck[sphinx]==6.2.1

--- a/docs/source/source_code/source_code.rst
+++ b/docs/source/source_code/source_code.rst
@@ -55,37 +55,12 @@ Example Documentation Blocks
 Source
 ------
 
-.. toctree::
-   :caption: src
-   :maxdepth: 1
-   :glob:
+Please refer to the `Doxygen Documentation <../doxyhtml/index.html>`_ for more details.
 
-   src/*
+.. todo:: Sphinx and Breathe do not support the Objective-C Domain.
+   See https://github.com/breathe-doc/breathe/issues/129
 
-.. toctree::
-   :caption: src/platform
-   :maxdepth: 1
-   :glob:
+.. .. doxygenindex::
+..    :allow-dot-graphs:
 
-   src/platform/*
-
-.. toctree::
-   :caption: src/platform/linux
-   :maxdepth: 1
-   :glob:
-
-   src/platform/linux/*
-
-.. toctree::
-   :caption: src/platform/macos
-   :maxdepth: 1
-   :glob:
-
-   src/platform/macos/*
-
-.. toctree::
-   :caption: src/platform/windows
-   :maxdepth: 1
-   :glob:
-
-   src/platform/windows/*
+.. Ideally, we would use `doxygenfile` with `:allow-dot-graphs:`, but sphinx complains about duplicated namespaces...

--- a/docs/source/source_code/src/audio.rst
+++ b/docs/source/source_code/src/audio.rst
@@ -1,5 +1,0 @@
-audio
-=====
-
-.. doxygenfile:: audio.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/cbs.rst
+++ b/docs/source/source_code/src/cbs.rst
@@ -1,5 +1,0 @@
-cbs
-===
-
-.. doxygenfile:: cbs.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/config.rst
+++ b/docs/source/source_code/src/config.rst
@@ -1,5 +1,0 @@
-config
-======
-
-.. doxygenfile:: config.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/confighttp.rst
+++ b/docs/source/source_code/src/confighttp.rst
@@ -1,5 +1,0 @@
-confighttp
-==========
-
-.. doxygenfile:: confighttp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/crypto.rst
+++ b/docs/source/source_code/src/crypto.rst
@@ -1,5 +1,0 @@
-crypto
-======
-
-.. doxygenfile:: crypto.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/entry_handler.rst
+++ b/docs/source/source_code/src/entry_handler.rst
@@ -1,5 +1,0 @@
-entry_handler
-=============
-
-.. doxygenfile:: entry_handler.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/file_handler.rst
+++ b/docs/source/source_code/src/file_handler.rst
@@ -1,5 +1,0 @@
-file_handler
-============
-
-.. doxygenfile:: file_handler.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/globals.rst
+++ b/docs/source/source_code/src/globals.rst
@@ -1,5 +1,0 @@
-globals
-=======
-
-.. doxygenfile:: globals.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/httpcommon.rst
+++ b/docs/source/source_code/src/httpcommon.rst
@@ -1,5 +1,0 @@
-httpcommon
-==========
-
-.. doxygenfile:: httpcommon.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/input.rst
+++ b/docs/source/source_code/src/input.rst
@@ -1,5 +1,0 @@
-input
-=====
-
-.. doxygenfile:: input.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/logging.rst
+++ b/docs/source/source_code/src/logging.rst
@@ -1,5 +1,0 @@
-logging
-=======
-
-.. doxygenfile:: logging.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/main.rst
+++ b/docs/source/source_code/src/main.rst
@@ -1,5 +1,0 @@
-main
-====
-
-.. doxygenfile:: main.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/move_by_copy.rst
+++ b/docs/source/source_code/src/move_by_copy.rst
@@ -1,5 +1,0 @@
-move_by_copy
-============
-
-.. doxygenfile:: move_by_copy.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/network.rst
+++ b/docs/source/source_code/src/network.rst
@@ -1,5 +1,0 @@
-network
-=======
-
-.. doxygenfile:: network.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/nvhttp.rst
+++ b/docs/source/source_code/src/nvhttp.rst
@@ -1,5 +1,0 @@
-nvhttp
-======
-
-.. doxygenfile:: nvhttp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/common.rst
+++ b/docs/source/source_code/src/platform/common.rst
@@ -1,4 +1,0 @@
-common
-======
-
-.. todo:: Add common.h

--- a/docs/source/source_code/src/platform/linux/cuda.rst
+++ b/docs/source/source_code/src/platform/linux/cuda.rst
@@ -1,5 +1,0 @@
-cuda
-====
-
-.. doxygenfile:: platform/linux/cuda.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/linux/graphics.rst
+++ b/docs/source/source_code/src/platform/linux/graphics.rst
@@ -1,4 +1,0 @@
-graphics
-========
-
-.. todo:: Add graphics.h

--- a/docs/source/source_code/src/platform/linux/misc.rst
+++ b/docs/source/source_code/src/platform/linux/misc.rst
@@ -1,4 +1,0 @@
-misc
-====
-
-.. todo:: Add misc.h

--- a/docs/source/source_code/src/platform/linux/vaapi.rst
+++ b/docs/source/source_code/src/platform/linux/vaapi.rst
@@ -1,5 +1,0 @@
-vaapi
-=====
-
-.. doxygenfile:: platform/linux/vaapi.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/linux/wayland.rst
+++ b/docs/source/source_code/src/platform/linux/wayland.rst
@@ -1,5 +1,0 @@
-wayland
-=======
-
-.. doxygenfile:: platform/linux/wayland.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/linux/x11grab.rst
+++ b/docs/source/source_code/src/platform/linux/x11grab.rst
@@ -1,4 +1,0 @@
-x11grab
-=======
-
-.. todo:: Add x11grab.h

--- a/docs/source/source_code/src/platform/macos/av_audio.rst
+++ b/docs/source/source_code/src/platform/macos/av_audio.rst
@@ -1,4 +1,0 @@
-av_audio
-========
-
-.. todo:: Add av_audio.h

--- a/docs/source/source_code/src/platform/macos/av_img_t.rst
+++ b/docs/source/source_code/src/platform/macos/av_img_t.rst
@@ -1,4 +1,0 @@
-av_img_t
-========
-
-.. todo:: Add av_img_t.h

--- a/docs/source/source_code/src/platform/macos/av_video.rst
+++ b/docs/source/source_code/src/platform/macos/av_video.rst
@@ -1,4 +1,0 @@
-av_video
-========
-
-.. todo:: Add av_video.h

--- a/docs/source/source_code/src/platform/macos/misc.rst
+++ b/docs/source/source_code/src/platform/macos/misc.rst
@@ -1,5 +1,0 @@
-misc
-====
-
-.. doxygenfile:: platform/macos/misc.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/platform/macos/nv12_zero_device.rst
+++ b/docs/source/source_code/src/platform/macos/nv12_zero_device.rst
@@ -1,4 +1,0 @@
-nv12_zero_device
-================
-
-.. todo:: Add nv12_zero_device.h

--- a/docs/source/source_code/src/platform/windows/PolicyConfig.rst
+++ b/docs/source/source_code/src/platform/windows/PolicyConfig.rst
@@ -1,4 +1,0 @@
-PolicyConfig
-============
-
-.. todo:: Add PolicyConfig.h

--- a/docs/source/source_code/src/platform/windows/display.rst
+++ b/docs/source/source_code/src/platform/windows/display.rst
@@ -1,4 +1,0 @@
-display
-=======
-
-.. todo:: Add display.h

--- a/docs/source/source_code/src/platform/windows/misc.rst
+++ b/docs/source/source_code/src/platform/windows/misc.rst
@@ -1,5 +1,0 @@
-misc
-====
-
-.. doxygenfile:: platform/windows/misc.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/process.rst
+++ b/docs/source/source_code/src/process.rst
@@ -1,5 +1,0 @@
-process
-=======
-
-.. doxygenfile:: process.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/round_robin.rst
+++ b/docs/source/source_code/src/round_robin.rst
@@ -1,5 +1,0 @@
-round_robin
-===========
-
-.. doxygenfile:: round_robin.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/rtsp.rst
+++ b/docs/source/source_code/src/rtsp.rst
@@ -1,5 +1,0 @@
-rtsp
-====
-
-.. doxygenfile:: rtsp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/stream.rst
+++ b/docs/source/source_code/src/stream.rst
@@ -1,5 +1,0 @@
-stream
-======
-
-.. doxygenfile:: stream.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/sync.rst
+++ b/docs/source/source_code/src/sync.rst
@@ -1,5 +1,0 @@
-sync
-====
-
-.. doxygenfile:: sync.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/system_tray.rst
+++ b/docs/source/source_code/src/system_tray.rst
@@ -1,5 +1,0 @@
-system_tray
-===========
-
-.. doxygenfile:: system_tray.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/task_pool.rst
+++ b/docs/source/source_code/src/task_pool.rst
@@ -1,5 +1,0 @@
-task_pool
-=========
-
-.. doxygenfile:: task_pool.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/thread_pool.rst
+++ b/docs/source/source_code/src/thread_pool.rst
@@ -1,5 +1,0 @@
-thread_pool
-===========
-
-.. doxygenfile:: thread_pool.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/thread_safe.rst
+++ b/docs/source/source_code/src/thread_safe.rst
@@ -1,5 +1,0 @@
-thread_safe
-===========
-
-.. doxygenfile:: thread_safe.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/upnp.rst
+++ b/docs/source/source_code/src/upnp.rst
@@ -1,5 +1,0 @@
-upnp
-====
-
-.. doxygenfile:: upnp.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/utility.rst
+++ b/docs/source/source_code/src/utility.rst
@@ -1,4 +1,0 @@
-utility
-=======
-
-.. todo:: Add utility.h

--- a/docs/source/source_code/src/uuid.rst
+++ b/docs/source/source_code/src/uuid.rst
@@ -1,5 +1,0 @@
-uuid
-====
-
-.. doxygenfile:: uuid.h
-   :allow-dot-graphs:

--- a/docs/source/source_code/src/video.rst
+++ b/docs/source/source_code/src/video.rst
@@ -1,5 +1,0 @@
-video
-=====
-
-.. doxygenfile:: video.h
-   :allow-dot-graphs:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Breathe does no support Objective-C and I am tired of fighting it. This PR will use Doxygen for source code documentation instead of Breathe. While it may not be as pretty, it will be sufficient.

Also, Windows builds will revert to installed boost instead of fetched to improve build times. The codeql build was especially slow.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Closes #2726 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
