### PR TITLE
feat(logging): include milliseconds in timestamps

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -4,6 +4,7 @@
  */
 // standard includes
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 
 // lib includes

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -8,6 +8,7 @@
 
 // lib includes
 #include <boost/core/null_deleter.hpp>
+#include <boost/format.hpp>
 #include <boost/log/attributes/clock.hpp>
 #include <boost/log/common.hpp>
 #include <boost/log/expressions.hpp>
@@ -67,7 +68,6 @@ namespace logging {
     sink->set_formatter([](const bl::record_view &view, bl::formatting_ostream &os) {
       constexpr const char *message = "Message";
       constexpr const char *severity = "Severity";
-      constexpr int DATE_BUFFER_SIZE = 21 + 2 + 1;  // Full string plus ": \0"
 
       auto log_level = view.attribute_values()[severity].extract<int>().get();
 
@@ -93,11 +93,15 @@ namespace logging {
           break;
       };
 
-      char _date[DATE_BUFFER_SIZE];
-      std::time_t t = std::time(nullptr);
-      strftime(_date, DATE_BUFFER_SIZE, "[%Y:%m:%d:%H:%M:%S]: ", std::localtime(&t));
+      auto now = std::chrono::system_clock::now();
+      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now - std::chrono::time_point_cast<std::chrono::seconds>(now));
 
-      os << _date << log_type << view.attribute_values()[message].extract<std::string>();
+      auto t = std::chrono::system_clock::to_time_t(now);
+      auto lt = *std::localtime(&t);
+
+      os << "["sv << std::put_time(&lt, "%Y-%m-%d %H:%M:%S.") << boost::format("%03u") % ms.count() << "]: "sv
+         << log_type << view.attribute_values()[message].extract<std::string>();
     });
 
     // Flush after each log record to ensure log file contents on disk isn't stale.

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -142,7 +142,7 @@
       /** Parse the text errors, calculating the text, the timestamp and the level */
       fancyLogs() {
         if (!this.logs) return [];
-        let regex = /(\[\d{4}:\d{2}:\d{2}:\d{2}:\d{2}:\d{2}\]):\s/g;
+        let regex = /(\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}]):\s/g;
         let rawLogLines = (this.logs.split(regex)).splice(1);
         let logLines = []
         for (let i = 0; i < rawLogLines.length; i += 2) {


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Include milliseconds in logging timestamps and improve formatting while at it.
Should now give better idea how long individual steps take (shader compilation, encoder probing, etc).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
Before
```
[2024:08:04:22:33:15]: Info: Sunshine version: 0.0.0.f8b0be1e
```
After
```
[2024-08-04 22:33:15.623] Info: Sunshine version: 0.0.0.f8b0be1e
```

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
