### PR TITLE
fix(upnp): Support miniupnpc API version 18 (release 2.2.8)

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -109,7 +109,11 @@ namespace upnp {
       IGDdatas data;
       urls_t urls;
       std::array<char, INET6_ADDRESS_STRLEN> lan_addr;
+#if (MINIUPNPC_API_VERSION >= 18)
+      auto status = UPNP_GetValidIGD(device.get(), &urls.el, &data, lan_addr.data(), lan_addr.size(), nullptr, 0);
+#else
       auto status = UPNP_GetValidIGD(device.get(), &urls.el, &data, lan_addr.data(), lan_addr.size());
+#endif
       if (status != 1 && status != 2) {
         BOOST_LOG(debug) << "No valid IPv6 IGD: "sv << status_string(status);
         return false;
@@ -331,7 +335,11 @@ namespace upnp {
         std::array<char, INET6_ADDRESS_STRLEN> lan_addr;
 
         urls_t urls;
+#if (MINIUPNPC_API_VERSION >= 18)
+        auto status = UPNP_GetValidIGD(device.get(), &urls.el, &data, lan_addr.data(), lan_addr.size(), nullptr, 0);
+#else
         auto status = UPNP_GetValidIGD(device.get(), &urls.el, &data, lan_addr.data(), lan_addr.size());
+#endif
         if (status != 1 && status != 2) {
           BOOST_LOG(error) << status_string(status);
           mapped = false;


### PR DESCRIPTION
## Description
The miniupnpc API has changed slightly. This allows both older and newer versions. The additional arguments are for returning data that Sunshine doesn't need to care about, so `nullptr, 0` is sufficient. I have already made the same change to a couple of other projects.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
