### PR TITLE
feat: use output/display names for wlgrab

### DIFF
--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -50,13 +50,32 @@ namespace wl {
         return -1;
       }
 
+      // load output names, to allow matching by name
+      for (auto &monitor : interface.monitors) {
+        monitor->listen(interface.output_manager);
+      }
+
+      display.roundtrip();
+
       auto monitor = interface.monitors[0].get();
 
       if (!display_name.empty()) {
-        auto streamedMonitor = util::from_view(display_name);
-
-        if (streamedMonitor >= 0 && streamedMonitor < interface.monitors.size()) {
-          monitor = interface.monitors[streamedMonitor].get();
+        // if display_name is numeric, match a display number
+        if (display_name.find_first_not_of("0123456789") == std::string::npos) {
+          auto streamedMonitor = util::from_view(display_name);
+          if (streamedMonitor >= 0 && streamedMonitor < interface.monitors.size()) {
+            monitor = interface.monitors[streamedMonitor].get();
+          }
+        }
+        // otherwise, match a display name
+        else {
+          for (auto &candidate : interface.monitors) {
+            auto candidateMonitor = candidate.get();
+            if (candidateMonitor->name == display_name) {
+              monitor = candidateMonitor;
+              break;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
TL;DR: This is a proof-of-concept PR for supporting using output names with the Wayland grabber, instead of arbitrarily-generated numeric ID as it is currently the standard in Sunshine.

Long version:

Currently, output IDs are assigned following this logic:

- get_registry() is called on the Wayland display, which causes the server to enumerate all global objects including wl_output objects (https://github.com/LizardByte/Sunshine/blob/eafb47238d92663851d264717f56609ffe92fdb9/src/platform/linux/wlgrab.cpp#L39)
- while receiving the responses, the callback (https://github.com/LizardByte/Sunshine/blob/1dd4b68e1cafbf134dd524cb7b7e1dbdfe686238/src/platform/linux/wayland.cpp#L175) singles out wl_output objects and saves the screen to an `std::vector`, implicitly assigning them numeric IDs in whatever order the Wayland server enumerates the objects

This is nondeterministic in two different ways:
- There is no guarantee that a Wayland server reuses the same objects IDs and enumeration order for two different clients (i.e. might be unstable across Sunshine restarts)
- There is no guarantee that across system reboots the Wayland server will enumerate outputs in the same order

This commit introduces support for indicating a [`wl_output`](https://wayland.app/protocols/wayland#wl_output)/[`zxdg_output_v1`](https://wayland.app/protocols/xdg-output-unstable-v1) (e.g. `eDP-1`, `HDMI-0` for wlroots based compositors) screen name in the `output_name` Sunshine parameter. I think this improves the above situation in the following ways:

- These names are explicitly specified in the interfaces to be stable within a Wayland session. While this is not as good as being stable across reboots (even though at a practical level this is also usually true, as these names are also used in compositor configuration files), at least it allows to reconfigure Sunshine on-the-fly before starting it, by updating its configuration file in a compositor-dependent manner if necessary.
- These same names are, in all Wayland compositors I have tried, the actual user-facing output names that are used in the tools. Thus, this allows users to configure Sunshine using the same output IDs that they use within other Wayland tools (e.g. wlr-randr, wf-recorder, compositor output configuration, etc), improving usability.
- At the same time, this PR retains compatibility with the previously-employed numeric IDs.

**Please note that this PR is a proof of concept**, mainly to kickstart a conversation on the feature. If the feature is deemed desirable, before merging it, some improvements that can be made to this PR are:
- The instructions on the web GUI should be updated to reflect this feature
- The documentation should report this feature
- It should be evaluated whether this is possible/feasible/desirable for other grabbers as well
- It should be evaluated whether to require using a prefix to indicate an output name instead of a numeric ID, as theoretically a numeric ID is also a valid Wayland output name (although I have never seen one which is entirely numeric)

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
(not relevant)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
This is somewhat related to #2490.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
