### PR TITLE
build(docs): disable rst check pretty tracebacks

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -88,7 +88,8 @@ set(RST_PATTERNS
 foreach(pattern ${RST_PATTERNS})
     message(STATUS "Checking RST files: ${pattern}")
     execute_process(
-        COMMAND "${Python3_ROOT_DIR}/rstcheck" -r "${pattern}"
+        # run rstcheck and disable pretty traceback
+        COMMAND ${CMAKE_COMMAND} -E env _TYPER_STANDARD_TRACEBACK=1 "${Python3_ROOT_DIR}/rstcheck" -r "${pattern}"
         COMMAND_ERROR_IS_FATAL ANY
         RESULT_VARIABLE RST_RESULT
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Disable pretty python tracebacks when running rstcheck, per https://github.com/rstcheck/rstcheck-core/issues/99#issuecomment-2212483499


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
