### PR TITLE
Check API before trying to disable border on WGC capture

### DIFF
--- a/src/platform/windows/display_wgc.cpp
+++ b/src/platform/windows/display_wgc.cpp
@@ -11,6 +11,7 @@
 
 #include <windows.graphics.capture.interop.h>
 #include <winrt/windows.foundation.h>
+#include <winrt/windows.foundation.metadata.h>
 #include <winrt/windows.graphics.directx.direct3d11.h>
 
 namespace platf {
@@ -19,6 +20,7 @@ namespace platf {
 
 namespace winrt {
   using namespace Windows::Foundation;
+  using namespace Windows::Foundation::Metadata;
   using namespace Windows::Graphics::Capture;
   using namespace Windows::Graphics::DirectX::Direct3D11;
 
@@ -120,7 +122,12 @@ namespace platf::dxgi {
       return -1;
     }
     try {
-      capture_session.IsBorderRequired(false);
+      if (winrt::ApiInformation::IsPropertyPresent(L"Windows.Graphics.Capture.GraphicsCaptureSession", L"IsBorderRequired")) {
+        capture_session.IsBorderRequired(false);
+      }
+      else {
+        BOOST_LOG(warning) << "Can't disable colored border around capture area on this version of Windows";
+      }
     }
     catch (winrt::hresult_error &e) {
       BOOST_LOG(warning) << "Screen capture may not be fully supported on this device for this release of Windows: failed to disable border around capture area: [0x"sv << util::hex(e.code()).to_string_view() << ']';


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

Using the new WGC capture method on Windows 10 currently causes a segmentation fault.
This should resolve it.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
