### PR TITLE
fix(linux/audio): don't set pulseaudio buffer size

### DIFF
--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -81,9 +81,13 @@ namespace platf {
       channel = position_mapping[*mapping++];
     });
 
-    pa_buffer_attr pa_attr = {};
-    pa_attr.fragsize = frame_size * channels * sizeof(float);
-    pa_attr.maxlength = pa_attr.fragsize * 2;
+    pa_buffer_attr pa_attr = {
+      .maxlength = uint32_t(-1),
+      .tlength = uint32_t(-1),
+      .prebuf = uint32_t(-1),
+      .minreq = uint32_t(-1),
+      .fragsize = uint32_t(frame_size * channels * sizeof(float))
+    };
 
     int status;
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Don't set pulseaudio buffer size.
We only care for fragment size anyway and don't pace consumption.
Should hopefully fix audio cracking in pipewire-pulseaudio.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #2988

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
