### PR TITLE
fix(linux/input): don't pass unknown battery values

### DIFF
--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -261,10 +261,12 @@ namespace platf::gamepad {
         case LI_BATTERY_STATE_FULL:
           state = inputtino::PS5Joypad::BATTERY_FULL;
           break;
+        case LI_BATTERY_STATE_UNKNOWN:
+          return;
       }
-      // Battery values in Moonlight are in the range [0, 0xFF (255)]
-      // Inputtino expects them as a percentage [0, 100]
-      std::get<inputtino::PS5Joypad>(*gamepad->joypad).set_battery(state, battery.percentage / 2.55);
+      if (battery.percentage != LI_BATTERY_PERCENTAGE_UNKNOWN) {
+        std::get<inputtino::PS5Joypad>(*gamepad->joypad).set_battery(state, battery.percentage);
+      }
     }
   }
 

--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -248,9 +248,9 @@ namespace platf::gamepad {
     if (!gamepad) {
       return;
     }
-    // Only the PS5 controller supports motion
+    // Only the PS5 controller supports battery reports
     if (std::holds_alternative<inputtino::PS5Joypad>(*gamepad->joypad)) {
-      inputtino::PS5Joypad::BATTERY_STATE state = inputtino::PS5Joypad::CHARGHING_ERROR;
+      inputtino::PS5Joypad::BATTERY_STATE state;
       switch (battery.state) {
         case LI_BATTERY_STATE_CHARGING:
           state = inputtino::PS5Joypad::BATTERY_CHARGHING;
@@ -262,6 +262,8 @@ namespace platf::gamepad {
           state = inputtino::PS5Joypad::BATTERY_FULL;
           break;
         case LI_BATTERY_STATE_UNKNOWN:
+        case LI_BATTERY_STATE_NOT_PRESENT:
+        default:
           return;
       }
       if (battery.percentage != LI_BATTERY_PERCENTAGE_UNKNOWN) {


### PR DESCRIPTION
## Description
The `battery.percentage` value is a real percentage (`0..100`), but it has a special value of `LI_BATTERY_PERCENTAGE_UNKNOWN` (0xFF) to indicate the percentage is unknown. We shouldn't pass this value or the `LI_BATTERY_STATE_UNKNOWN` status into `inputino`.

cc: @ABeltramo 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #2715
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
