### PR TITLE
build(linux): add common build script

### DIFF
--- a/.codeql-prebuild-cpp-Linux.sh
+++ b/.codeql-prebuild-cpp-Linux.sh
@@ -1,76 +1,11 @@
 # install dependencies for C++ analysis
 set -e
 
-CUDA_VERSION=11.8.0
-CUDA_BUILD=520.61.05
-
-# install wget and cuda first
-sudo apt-get update -y
-sudo apt-get install -y \
-  wget
-
-# Install CUDA
-url_base="https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/local_installers"
-url="${url_base}/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux.run"
-sudo wget -q -O /root/cuda.run ${url}
-sudo chmod a+x /root/cuda.run
-sudo /root/cuda.run --silent --toolkit --toolkitpath=/usr/local/cuda --no-opengl-libs --no-man-page --no-drm
-sudo rm /root/cuda.run
-
-# Install dependencies
-sudo apt-get install -y \
-  build-essential \
-  gcc-10 \
-  g++-10 \
-  libayatana-appindicator3-dev \
-  libavdevice-dev \
-  libcap-dev \
-  libcurl4-openssl-dev \
-  libdrm-dev \
-  libevdev-dev \
-  libminiupnpc-dev \
-  libmfx-dev \
-  libnotify-dev \
-  libnuma-dev \
-  libopus-dev \
-  libpulse-dev \
-  libssl-dev \
-  libva-dev \
-  libvdpau-dev \
-  libwayland-dev \
-  libx11-dev \
-  libxcb-shm0-dev \
-  libxcb-xfixes0-dev \
-  libxcb1-dev \
-  libxfixes-dev \
-  libxrandr-dev \
-  libxtst-dev
-
-# clean apt cache
-sudo apt-get clean
-sudo rm -rf /var/lib/apt/lists/*
-
-# Update gcc alias
-# https://stackoverflow.com/a/70653945/11214013
-sudo update-alternatives --install \
-  /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-  --slave /usr/bin/g++ g++ /usr/bin/g++-10 \
-  --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
-  --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-  --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10
-
-# build
-mkdir -p build
-cd build || exit 1
-cmake \
-  -DBUILD_DOCS=OFF \
-  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
-  -G "Unix Makefiles" \
-  ..
-make -j"$(nproc)"
+chmod +x ./scripts/linux_build.sh
+./scripts/linux_build.sh --skip-package --ubuntu-test-repo
 
 # Delete CUDA
-sudo rm -rf /usr/local/cuda
+rm -rf ./build/cuda
 
 # skip autobuild
 echo "skip_autobuild=true" >> "$GITHUB_OUTPUT"

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,9 @@ scripts/
 tools/
 crowdin.yml
 
+# don't ignore linux build script
+!scripts/linux_build.sh
+
 # ignore dev directories
 build/
 cmake-*/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -257,7 +257,7 @@ jobs:
       matrix:
         include:  # package these differently
           - type: AppImage
-            EXTRA_ARGS: '-DSUNSHINE_BUILD_APPIMAGE=ON'
+            EXTRA_ARGS: '--appimage-build'
             dist: 22.04
 
     steps:
@@ -276,81 +276,23 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install wget
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y \
-            wget
-
-      - name: Install CUDA
-        env:
-          CUDA_VERSION: 11.8.0
-          CUDA_BUILD: 520.61.05
-        timeout-minutes: 4
-        run: |
-          url_base="https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/local_installers"
-          url="${url_base}/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux.run"
-          sudo wget -q -O /root/cuda.run ${url}
-          sudo chmod a+x /root/cuda.run
-          sudo /root/cuda.run --silent --toolkit --toolkitpath=/usr/local/cuda --no-opengl-libs --no-man-page --no-drm
-          sudo rm /root/cuda.run
-
       - name: Setup Dependencies Linux
         timeout-minutes: 5
         run: |
-          # allow newer gcc
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          # create the artifacts directory
+          mkdir -p artifacts
 
-          # allow libfuse2 for appimage on 22.04
+          # allow libfuse2 for appimage on 22.04+
           sudo add-apt-repository universe
 
-          # libx11-xcb-dev and libxcb-dri3-dev are required for building libva
           sudo apt-get install -y \
-            build-essential \
-            cmake \
-            doxygen \
-            graphviz \
-            gcc-10 \
-            g++-10 \
-            libayatana-appindicator3-dev \
-            libavdevice-dev \
-            libcap-dev \
-            libcurl4-openssl-dev \
             libdrm-dev \
-            libevdev-dev \
             libfuse2 \
-            libminiupnpc-dev \
-            libnotify-dev \
-            libnuma-dev \
-            libopus-dev \
-            libpulse-dev \
-            libssl-dev \
-            libvdpau-dev \
+            libgl-dev \
             libwayland-dev \
-            libx11-dev \
             libx11-xcb-dev \
             libxcb-dri3-dev \
-            libxcb-shm0-dev \
-            libxcb-xfixes0-dev \
-            libxcb1-dev \
-            libxfixes-dev \
-            libxrandr-dev \
-            libxtst-dev \
-            python3 \
-            python3-venv
-
-          # clean apt cache
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-
-          # Update gcc alias
-          # https://stackoverflow.com/a/70653945/11214013
-          sudo update-alternatives --install \
-            /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-10 \
-            --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
-            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10
+            libxfixes-dev
 
       - name: Setup python
         id: python
@@ -371,7 +313,7 @@ jobs:
             --enable-x11 \
             --enable-glx \
             --enable-wayland \
-            --without-legacy # emgd, nvctrl, fglrx
+            --without-legacy  # emgd, nvctrl, fglrx
           make -j $(nproc)
           sudo make install
           cd .. && rm -rf libva-*
@@ -381,28 +323,9 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           BUILD_VERSION: ${{ needs.setup_release.outputs.release_tag }}
           COMMIT: ${{ needs.setup_release.outputs.release_commit }}
-        timeout-minutes: 10
         run: |
-          echo "nproc: $(nproc)"
-
-          mkdir -p build
-          mkdir -p artifacts
-
-          cd build
-          cmake \
-            -DBUILD_WERROR=ON \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CUDA_COMPILER:PATH=/usr/local/cuda/bin/nvcc \
-            -DCMAKE_INSTALL_PREFIX=/usr \
-            -DSUNSHINE_ASSETS_DIR=share/sunshine \
-            -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
-            -DSUNSHINE_ENABLE_WAYLAND=ON \
-            -DSUNSHINE_ENABLE_X11=ON \
-            -DSUNSHINE_ENABLE_DRM=ON \
-            -DSUNSHINE_ENABLE_CUDA=ON \
-            ${{ matrix.EXTRA_ARGS }} \
-            ..
-          make -j $(expr $(nproc) - 1)  # use all but one core
+          chmod +x ./scripts/linux_build.sh
+          ./scripts/linux_build.sh --skip-cleanup --skip-package --ubuntu-test-repo ${{ matrix.EXTRA_ARGS }}
 
       - name: Set AppImage Version
         if: |
@@ -416,7 +339,7 @@ jobs:
         working-directory: build
         run: |
           # install sunshine to the DESTDIR
-          make install DESTDIR=AppDir
+          DESTDIR=AppDir ninja install
 
           # custom AppRun file
           cp -f ../packaging/linux/AppImage/AppRun ./AppDir/
@@ -454,7 +377,7 @@ jobs:
       - name: Delete CUDA
         # free up space on the runner
         run: |
-          sudo rm -rf /usr/local/cuda
+          rm -rf ./build/cuda
 
       - name: Verify AppImage
         if: ${{ matrix.type == 'AppImage' }}

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -14,10 +14,14 @@ else()
     find_package(Systemd)
     find_package(Udev)
 
-    install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/60-sunshine.rules"
-            DESTINATION "${UDEV_RULES_INSTALL_DIR}")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service"
-            DESTINATION "${SYSTEMD_USER_UNIT_INSTALL_DIR}")
+    if(UDEV_FOUND)
+        install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/60-sunshine.rules"
+                DESTINATION "${UDEV_RULES_INSTALL_DIR}")
+    endif()
+    if(SYSTEMD_FOUND)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service"
+                DESTINATION "${SYSTEMD_USER_UNIT_INSTALL_DIR}")
+    endif()
 endif()
 
 # Post install

--- a/docker/debian-bookworm.dockerfile
+++ b/docker/debian-bookworm.dockerfile
@@ -11,9 +11,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 FROM sunshine-base as sunshine-build
 
-ARG TARGETPLATFORM
-RUN echo "target_platform: ${TARGETPLATFORM}"
-
 ARG BRANCH
 ARG BUILD_VERSION
 ARG COMMIT
@@ -24,98 +21,20 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV COMMIT=${COMMIT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# install dependencies
-RUN <<_DEPS
-#!/bin/bash
-set -e
-apt-get update -y
-apt-get install -y --no-install-recommends \
-  build-essential \
-  cmake=3.25.* \
-  doxygen \
-  git \
-  graphviz \
-  libayatana-appindicator3-dev \
-  libcap-dev \
-  libcurl4-openssl-dev \
-  libdrm-dev \
-  libevdev-dev \
-  libminiupnpc-dev \
-  libnotify-dev \
-  libnuma-dev \
-  libopus-dev \
-  libpulse-dev \
-  libssl-dev \
-  libva-dev \
-  libvdpau-dev \
-  libwayland-dev \
-  libx11-dev \
-  libxcb-shm0-dev \
-  libxcb-xfixes0-dev \
-  libxcb1-dev \
-  libxfixes-dev \
-  libxrandr-dev \
-  libxtst-dev \
-  nodejs \
-  npm \
-  python3.11 \
-  python3.11-venv \
-  udev \
-  wget \
-  x11-xserver-utils \
-  xvfb
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-_DEPS
-
-# install cuda
-WORKDIR /build/cuda
-# versions: https://developer.nvidia.com/cuda-toolkit-archive
-ENV CUDA_VERSION="12.0.0"
-ENV CUDA_BUILD="525.60.13"
-# hadolint ignore=SC3010
-RUN <<_INSTALL_CUDA
-#!/bin/bash
-set -e
-cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-cuda_suffix=""
-if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-  cuda_suffix="_sbsa"
-fi
-url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
-echo "cuda url: ${url}"
-wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
-chmod a+x ./cuda.run
-./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
-rm ./cuda.run
-_INSTALL_CUDA
 
 # copy repository
 WORKDIR /build/sunshine/
 COPY --link .. .
 
-# setup build directory
-WORKDIR /build/sunshine/build
-
 # cmake and cpack
-RUN <<_MAKE
+RUN <<_BUILD
 #!/bin/bash
 set -e
-cmake \
-  -DBUILD_WERROR=ON \
-  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DSUNSHINE_ASSETS_DIR=share/sunshine \
-  -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
-  -DSUNSHINE_ENABLE_WAYLAND=ON \
-  -DSUNSHINE_ENABLE_X11=ON \
-  -DSUNSHINE_ENABLE_DRM=ON \
-  -DSUNSHINE_ENABLE_CUDA=ON \
-  /build/sunshine
-make -j "$(nproc)"
-cpack -G DEB
-_MAKE
+chmod +x ./scripts/linux_build.sh
+./scripts/linux_build.sh --sudo-off
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+_BUILD
 
 # run tests
 WORKDIR /build/sunshine/build/tests

--- a/docker/fedora-39.dockerfile
+++ b/docker/fedora-39.dockerfile
@@ -9,9 +9,6 @@ FROM ${BASE}:${TAG} AS sunshine-base
 
 FROM sunshine-base as sunshine-build
 
-ARG TARGETPLATFORM
-RUN echo "target_platform: ${TARGETPLATFORM}"
-
 ARG BRANCH
 ARG BUILD_VERSION
 ARG COMMIT
@@ -22,105 +19,20 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV COMMIT=${COMMIT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# install dependencies
-# hadolint ignore=DL3041
-RUN <<_DEPS
-#!/bin/bash
-set -e
-dnf -y update
-dnf -y group install "Development Tools"
-dnf -y install \
-  cmake-3.27.* \
-  gcc-13.2.* \
-  gcc-c++-13.2.* \
-  git \
-  libappindicator-gtk3-devel \
-  libcap-devel \
-  libcurl-devel \
-  libdrm-devel \
-  libevdev-devel \
-  libnotify-devel \
-  libva-devel \
-  libvdpau-devel \
-  libX11-devel \
-  libxcb-devel \
-  libXcursor-devel \
-  libXfixes-devel \
-  libXi-devel \
-  libXinerama-devel \
-  libXrandr-devel \
-  libXtst-devel \
-  mesa-libGL-devel \
-  miniupnpc-devel \
-  nodejs \
-  numactl-devel \
-  openssl-devel \
-  opus-devel \
-  pulseaudio-libs-devel \
-  rpm-build \
-  wget \
-  which \
-  xorg-x11-server-Xvfb
-dnf clean all
-rm -rf /var/cache/yum
-_DEPS
-
-# install cuda
-WORKDIR /build/cuda
-# versions: https://developer.nvidia.com/cuda-toolkit-archive
-ENV CUDA_VERSION="12.4.0"
-ENV CUDA_BUILD="550.54.14"
-# hadolint ignore=SC3010
-RUN <<_INSTALL_CUDA
-#!/bin/bash
-set -e
-cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-cuda_suffix=""
-if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-  cuda_suffix="_sbsa"
-
-  # patch headers https://bugs.launchpad.net/ubuntu/+source/mumax3/+bug/2032624
-  sed -i 's/__Float32x4_t/int/g' /usr/include/bits/math-vector.h
-  sed -i 's/__Float64x2_t/int/g' /usr/include/bits/math-vector.h
-  sed -i 's/__SVFloat32_t/float/g' /usr/include/bits/math-vector.h
-  sed -i 's/__SVFloat64_t/float/g' /usr/include/bits/math-vector.h
-  sed -i 's/__SVBool_t/int/g' /usr/include/bits/math-vector.h
-fi
-url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
-echo "cuda url: ${url}"
-wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
-chmod a+x ./cuda.run
-./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
-rm ./cuda.run
-_INSTALL_CUDA
 
 # copy repository
 WORKDIR /build/sunshine/
 COPY --link .. .
 
-# setup build directory
-WORKDIR /build/sunshine/build
-
 # cmake and cpack
-RUN <<_MAKE
+RUN <<_BUILD
 #!/bin/bash
 set -e
-cmake \
-  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
-  -DBUILD_DOCS=OFF \
-  -DBUILD_WERROR=ON \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DSUNSHINE_ASSETS_DIR=share/sunshine \
-  -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
-  -DSUNSHINE_ENABLE_WAYLAND=ON \
-  -DSUNSHINE_ENABLE_X11=ON \
-  -DSUNSHINE_ENABLE_DRM=ON \
-  -DSUNSHINE_ENABLE_CUDA=ON \
-  /build/sunshine
-make -j "$(nproc)"
-cpack -G RPM
-_MAKE
+chmod +x ./scripts/linux_build.sh
+./scripts/linux_build.sh --sudo-off
+dnf clean all
+rm -rf /var/cache/yum
+_BUILD
 
 # run tests
 WORKDIR /build/sunshine/build/tests

--- a/docker/fedora-40.dockerfile
+++ b/docker/fedora-40.dockerfile
@@ -9,9 +9,6 @@ FROM ${BASE}:${TAG} AS sunshine-base
 
 FROM sunshine-base as sunshine-build
 
-ARG TARGETPLATFORM
-RUN echo "target_platform: ${TARGETPLATFORM}"
-
 ARG BRANCH
 ARG BUILD_VERSION
 ARG COMMIT
@@ -22,109 +19,20 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV COMMIT=${COMMIT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# install dependencies
-# hadolint ignore=DL3041
-RUN <<_DEPS
-#!/bin/bash
-set -e
-dnf -y update
-dnf -y group install "Development Tools"
-dnf -y install \
-  cmake-3.28.* \
-  doxygen \
-  gcc-14.1.* \
-  gcc-c++-14.1.* \
-  git \
-  graphviz \
-  libappindicator-gtk3-devel \
-  libcap-devel \
-  libcurl-devel \
-  libdrm-devel \
-  libevdev-devel \
-  libnotify-devel \
-  libva-devel \
-  libvdpau-devel \
-  libX11-devel \
-  libxcb-devel \
-  libXcursor-devel \
-  libXfixes-devel \
-  libXi-devel \
-  libXinerama-devel \
-  libXrandr-devel \
-  libXtst-devel \
-  mesa-libGL-devel \
-  miniupnpc-devel \
-  nodejs \
-  numactl-devel \
-  openssl-devel \
-  opus-devel \
-  pulseaudio-libs-devel \
-  python3.11 \
-  rpm-build \
-  wget \
-  which \
-  xorg-x11-server-Xvfb
-dnf clean all
-rm -rf /var/cache/yum
-_DEPS
-
-# TODO: re-enable cuda once cuda supports gcc-14
-## install cuda
-#WORKDIR /build/cuda
-## versions: https://developer.nvidia.com/cuda-toolkit-archive
-#ENV CUDA_VERSION="12.4.0"
-#ENV CUDA_BUILD="550.54.14"
-## hadolint ignore=SC3010
-#RUN <<_INSTALL_CUDA
-##!/bin/bash
-#set -e
-#cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-#cuda_suffix=""
-#if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-#  cuda_suffix="_sbsa"
-#
-#  # patch headers https://bugs.launchpad.net/ubuntu/+source/mumax3/+bug/2032624
-#  sed -i 's/__Float32x4_t/int/g' /usr/include/bits/math-vector.h
-#  sed -i 's/__Float64x2_t/int/g' /usr/include/bits/math-vector.h
-#  sed -i 's/__SVFloat32_t/float/g' /usr/include/bits/math-vector.h
-#  sed -i 's/__SVFloat64_t/float/g' /usr/include/bits/math-vector.h
-#  sed -i 's/__SVBool_t/int/g' /usr/include/bits/math-vector.h
-#fi
-#url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
-#echo "cuda url: ${url}"
-#wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
-#chmod a+x ./cuda.run
-#./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
-#rm ./cuda.run
-#_INSTALL_CUDA
 
 # copy repository
 WORKDIR /build/sunshine/
 COPY --link .. .
 
-# setup build directory
-WORKDIR /build/sunshine/build
-
-# TODO: re-add as first cmake argument: -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
-# TODO: enable cuda flag
 # cmake and cpack
-RUN <<_MAKE
+RUN <<_BUILD
 #!/bin/bash
 set -e
-cmake \
-  -DBUILD_WERROR=ON \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DSUNSHINE_ASSETS_DIR=share/sunshine \
-  -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
-  -DSUNSHINE_ENABLE_WAYLAND=ON \
-  -DSUNSHINE_ENABLE_X11=ON \
-  -DSUNSHINE_ENABLE_DRM=ON \
-  -DSUNSHINE_ENABLE_CUDA=OFF \
-  /build/sunshine
-make -j "$(nproc)"
-cpack -G RPM
-_MAKE
+chmod +x ./scripts/linux_build.sh
+./scripts/linux_build.sh --sudo-off
+dnf clean all
+rm -rf /var/cache/yum
+_BUILD
 
 # run tests
 WORKDIR /build/sunshine/build/tests

--- a/docker/ubuntu-22.04.dockerfile
+++ b/docker/ubuntu-22.04.dockerfile
@@ -11,9 +11,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 FROM sunshine-base as sunshine-build
 
-ARG TARGETPLATFORM
-RUN echo "target_platform: ${TARGETPLATFORM}"
-
 ARG BRANCH
 ARG BUILD_VERSION
 ARG COMMIT
@@ -24,134 +21,20 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV COMMIT=${COMMIT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# install dependencies
-RUN <<_DEPS
-#!/bin/bash
-set -e
-apt-get update -y
-apt-get install -y --no-install-recommends \
-  build-essential \
-  cmake=3.22.* \
-  ca-certificates \
-  doxygen \
-  git \
-  graphviz \
-  libayatana-appindicator3-dev \
-  libcap-dev \
-  libcurl4-openssl-dev \
-  libdrm-dev \
-  libevdev-dev \
-  libminiupnpc-dev \
-  libnotify-dev \
-  libnuma-dev \
-  libopus-dev \
-  libpulse-dev \
-  libssl-dev \
-  libva-dev \
-  libvdpau-dev \
-  libwayland-dev \
-  libx11-dev \
-  libxcb-shm0-dev \
-  libxcb-xfixes0-dev \
-  libxcb1-dev \
-  libxfixes-dev \
-  libxrandr-dev \
-  libxtst-dev \
-  python3.10 \
-  python3.10-venv \
-  udev \
-  wget \
-  x11-xserver-utils \
-  xvfb
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-_DEPS
-
-# install cmake
-# sunshine requires cmake >= 3.25
-WORKDIR /build/cmake
-# https://cmake.org/download/
-ENV CMAKE_VERSION="3.30.1"
-# hadolint ignore=SC3010
-RUN <<_INSTALL_CMAKE
-#!/bin/bash
-cmake_prefix="https://github.com/Kitware/CMake/releases/download/v"
-if [[ "${TARGETPLATFORM}" == 'linux/amd64' ]]; then
-  cmake_arch="x86_64"
-elif [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-  cmake_arch="aarch64"
-fi
-url="${cmake_prefix}${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.sh"
-echo "cmake url: ${url}"
-wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cmake.sh
-sh ./cmake.sh --prefix=/usr/local --skip-license
-cmake --version
-_INSTALL_CMAKE
-
-#Install Node
-# hadolint ignore=SC1091
-RUN <<_INSTALL_NODE
-#!/bin/bash
-set -e
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
-source "$HOME/.nvm/nvm.sh"
-nvm install 20.9.0
-nvm use 20.9.0
-_INSTALL_NODE
-
-# install cuda
-WORKDIR /build/cuda
-# versions: https://developer.nvidia.com/cuda-toolkit-archive
-ENV CUDA_VERSION="11.8.0"
-ENV CUDA_BUILD="520.61.05"
-# hadolint ignore=SC3010
-RUN <<_INSTALL_CUDA
-#!/bin/bash
-set -e
-cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-cuda_suffix=""
-if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-  cuda_suffix="_sbsa"
-fi
-url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
-echo "cuda url: ${url}"
-wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
-chmod a+x ./cuda.run
-./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
-rm ./cuda.run
-_INSTALL_CUDA
 
 # copy repository
 WORKDIR /build/sunshine/
 COPY --link .. .
 
-# setup build directory
-WORKDIR /build/sunshine/build
-
 # cmake and cpack
-# hadolint ignore=SC1091
-RUN <<_MAKE
+RUN <<_BUILD
 #!/bin/bash
 set -e
-#Set Node version
-source "$HOME/.nvm/nvm.sh"
-nvm use 20.9.0
-#Actually build
-cmake \
-  -DBUILD_WERROR=ON \
-  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DSUNSHINE_ASSETS_DIR=share/sunshine \
-  -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
-  -DSUNSHINE_ENABLE_WAYLAND=ON \
-  -DSUNSHINE_ENABLE_X11=ON \
-  -DSUNSHINE_ENABLE_DRM=ON \
-  -DSUNSHINE_ENABLE_CUDA=ON \
-  /build/sunshine
-make -j "$(nproc)"
-cpack -G DEB
-_MAKE
+chmod +x ./scripts/linux_build.sh
+./scripts/linux_build.sh --sudo-off
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+_BUILD
 
 # run tests
 WORKDIR /build/sunshine/build/tests

--- a/docker/ubuntu-24.04.dockerfile
+++ b/docker/ubuntu-24.04.dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # artifacts: true
-# platforms: linux/amd64
+# platforms: linux/amd64,linux/arm64/v8
 # platforms_pr: linux/amd64
 # no-cache-filters: sunshine-base,artifacts,sunshine
 ARG BASE=ubuntu
@@ -10,9 +10,6 @@ FROM ${BASE}:${TAG} AS sunshine-base
 ENV DEBIAN_FRONTEND=noninteractive
 
 FROM sunshine-base as sunshine-build
-
-ARG TARGETPLATFORM
-RUN echo "target_platform: ${TARGETPLATFORM}"
 
 ARG BRANCH
 ARG BUILD_VERSION
@@ -24,129 +21,20 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV COMMIT=${COMMIT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# install dependencies
-RUN <<_DEPS
-#!/bin/bash
-set -e
-apt-get update -y
-apt-get install -y --no-install-recommends \
-  build-essential \
-  cmake=3.28.* \
-  ca-certificates \
-  doxygen \
-  gcc-11 \
-  g++-11 \
-  git \
-  graphviz \
-  libayatana-appindicator3-dev \
-  libcap-dev \
-  libcurl4-openssl-dev \
-  libdrm-dev \
-  libevdev-dev \
-  libminiupnpc-dev \
-  libnotify-dev \
-  libnuma-dev \
-  libopus-dev \
-  libpulse-dev \
-  libssl-dev \
-  libva-dev \
-  libvdpau-dev \
-  libwayland-dev \
-  libx11-dev \
-  libxcb-shm0-dev \
-  libxcb-xfixes0-dev \
-  libxcb1-dev \
-  libxfixes-dev \
-  libxrandr-dev \
-  libxtst-dev \
-  python3.12 \
-  python3.12-venv \
-  udev \
-  wget \
-  x11-xserver-utils \
-  xvfb
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-_DEPS
-
-
-#Install Node
-# hadolint ignore=SC1091
-RUN <<_INSTALL_NODE
-#!/bin/bash
-set -e
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
-source "$HOME/.nvm/nvm.sh"
-nvm install 20.9.0
-nvm use 20.9.0
-_INSTALL_NODE
-
-# Update gcc alias
-# https://stackoverflow.com/a/70653945/11214013
-RUN <<_GCC_ALIAS
-#!/bin/bash
-set -e
-update-alternatives --install \
-  /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
-  --slave /usr/bin/g++ g++ /usr/bin/g++-11 \
-  --slave /usr/bin/gcov gcov /usr/bin/gcov-11 \
-  --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 \
-  --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11
-_GCC_ALIAS
-
-# install cuda
-WORKDIR /build/cuda
-# versions: https://developer.nvidia.com/cuda-toolkit-archive
-ENV CUDA_VERSION="11.8.0"
-ENV CUDA_BUILD="520.61.05"
-# hadolint ignore=SC3010
-RUN <<_INSTALL_CUDA
-#!/bin/bash
-set -e
-cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-cuda_suffix=""
-if [[ "${TARGETPLATFORM}" == 'linux/arm64' ]]; then
-  cuda_suffix="_sbsa"
-fi
-url="${cuda_prefix}${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUILD}_linux${cuda_suffix}.run"
-echo "cuda url: ${url}"
-wget "$url" --progress=bar:force:noscroll -q --show-progress -O ./cuda.run
-chmod a+x ./cuda.run
-./cuda.run --silent --toolkit --toolkitpath=/build/cuda --no-opengl-libs --no-man-page --no-drm
-rm ./cuda.run
-_INSTALL_CUDA
 
 # copy repository
 WORKDIR /build/sunshine/
 COPY --link .. .
 
-# setup build directory
-WORKDIR /build/sunshine/build
-
 # cmake and cpack
-# hadolint ignore=SC1091
-RUN <<_MAKE
+RUN <<_BUILD
 #!/bin/bash
 set -e
-#Set Node version
-source "$HOME/.nvm/nvm.sh"
-nvm use 20.9.0
-#Actually build
-cmake \
-  -DBUILD_WERROR=ON \
-  -DCMAKE_CUDA_COMPILER:PATH=/build/cuda/bin/nvcc \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DSUNSHINE_ASSETS_DIR=share/sunshine \
-  -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
-  -DSUNSHINE_ENABLE_WAYLAND=ON \
-  -DSUNSHINE_ENABLE_X11=ON \
-  -DSUNSHINE_ENABLE_DRM=ON \
-  -DSUNSHINE_ENABLE_CUDA=ON \
-  /build/sunshine
-make -j "$(nproc)"
-cpack -G DEB
-_MAKE
+chmod +x ./scripts/linux_build.sh
+./scripts/linux_build.sh --sudo-off
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+_BUILD
 
 # run tests
 WORKDIR /build/sunshine/build/tests

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -1,0 +1,475 @@
+#!/bin/bash
+set -e
+
+# Default value for arguments
+appimage_build=0
+skip_cleanup=0
+skip_cuda=0
+skip_libva=0
+skip_package=0
+sudo_cmd="sudo"
+ubuntu_test_repo=0
+
+function _usage() {
+  local exit_code=$1
+
+  cat <<EOF
+This script installs the dependencies and builds the project.
+The script is intended to be run on a Debian-based or Fedora-based system.
+
+Usage:
+  $0 [options]
+
+Options:
+  -h, --help           Display this help message.
+  -s, --sudo-off       Disable sudo command.
+  --appimage-build     Compile for AppImage, this will not create the AppImage, just the executable.
+  --skip-cleanup       Do not restore the original gcc alternatives, or the math-vector.h file.
+  --skip-cuda          Skip CUDA installation.
+  --skip-libva         Skip libva installation. This will automatically be enabled if passing --appimage-build.
+  --skip-package       Skip creating DEB, or RPM package.
+  --ubuntu-test-repo   Install ppa:ubuntu-toolchain-r/test repo on Ubuntu.
+EOF
+
+  exit "$exit_code"
+}
+
+# Parse named arguments
+while getopts ":hs-:" opt; do
+  case ${opt} in
+    h ) _usage 0 ;;
+    s ) sudo_cmd="" ;;
+    - )
+      case "${OPTARG}" in
+        help) _usage 0 ;;
+        appimage-build)
+          appimage_build=1
+          skip_libva=1
+          ;;
+        skip-cleanup) skip_cleanup=1 ;;
+        skip-cuda) skip_cuda=1 ;;
+        skip-libva) skip_libva=1 ;;
+        skip-package) skip_package=1 ;;
+        sudo-off) sudo_cmd="" ;;
+        ubuntu-test-repo) ubuntu_test_repo=1 ;;
+        *)
+          echo "Invalid option: --${OPTARG}" 1>&2
+          _usage 1
+          ;;
+      esac
+      ;;
+    \? )
+      echo "Invalid option: -${OPTARG}" 1>&2
+      _usage 1
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+# dependencies array to build out
+dependencies=()
+
+function add_debain_based_deps() {
+  dependencies+=(
+    "bison"  # required if we need to compile doxygen
+    "build-essential"
+    "cmake"
+    "doxygen"
+    "flex"  # required if we need to compile doxygen
+    "gcc-${gcc_version}"
+    "g++-${gcc_version}"
+    "git"
+    "graphviz"
+    "libcap-dev"  # KMS
+    "libcurl4-openssl-dev"
+    "libdrm-dev"  # KMS
+    "libevdev-dev"
+    "libminiupnpc-dev"
+    "libnotify-dev"
+    "libnuma-dev"
+    "libopus-dev"
+    "libpulse-dev"
+    "libssl-dev"
+    "libvdpau-dev"
+    "libwayland-dev"  # Wayland
+    "libx11-dev"  # X11
+    "libxcb-shm0-dev"  # X11
+    "libxcb-xfixes0-dev"  # X11
+    "libxcb1-dev"  # X11
+    "libxfixes-dev"  # X11
+    "libxrandr-dev"  # X11
+    "libxtst-dev"  # X11
+    "ninja-build"
+    "npm"  # web-ui
+    "udev"
+    "wget"  # necessary for cuda install with `run` file
+    "xvfb"  # necessary for headless unit testing
+  )
+
+  if [ "$skip_libva" == 0 ]; then
+    dependencies+=(
+      "libva-dev"  # VA-API
+    )
+  fi
+}
+
+function add_debain_deps() {
+  add_debain_based_deps
+  dependencies+=(
+    "libayatana-appindicator3-dev"
+  )
+}
+
+function add_ubuntu_deps() {
+  if [ "$ubuntu_test_repo" == 1 ]; then
+    # allow newer gcc
+    ${sudo_cmd} add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  fi
+
+  add_debain_based_deps
+  dependencies+=(
+    "libappindicator3-dev"
+  )
+}
+
+function add_fedora_deps() {
+  dependencies+=(
+    "cmake"
+    "doxygen"
+    "gcc"
+    "g++"
+    "git"
+    "graphviz"
+    "libappindicator-gtk3-devel"
+    "libcap-devel"
+    "libcurl-devel"
+    "libdrm-devel"
+    "libevdev-devel"
+    "libnotify-devel"
+    "libvdpau-devel"
+    "libX11-devel"  # X11
+    "libxcb-devel"  # X11
+    "libXcursor-devel"  # X11
+    "libXfixes-devel"  # X11
+    "libXi-devel"  # X11
+    "libXinerama-devel"  # X11
+    "libXrandr-devel"  # X11
+    "libXtst-devel"  # X11
+    "mesa-libGL-devel"
+    "miniupnpc-devel"
+    "ninja-build"
+    "npm"
+    "numactl-devel"
+    "openssl-devel"
+    "opus-devel"
+    "pulseaudio-libs-devel"
+    "rpm-build"  # if you want to build an RPM binary package
+    "wget"  # necessary for cuda install with `run` file
+    "which"  # necessary for cuda install with `run` file
+    "xorg-x11-server-Xvfb"  # necessary for headless unit testing
+  )
+
+  if [ "$skip_libva" == 0 ]; then
+    dependencies+=(
+      "libva-devel"  # VA-API
+    )
+  fi
+}
+
+function install_cuda() {
+  # check if we need to install cuda
+  if [ -f "${build_dir}/cuda/bin/nvcc" ]; then
+    echo "cuda already installed"
+    return
+  fi
+
+  local cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
+  local cuda_suffix=""
+  if [ "$architecture" == "aarch64" ]; then
+    local cuda_suffix="_sbsa"
+  fi
+
+  if [ "$architecture" == "aarch64" ]; then
+    # we need to patch the math-vector.h file for aarch64 fedora
+    # back up /usr/include/bits/math-vector.h
+    math_vector_file=""
+    if [ "$distro" == "ubuntu" ] || [ "$version" == "24.04" ]; then
+      math_vector_file="/usr/include/aarch64-linux-gnu/bits/math-vector.h"
+    elif [ "$distro" == "fedora" ]; then
+      math_vector_file="/usr/include/bits/math-vector.h"
+    fi
+
+    if [ -n "$math_vector_file" ]; then
+      # patch headers https://bugs.launchpad.net/ubuntu/+source/mumax3/+bug/2032624
+      ${sudo_cmd} cp "$math_vector_file" "$math_vector_file.bak"
+      ${sudo_cmd} sed -i 's/__Float32x4_t/int/g' "$math_vector_file"
+      ${sudo_cmd} sed -i 's/__Float64x2_t/int/g' "$math_vector_file"
+      ${sudo_cmd} sed -i 's/__SVFloat32_t/float/g' "$math_vector_file"
+      ${sudo_cmd} sed -i 's/__SVFloat64_t/float/g' "$math_vector_file"
+      ${sudo_cmd} sed -i 's/__SVBool_t/int/g' "$math_vector_file"
+    fi
+  fi
+
+  local url="${cuda_prefix}${cuda_version}/local_installers/cuda_${cuda_version}_${cuda_build}_linux${cuda_suffix}.run"
+  echo "cuda url: ${url}"
+  wget "$url" --progress=bar:force:noscroll -q --show-progress -O "${build_dir}/cuda.run"
+  chmod a+x "${build_dir}/cuda.run"
+  "${build_dir}/cuda.run" --silent --toolkit --toolkitpath="${build_dir}/cuda" --no-opengl-libs --no-man-page --no-drm
+  rm "${build_dir}/cuda.run"
+}
+
+function check_version() {
+  local package_name=$1
+  local min_version=$2
+  local installed_version
+
+  echo "Checking if $package_name is installed and at least version $min_version"
+
+  if [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
+    installed_version=$(dpkg -s "$package_name" 2>/dev/null | grep '^Version:' | awk '{print $2}')
+  elif [ "$distro" == "fedora" ]; then
+    installed_version=$(rpm -q --queryformat '%{VERSION}' "$package_name" 2>/dev/null)
+  else
+    echo "Unsupported Distro"
+    return 1
+  fi
+
+  if [ -z "$installed_version" ]; then
+    echo "Package not installed"
+    return 1
+  fi
+
+  if [ "$(printf '%s\n' "$installed_version" "$min_version" | sort -V | head -n1)" = "$min_version" ]; then
+    echo "$package_name version $installed_version is at least $min_version"
+    return 0
+  else
+    echo "$package_name version $installed_version is less than $min_version"
+    return 1
+  fi
+}
+
+function run_install() {
+  # prepare CMAKE args
+  cmake_args=(
+    "-B=build"
+    "-G=Ninja"
+    "-S=."
+    "-DBUILD_WERROR=ON"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_INSTALL_PREFIX=/usr"
+    "-DSUNSHINE_ASSETS_DIR=share/sunshine"
+    "-DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine"
+    "-DSUNSHINE_ENABLE_WAYLAND=ON"
+    "-DSUNSHINE_ENABLE_X11=ON"
+    "-DSUNSHINE_ENABLE_DRM=ON"
+  )
+
+  if [ "$appimage_build" == 1 ]; then
+    cmake_args+=("-DSUNSHINE_BUILD_APPIMAGE=ON")
+  fi
+
+  # Update the package list
+  $package_update_command
+
+  if [ "$distro" == "debian" ]; then
+    add_debain_deps
+  elif [ "$distro" == "ubuntu" ]; then
+    add_ubuntu_deps
+  elif [ "$distro" == "fedora" ]; then
+    add_fedora_deps
+    dnf group install "Development Tools" -y
+  fi
+
+  # Install the dependencies
+  $package_install_command "${dependencies[@]}"
+
+  # reload the environment
+  # shellcheck source=/dev/null
+  source ~/.bashrc
+
+  gcc_alternative_files=(
+    "gcc"
+    "g++"
+    "gcov"
+    "gcc-ar"
+    "gcc-ranlib"
+  )
+
+  # update alternatives for gcc and g++ if a debian based distro
+  if [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
+    for file in "${gcc_alternative_files[@]}"; do
+      file_path="/etc/alternatives/$file"
+      if [ -e "$file_path" ]; then
+        mv "$file_path" "$file_path.bak"
+      fi
+    done
+
+    ${sudo_cmd} update-alternatives --install \
+      /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 \
+      --slave /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} \
+      --slave /usr/bin/gcov gcov /usr/bin/gcov-${gcc_version} \
+      --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-${gcc_version} \
+      --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-${gcc_version}
+  fi
+
+  # compile cmake if the version is too low
+  cmake_min="3.25.0"
+  target_cmake_version="3.30.1"
+  if ! check_version "cmake" "$cmake_min"; then
+    cmake_prefix="https://github.com/Kitware/CMake/releases/download/v"
+    if [ "$architecture" == "x86_64" ]; then
+      cmake_arch="x86_64"
+    elif [ "$architecture" == "aarch64" ]; then
+      cmake_arch="aarch64"
+    fi
+    url="${cmake_prefix}${target_cmake_version}/cmake-${target_cmake_version}-linux-${cmake_arch}.sh"
+    echo "cmake url: ${url}"
+    wget "$url" --progress=bar:force:noscroll -q --show-progress -O "${build_dir}/cmake.sh"
+    ${sudo_cmd} sh "${build_dir}/cmake.sh" --skip-license --prefix=/usr/local
+    echo "cmake installed, version:"
+    cmake --version
+  fi
+
+  # compile doxygen if version is too low
+  doxygen_min="1.10.0"
+  _doxygen_min="1_10_0"
+  if ! check_version "doxygen" "$doxygen_min"; then
+    if [ "${SUNSHINE_COMPILE_DOXYGEN}" == "true" ]; then
+      echo "Compiling doxygen"
+      doxygen_url="https://github.com/doxygen/doxygen/releases/download/Release_${_doxygen_min}/doxygen-${doxygen_min}.src.tar.gz"
+      echo "doxygen url: ${doxygen_url}"
+      wget "$doxygen_url" --progress=bar:force:noscroll -q --show-progress -O "${build_dir}/doxygen.tar.gz"
+      tar -xzf "${build_dir}/doxygen.tar.gz"
+      cd "doxygen-${doxygen_min}"
+      cmake -DCMAKE_BUILD_TYPE=Release -G="Ninja" -B="build" -S="."
+      ninja -C "build"
+      ninja -C "build" install
+    else
+      echo "Doxygen version too low, skipping docs"
+      cmake_args+=("-DBUILD_DOCS=OFF")
+    fi
+  fi
+
+  # install node from nvm
+  if [ "$nvm_node" == 1 ]; then
+    nvm_url="https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh"
+    echo "nvm url: ${nvm_url}"
+    wget -qO- ${nvm_url} | bash
+    source "$HOME/.nvm/nvm.sh"
+    nvm install node
+    nvm use node
+  fi
+
+  # run the cuda install
+  if [ -n "$cuda_version" ] && [ "$skip_cuda" == 0 ]; then
+    install_cuda
+    cmake_args+=("-DSUNSHINE_ENABLE_CUDA=ON")
+    cmake_args+=("-DCMAKE_CUDA_COMPILER:PATH=${build_dir}/cuda/bin/nvcc")
+  fi
+
+  # Cmake stuff here
+  mkdir -p "build"
+  echo "cmake args:"
+  echo "${cmake_args[@]}"
+  cmake "${cmake_args[@]}"
+  ninja -C "build"
+
+  # Create the package
+  if [ "$skip_package" == 0 ]; then
+    if [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
+      cpack -G DEB --config ./build/CPackConfig.cmake
+    elif [ "$distro" == "fedora" ]; then
+      cpack -G RPM --config ./build/CPackConfig.cmake
+    fi
+  fi
+
+  if [ "$skip_cleanup" == 0 ]; then
+    # Restore the original gcc alternatives
+    if [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
+      for file in "${gcc_alternative_files[@]}"; do
+        if [ -e "/etc/alternatives/$file.bak" ]; then
+          ${sudo_cmd} mv "/etc/alternatives/$file.bak" "/etc/alternatives/$file"
+        else
+          ${sudo_cmd} rm "/etc/alternatives/$file"
+        fi
+      done
+    fi
+
+    # restore the math-vector.h file
+    if [ "$architecture" == "aarch64" ] && [ -n "$math_vector_file" ]; then
+      ${sudo_cmd} mv -f "$math_vector_file.bak" "$math_vector_file"
+    fi
+  fi
+}
+
+# Determine the OS and call the appropriate function
+cat /etc/os-release
+if grep -q "Debian GNU/Linux 12 (bookworm)" /etc/os-release; then
+  distro="debian"
+  version="12"
+  package_update_command="${sudo_cmd} apt-get update"
+  package_install_command="${sudo_cmd} apt-get install -y"
+  cuda_version="12.0.0"
+  cuda_build="525.60.13"
+  gcc_version="12"
+  nvm_node=0
+elif grep -q "PLATFORM_ID=\"platform:f39\"" /etc/os-release; then
+  distro="fedora"
+  version="39"
+  package_update_command="${sudo_cmd} dnf update -y"
+  package_install_command="${sudo_cmd} dnf install -y"
+  cuda_version="12.4.0"
+  cuda_build="550.54.14"
+  gcc_version="13"
+  nvm_node=0
+elif grep -q "PLATFORM_ID=\"platform:f40\"" /etc/os-release; then
+  distro="fedora"
+  version="40"
+  package_update_command="${sudo_cmd} dnf update -y"
+  package_install_command="${sudo_cmd} dnf install -y"
+  cuda_version=
+  cuda_build=
+  gcc_version="13"
+  nvm_node=0
+elif grep -q "Ubuntu 22.04" /etc/os-release; then
+  distro="ubuntu"
+  version="22.04"
+  package_update_command="${sudo_cmd} apt-get update"
+  package_install_command="${sudo_cmd} apt-get install -y"
+  cuda_version="11.8.0"
+  cuda_build="520.61.05"
+  gcc_version="11"
+  nvm_node=1
+elif grep -q "Ubuntu 24.04" /etc/os-release; then
+  distro="ubuntu"
+  version="24.04"
+  package_update_command="${sudo_cmd} apt-get update"
+  package_install_command="${sudo_cmd} apt-get install -y"
+  cuda_version="11.8.0"
+  cuda_build="520.61.05"
+  gcc_version="11"
+  nvm_node=0
+else
+  echo "Unsupported Distro or Version"
+  exit 1
+fi
+
+architecture=$(uname -m)
+
+echo "Detected Distro: $distro"
+echo "Detected Version: $version"
+echo "Detected Architecture: $architecture"
+
+if [ "$architecture" != "x86_64" ] && [ "$architecture" != "aarch64" ]; then
+  echo "Unsupported Architecture"
+  exit 1
+fi
+
+# get directory of this script
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+build_dir="$script_dir/../build"
+echo "Script Directory: $script_dir"
+echo "Build Directory: $build_dir"
+mkdir -p "$build_dir"
+
+run_install


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This is an attempt to have a single build script for all the distros we provide packages for, excluding those with a build spec like PKGBUILD or flatpak.

Skipping documentation update, as that will be handled in #2932 

TODO:
- [x] Get working in all docker builds
  - [x] aarch64 debian
  - [x] aarch64 ubuntu 22.04
  - [x] aarch64 ubuntu 24.04
  - [x] x86_64 debian
  - [x] x86_64 ubuntu 22.04
  - [x] x86_64 ubuntu 24.04
  - [x] x86_64 fedora 39
  - [x] x86_64 fedora 40
- [x] Get working in AppImage build
- [x] Get working in CodeQL build
- [x] Skip some steps if certain conditions exist, like cuda install on secondary runs
- [x] More echo/print statements
- [x] Allow passing arguments

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
