### PR TITLE
docs(doxygen): disable html copy clipboard

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -54,6 +54,7 @@ GENERATE_XML = NO
 
 HAVE_DOT = YES
 HTML_COLORSTYLE = LIGHT  # required with Doxygen >= 1.9.5
+HTML_COPY_CLIPBOARD = NO  # required for Doxygen >= 1.10.0
 HTML_EXTRA_FILES = ../third-party/doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js
 HTML_EXTRA_FILES += ../third-party/doxygen-awesome-css/doxygen-awesome-fragment-copy-button.js
 HTML_EXTRA_FILES += ../third-party/doxygen-awesome-css/doxygen-awesome-paragraph-link.js


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This is required for Doxygen >= 1.10.0, although it doesn't affect us because we have a custom `header.html` where the copy clipboard functionality was removed altogether, in favor of doxygen-awesome-css' clipboard feature.

See: https://github.com/LizardByte/Sunshine/pull/2765


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
