### PR TITLE
build(docs): use patterns to locate python venv interpreter

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -35,17 +35,28 @@ execute_process(
     RESULT_VARIABLE VENV_RESULT
 )
 
-# set Python3_EXECUTABLE to the python interpreter in the venv
-if(WIN32)
-    set(Python3_EXECUTABLE "${VENV_DIR}/Scripts/python.exe")  # cmake-lint: disable=C0103
-    set(Python3_ROOT_DIR "${VENV_DIR}/Scripts")  # cmake-lint: disable=C0103
-else()
-    set(Python3_EXECUTABLE "${VENV_DIR}/bin/python")  # cmake-lint: disable=C0103
-    set(Python3_ROOT_DIR "${VENV_DIR}/bin")  # cmake-lint: disable=C0103
-endif()
+unset(Python3_EXECUTABLE)
 
-# print path
-message(STATUS "Python3_EXECUTABLE: ${Python3_EXECUTABLE}")
+set(VENV_PATTERNS
+        ${VENV_DIR}/bin/python
+        ${VENV_DIR}/Scripts/python.exe
+)
+
+# set Python3_EXECUTABLE to the python interpreter in the venv
+foreach(pattern ${VENV_PATTERNS})
+    if(EXISTS ${pattern})
+        set(Python3_EXECUTABLE "${pattern}")  # cmake-lint: disable=C0103
+        get_filename_component(Python3_ROOT_DIR ${pattern} DIRECTORY)
+        message(STATUS "Using Python3_EXECUTABLE (venv): ${Python3_EXECUTABLE}")
+        message(STATUS "Using Python3_ROOT_DIR (venv): ${Python3_ROOT_DIR}")
+        break()
+    endif()
+endforeach()
+
+# fail if Python3_ROOT_DIR is not set
+if(NOT DEFINED Python3_EXECUTABLE)
+    message(FATAL_ERROR "Unable to setup python venv")
+endif()
 
 # call a simple python command
 execute_process(


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Locate the venv interpreter instead of assuming it's location based on the OS.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
