### PR TITLE
Escape backslashes in javascript string

### DIFF
--- a/src_assets/common/assets/web/configs/tabs/audiovideo/LegacyDisplayOutputSelector.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/LegacyDisplayOutputSelector.vue
@@ -9,7 +9,7 @@ const props = defineProps([
 ])
 
 const config = ref(props.config)
-const outputNamePlaceholder = (props.platform === 'windows') ? '\\.\DISPLAY1' : '0'
+const outputNamePlaceholder = (props.platform === 'windows') ? '\\\\.\\DISPLAY1' : '0'
 </script>
 
 <template>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Backslashes were not escaped which caused default value hint for captured display to be incorrect.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
![2024-07-15 10_27_47-Window](https://github.com/user-attachments/assets/3ba2d479-679e-404f-b5c9-1ccb2a31f195)
![2024-07-15 10_23_31-Window](https://github.com/user-attachments/assets/a91c97f2-7410-4288-acf1-719502beb103)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
