### PR TITLE
ci(brew): add prerelease variant to tap

### DIFF
--- a/.github/workflows/update-homebrew-release.yml
+++ b/.github/workflows/update-homebrew-release.yml
@@ -69,3 +69,68 @@ jobs:
           publish: true
           token: ${{ secrets.GH_BOT_TOKEN }}
           validate: false
+
+  update-homebrew-prerelease:
+    if: >-
+      github.repository_owner == 'LizardByte' &&
+      !github.event.release.draft && github.event.release.prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Homebrew repo
+        env:
+          TOPIC: homebrew-pkg
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const topic = process.env.TOPIC;
+            console.log(`Checking if repo has topic: ${topic}`);
+
+            const repoTopics = await github.rest.repos.getAllTopics({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            console.log(`Repo topics: ${repoTopics.data.names}`);
+
+            const hasTopic = repoTopics.data.names.includes(topic);
+            console.log(`Has topic: ${hasTopic}`);
+
+            core.setOutput('hasTopic', hasTopic);
+
+      - name: Download release asset
+        id: download
+        if: >-
+          steps.check.outputs.hasTopic == 'true'
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repository: "${{ github.repository }}"
+          latest: true
+          preRelease: true
+          fileName: "*.rb"
+          tarBall: false
+          zipBall: false
+          out-file-path: "release_downloads"
+          extract: false
+
+      - name: Prepare Formula as Prerelease
+        if: >-
+          steps.check.outputs.hasTopic == 'true' &&
+          fromJson(steps.download.outputs.downloaded_files)[0]
+        run: |
+          cp ${{ fromJson(steps.download.outputs.downloaded_files)[0] }} ${{ github.workspace }}/homebrew/sunshine-prerelease.rb
+          sed -i 's/class Sunshine < Formula/class SunshinePrerelease < Formula/' ${{ github.workspace }}/homebrew/sunshine-prerelease.rb
+
+          cat ${{ github.workspace }}/homebrew/sunshine-prerelease.rb
+
+      - name: Publish Homebrew Formula
+        if: >-
+          steps.check.outputs.hasTopic == 'true' &&
+          fromJson(steps.download.outputs.downloaded_files)[0]
+        uses: LizardByte/homebrew-release-action@v2024.612.21058
+        with:
+          formula_file: ${{ github.workspace }}/homebrew/sunshine-prerelease.rb
+          git_email: ${{ secrets.GH_BOT_EMAIL }}
+          git_username: ${{ secrets.GH_BOT_NAME }}
+          publish: true
+          token: ${{ secrets.GH_BOT_TOKEN }}
+          validate: false


### PR DESCRIPTION
## Description
The proposal here is to publish a prerelease variant to our homebrew tap, so we can then install it as:

```sh
brew tap LizardByte/homebrew
brew install sunshine-prerelease
```

I'll probably need help here @ReenigneArcher, I'm not sure I'm on the right track.

Regarding the formula, I'm trying to replicate the following sample I made locally `sunshine-prerelease.rb`:
```rb
require "language/node"

class SunshinePrerelease < Formula
  desc "Self-hosted game stream host for Moonlight"
  homepage "https://app.lizardbyte.dev/Sunshine"
  url "https://github.com/LizardByte/Sunshine.git",
    tag: "v2024.805.184417"
  version "2024.805.184417"
  license all_of: ["GPL-3.0-only"]
  head "https://github.com/LizardByte/Sunshine.git", branch: "master"

  # https://docs.brew.sh/Brew-Livecheck#githublatest-strategy-block
  livecheck do
    url :stable
    regex(/^v?(\d+\.\d+\.\d+)$/i)
    strategy :github_latest do |json, regex|
      match = json["tag_name"]&.match(regex)
      next if match.blank?

      match[1]
    end
  end

  option "with-docs-off", "Disable docs"
  option "with-dynamic-boost", "Dynamically link Boost libraries"
  option "without-dynamic-boost", "Statically link Boost libraries" # default option

  depends_on "cmake" => :build
  depends_on "doxygen" => :build
  depends_on "graphviz" => :build
  depends_on "node" => :build
  depends_on "pkg-config" => :build
  depends_on "curl"
  depends_on "miniupnpc"
  depends_on "openssl"
  depends_on "opus"
  depends_on "icu4c" if build.without?("dynamic-boost")

  conflicts_with "sunshine", because: "sunshine-prerelease symlink with the name for compatibility with sunshine"

  on_linux do
    depends_on "avahi"
    depends_on "libcap"
    depends_on "libdrm"
    depends_on "libnotify"
    depends_on "libva"
    depends_on "libvdpau"
    depends_on "libx11"
    depends_on "libxcb"
    depends_on "libxcursor"
    depends_on "libxfixes"
    depends_on "libxi"
    depends_on "libxinerama"
    depends_on "libxrandr"
    depends_on "libxtst"
    depends_on "numactl"
    depends_on "pulseaudio"
    depends_on "systemd"
    depends_on "wayland"
  end

  def install
    ENV["BRANCH"] = "master"
    ENV["BUILD_VERSION"] = "v2024.805.184417"
    ENV["COMMIT"] = "4bd521bb4360d8ba9b1af8d2d704e8f79c3e9a38"

    args = %W[
      -DBUILD_WERROR=ON
      -DCMAKE_INSTALL_PREFIX=#{prefix}
      -DHOMEBREW_ALLOW_FETCHCONTENT=ON
      -DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}
      -DSUNSHINE_ASSETS_DIR=sunshine/assets
      -DSUNSHINE_BUILD_HOMEBREW=ON
      -DSUNSHINE_ENABLE_TRAY=OFF
    ]

    if build.with? "docs-off"
      ohai "Building docs: disabled"
      args << "-DBUILD_DOCS=OFF"
    else
      ohai "Building docs: enabled"
      args << "-DBUILD_DOCS=ON"
    end

    if build.without? "dynamic-boost"
      args << "-DBOOST_USE_STATIC=ON"
      ohai "Statically linking Boost libraries"

      unless Formula["icu4c"].any_version_installed?
        odie <<~EOS
          icu4c must be installed to link against static Boost libraries,
          either install icu4c or use brew install sunshine --with-dynamic-boost instead
        EOS
      end
      ENV.append "CXXFLAGS", "-I#{Formula["icu4c"].opt_include}"
      icu4c_lib_path = Formula["icu4c"].opt_lib.to_s
      ENV.append "LDFLAGS", "-L#{icu4c_lib_path}"
      ENV["LIBRARY_PATH"] = icu4c_lib_path
      ohai "Linking against ICU libraries at: #{icu4c_lib_path}"
    else
      args << "-DBOOST_USE_STATIC=OFF"
      ohai "Dynamically linking Boost libraries"
    end

    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args

    cd "build" do
      system "make"
      system "make", "install"

      bin.install "tests/test_sunshine"
    end

    bin.install "src_assets/linux/misc/postinst" if OS.linux?
  end

  service do
    run [opt_bin/"sunshine", "~/.config/sunshine/sunshine.conf"]
  end

  def caveats
    caveats_message = <<~EOS
      Thanks for installing Sunshine!

      To get started, review the documentation at:
        https://docs.lizardbyte.dev/projects/sunshine/en/latest/
    EOS

    if OS.linux?
      caveats_message += <<~EOS
        ATTENTION: To complete installation, you must run the following command:
        `sudo #{bin}/postinst`
      EOS
    end

    if OS.mac?
      caveats_message += <<~EOS
        Sunshine can only access microphones on macOS due to system limitations.
        To stream system audio use "Soundflower" or "BlackHole".

        Gamepads are not currently supported on macOS.
      EOS
    end

    caveats_message
  end

  test do
    # test that the binary runs at all
    system bin/"sunshine", "--version"

    # run the test suite
    system bin/"test_sunshine", "--gtest_color=yes"
  end
end
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
