### PR TITLE
build(linux): disable GCC 12 Wrestrict warning

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -6,12 +6,19 @@ list(APPEND SUNSHINE_COMPILE_OPTIONS -Wall -Wno-sign-compare)
 # Werror - treat warnings as errors
 # Wno-maybe-uninitialized/Wno-uninitialized - disable warnings for maybe uninitialized variables
 # Wno-sign-compare - disable warnings for signed/unsigned comparisons
+# Wno-restrict - disable warnings for memory overlap
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # GCC specific compile options
 
     # GCC 12 and higher will complain about maybe-uninitialized
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
         list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-maybe-uninitialized)
+
+        # Disable the bogus warning that may prevent compilation (only for GCC 12).
+        # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651.
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
+            list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-restrict)
+        endif()
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # Clang specific compile options


### PR DESCRIPTION
## Description
This is an actual "fix" for https://github.com/LizardByte/Sunshine/pull/2919 and other places where the warning cannot be resolved easily (https://github.com/FrogTheFrog/Sunshine/actions/runs/10126414768/job/28003050801).

There is a bug for GCC 12 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651) which unfortunately is used by flatpak.
Since we are treating all warnings as errors, such a bogus warning will prevent Sunshine from compiling. In some cases it is impossible to avoid this warning as it happens somewhere outside of Sunshine's code, like GTest:
```
test_sunshine.dir/unit/test_display_device.cpp.o -c /run/build/sunshine/tests/unit/test_display_device.cpp
In file included from /usr/include/c++/12.2.0/string:40,
                 from /usr/include/c++/12.2.0/bitset:47,
                 from /run/build/sunshine/src/config.h:7,
                 from /run/build/sunshine/tests/unit/test_display_device.cpp:5:
In static member function ‘static constexpr std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)’,
    inlined from ‘static constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:423:21,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.tcc:532:22,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:2171:19,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::replace(size_type, size_type, const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:2196:22,
    inlined from ‘std::string testing::internal::CanonicalizeForStdLibVersioning(std::string)’ at /run/build/sunshine/third-party/googletest/googletest/include/gtest/internal/gtest-type-util.h:83:14:
/usr/include/c++/12.2.0/bits/char_traits.h:431:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets [2, 9223372036854775807] and 1 may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

In this case, GTest is calling `CanonicalizeForStdLibVersioning` to pretty print a type name. Even if the function would never reach the "bad code" branch, it still produces a warning and there is no way around it.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
