### PR TITLE
build(archlinux): generate srcinfo file during build

### DIFF
--- a/docker/archlinux.dockerfile
+++ b/docker/archlinux.dockerfile
@@ -3,7 +3,7 @@
 # platforms: linux/amd64
 # archlinux does not have an arm64 base image
 # no-cache-filters: artifacts,sunshine
-ARG BASE=archlinux
+ARG BASE=archlinux/archlinux
 ARG TAG=base-devel
 FROM ${BASE}:${TAG} AS sunshine-base
 
@@ -13,6 +13,7 @@ RUN <<_DEPS
 set -e
 pacman -Syu --disable-download-timeout --needed --noconfirm \
   archlinux-keyring
+pacman -Scc --noconfirm
 _DEPS
 
 # Setup builder user, arch prevents running makepkg as root
@@ -45,6 +46,7 @@ pacman -Syu --disable-download-timeout --needed --noconfirm \
   git \
   namcap \
   xorg-server-xvfb
+pacman -Scc --noconfirm
 _DEPS
 
 # Setup builder user
@@ -80,6 +82,7 @@ _MAKE
 WORKDIR /build/sunshine/pkg
 RUN mv /build/sunshine/build/PKGBUILD .
 RUN mv /build/sunshine/build/sunshine.install .
+RUN makepkg --printsrcinfo > .SRCINFO
 
 # create a PKGBUILD archive
 USER root
@@ -121,6 +124,7 @@ pacman -Syu --disable-download-timeout --needed --noconfirm \
   archlinux-keyring
 pacman -U --disable-download-timeout --needed --noconfirm \
   /sunshine.pkg.tar.zst
+pacman -Scc --noconfirm
 _INSTALL_SUNSHINE
 
 # network setup

--- a/docs/source/about/setup.rst
+++ b/docs/source/about/setup.rst
@@ -97,12 +97,12 @@ Install
 
       .. tab:: Prebuilt Package
 
-         #. Open terminal and run the following code.
+         #. Follow the instructions at LizardByte's `pacman-repo <https://github.com/LizardByte/pacman-repo>`__ to add
+            the repository. Then run the following code.
 
             .. code-block:: bash
 
-               wget https://github.com/LizardByte/Sunshine/releases/latest/download/sunshine.pkg.tar.zst
-               pacman -U --noconfirm sunshine.pkg.tar.zst
+               pacman -S sunshine
 
          Uninstall:
             .. code-block:: bash


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Generate a .SRCINFO file when building Arch package.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
