### PR TITLE
 fix(linux/input): handle pen EVENT_MOVE events 

### DIFF
--- a/src/platform/linux/input/inputtino_pen.cpp
+++ b/src/platform/linux/input/inputtino_pen.cpp
@@ -61,11 +61,13 @@ namespace platf::pen {
         tilt_y = std::atan2(std::cos(-rotation_rads) * r, z) * 180.f / M_PI;
       }
 
+      bool is_touching = pen.eventType == LI_TOUCH_EVENT_DOWN || pen.eventType == LI_TOUCH_EVENT_MOVE;
+
       (*raw->pen).place_tool(tool,
         pen.x,
         pen.y,
-        pen.eventType == LI_TOUCH_EVENT_DOWN ? pen.pressureOrDistance : -1,
-        pen.eventType == LI_TOUCH_EVENT_HOVER ? pen.pressureOrDistance : -1,
+        is_touching ? pen.pressureOrDistance : -1,
+        is_touching ? -1 : pen.pressureOrDistance,
         tilt_x,
         tilt_y);
     }


### PR DESCRIPTION
## Description
Currently, pen input is unusable on linux, because of the following issues, as per #2756 

- No pressure sensitivity while using the pen
- Pen doesn't release when hovering after the first touch

This is caused by the fact that EVENT_MOVE events are considered to not touch the screen, which is not the case.

### Issues Fixed or Closed
- Fixes #2756 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
