### PR TITLE
fix: remove logging::bracket "*_view" overloads

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -172,22 +172,12 @@ namespace logging {
 
   std::string
   bracket(const std::string &input) {
-    return bracket(std::string_view(input));
-  }
-
-  std::string
-  bracket(const std::string_view &input) {
-    return "["s + std::string(input) + "]"s;
+    return "["s + input + "]"s;
   }
 
   std::wstring
   bracket(const std::wstring &input) {
-    return bracket(std::wstring_view(input));
-  }
-
-  std::wstring
-  bracket(const std::wstring_view &input) {
-    return L"["s + std::wstring(input) + L"]"s;
+    return L"["s + input + L"]"s;
   }
 
 }  // namespace logging

--- a/src/logging.h
+++ b/src/logging.h
@@ -217,23 +217,7 @@ namespace logging {
    * @param input Input string.
    * @return Enclosed string.
    */
-  std::string
-  bracket(const std::string_view &input);
-
-  /**
-   * @brief Enclose string in square brackets.
-   * @param input Input string.
-   * @return Enclosed string.
-   */
   std::wstring
   bracket(const std::wstring &input);
-
-  /**
-   * @brief Enclose string in square brackets.
-   * @param input Input string.
-   * @return Enclosed string.
-   */
-  std::wstring
-  bracket(const std::wstring_view &input);
 
 }  // namespace logging


### PR DESCRIPTION
## Description
For some reason, sometimes it could cause compiler issues:
https://github.com/LizardByte/Sunshine/actions/runs/10107693224/job/27952073497

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
