### PR TITLE
Bump MAX_FEC_BLOCKS to 4

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1340,9 +1340,9 @@ namespace stream {
       // it will generate greater than DATA_SHARDS_MAX shards.
       // Therefore, we start breaking the data up into three separate fec blocks.
       auto multi_fec_threshold = 90 * blocksize;
-
-      // We can go up to 4 fec blocks, but 3 is plenty
-      constexpr auto MAX_FEC_BLOCKS = 3;
+      
+      // We can go up to 4 fec blocks
+      constexpr auto MAX_FEC_BLOCKS = 4;
 
       std::array<std::string_view, MAX_FEC_BLOCKS> fec_blocks;
       decltype(fec_blocks)::iterator
@@ -1357,12 +1357,12 @@ namespace stream {
         auto unaligned_size = payload.size() / MAX_FEC_BLOCKS;
         auto aligned_size = ((unaligned_size + (blocksize - 1)) / blocksize) * blocksize;
 
-        // Break the data up into 3 blocks, each containing multiple complete video packets.
-        fec_blocks[0] = payload.substr(0, aligned_size);
-        fec_blocks[1] = payload.substr(aligned_size, aligned_size);
-        fec_blocks[2] = payload.substr(aligned_size * 2);
+        // Break the data up into blocks, each containing multiple complete video packets.
+        for (int x = 0; x < MAX_FEC_BLOCKS; ++x) {
+            fec_blocks[x] = payload.substr(aligned_size*x, aligned_size);
+        }
 
-        lastBlockIndex = 2 << 6;
+        lastBlockIndex = (MAX_FEC_BLOCKS - 1) << 6;
         fec_blocks_end = std::end(fec_blocks);
       }
       else {


### PR DESCRIPTION
## Description

Sunshine implementation arbitrarily limits itself to 3 FEC blocks even though the protocol supports 4. This is fine for typical use cases. However, when dealing with large payloads (low FPS, high bitrate), there is a risk that the resulting packet size exceeds the capability of the error correction code.

This change removes magic constants to make full use of the of the error correcting bandwidth defined by the protocol and supported by Moonlight.

- Mitigates #1040 and similar issues

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
