### PR TITLE
chore(issue-template): add Apple Silicon to GPUs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -122,9 +122,9 @@ body:
       description: The type of the installed graphics card.
       options:
         - AMD
+        - Apple Silicon
         - Intel
         - Nvidia
-        - Apple Silicon
         - none (software encoding)
         - n/a
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -124,6 +124,7 @@ body:
         - AMD
         - Intel
         - Nvidia
+        - Apple Silicon
         - none (software encoding)
         - n/a
     validations:


### PR DESCRIPTION
## Description
Apple users with Apple Silicon had only third-party GPU vendor options, added Apple Silicon to avoid confusion.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
