### PR TITLE
build(linux): drop support for AUR

### DIFF
--- a/docker/archlinux.dockerfile
+++ b/docker/archlinux.dockerfile
@@ -81,7 +81,16 @@ WORKDIR /build/sunshine/pkg
 RUN mv /build/sunshine/build/PKGBUILD .
 RUN mv /build/sunshine/build/sunshine.install .
 
+# create a PKGBUILD archive
+USER root
+RUN <<_REPO
+#!/bin/bash
+set -e
+tar -czf /build/sunshine/sunshine.pkg.tar.gz .
+_REPO
+
 # namcap and build PKGBUILD file
+USER builder
 RUN <<_PKGBUILD
 #!/bin/bash
 set -e
@@ -96,6 +105,7 @@ _PKGBUILD
 FROM scratch as artifacts
 
 COPY --link --from=sunshine-build /build/sunshine/pkg/sunshine*.pkg.tar.zst /sunshine.pkg.tar.zst
+COPY --link --from=sunshine-build /build/sunshine/sunshine.pkg.tar.gz /sunshine.pkg.tar.gz
 
 FROM sunshine-base as sunshine
 

--- a/docs/source/about/setup.rst
+++ b/docs/source/about/setup.rst
@@ -93,17 +93,42 @@ Install
 
    .. tab:: Arch Linux Package
 
-      #. Open terminal and run the following code.
+      .. warning:: We do not provide support for any AUR packages.
 
-         .. code-block:: bash
+      .. tab:: Prebuilt Package
 
-            wget https://github.com/LizardByte/Sunshine/releases/latest/download/sunshine.pkg.tar.zst
-            pacman -U --noconfirm sunshine.pkg.tar.zst
+         #. Open terminal and run the following code.
 
-      Uninstall:
-         .. code-block:: bash
+            .. code-block:: bash
 
-            pacman -R sunshine
+               wget https://github.com/LizardByte/Sunshine/releases/latest/download/sunshine.pkg.tar.zst
+               pacman -U --noconfirm sunshine.pkg.tar.zst
+
+         Uninstall:
+            .. code-block:: bash
+
+               pacman -R sunshine
+
+      .. tab:: PKGBUILD Archive
+
+         #. Open terminal and run the following code.
+
+            .. code-block:: bash
+
+               wget https://github.com/LizardByte/Sunshine/releases/latest/download/sunshine.pkg.tar.gz
+               tar -xvf sunshine.pkg.tar.gz
+               cd sunshine
+
+               # install optional dependencies
+               pacman -S cuda  # Nvidia GPU encoding support
+               pacman -S libva-mesa-driver  # AMD GPU encoding support
+
+               makepkg -si
+
+         Uninstall:
+            .. code-block:: bash
+
+               pacman -R sunshine
 
    .. tab:: Debian/Ubuntu Package
 
@@ -261,15 +286,15 @@ Install
             .. table::
                :widths: auto
 
-               ========   ==============================================   ===============
-               package    ExecStart                                        Auto Configured
-               ========   ==============================================   ===============
-               aur        /usr/bin/sunshine                                ✔
-               deb        /usr/bin/sunshine                                ✔
-               rpm        /usr/bin/sunshine                                ✔
-               AppImage   ~/sunshine.AppImage                              ✔
-               Flatpak    flatpak run dev.lizardbyte.app.Sunshine          ✔
-               ========   ==============================================   ===============
+               =========   ==============================================   ===============
+               package     ExecStart                                        Auto Configured
+               =========   ==============================================   ===============
+               ArchLinux   /usr/bin/sunshine                                ✔
+               deb         /usr/bin/sunshine                                ✔
+               rpm         /usr/bin/sunshine                                ✔
+               AppImage    ~/sunshine.AppImage                              ✔
+               Flatpak     flatpak run dev.lizardbyte.app.Sunshine          ✔
+               =========   ==============================================   ===============
 
       **Start once**
             .. code-block:: bash

--- a/docs/source/about/third_party_packages.rst
+++ b/docs/source/about/third_party_packages.rst
@@ -3,13 +3,6 @@ Third Party Packages
 
 .. danger:: These packages are not maintained by LizardByte. Use at your own risk.
 
-AUR
----
-
-.. image:: https://img.shields.io/badge/dynamic/json.svg?color=blue&label=AUR&style=for-the-badge&query=$.results.0.Version&url=https%3A%2F%2Fapp.lizardbyte.dev%2Funo%2Faur%2Fsunshine.json&logo=archlinux
-   :alt: AUR
-   :target: https://aur.archlinux.org/packages/sunshine
-
 Chocolatey
 ----------
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Dropping support for ArchLinux AUR as I am not willing to constantly battle people like `@xiota`, `@dr460nf1r3`. No bug reports will be accepted from users using any AUR package.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
