### PR TITLE
fix: automatic selection for hybrid GPU and IDDSampleDriver users

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -368,7 +368,7 @@ namespace platf::dxgi {
       std::vector<std::string> args = { std::to_string(i), display_name };
       try {
         if (verify_frame_capture) {
-          args.push_back("--verify-frame-capture");
+          args.emplace_back("--verify-frame-capture");
         }
         result = bp::system(cmd, bp::args(args), bp::std_out > bp::null, bp::std_err > bp::null);
       }

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -377,7 +377,7 @@ namespace platf::dxgi {
         return false;
       }
 
-      BOOST_LOG(info) << "ddprobe.exe " << boost::algorithm::join(args, " ") << "returned 0x"
+      BOOST_LOG(info) << "ddprobe.exe " << boost::algorithm::join(args, " ") << " returned 0x"
                       << util::hex(result).to_string_view();
 
       // E_ACCESSDENIED can happen at the login screen. If we get this error,

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -72,18 +72,18 @@ syncThreadDesktop() {
 }
 
 /**
- * @brief Checks whether a given frame is entirely dark by evaluating the RGB values of each pixel.
- *
- * This function determines if the provided frame is completely dark by analyzing the RGB values of every pixel.
- * It iterates over all pixels in the frame and compares each pixel's RGB channels to a defined darkness threshold.
- * If any pixel's RGB values exceed this threshold, the function concludes that the frame is not entirely dark and returns `false`.
- * If all pixels are below the threshold, indicating a completely dark frame, the function returns `true`.
- *
- * @param mappedResource A reference to a `D3D11_MAPPED_SUBRESOURCE` structure containing the mapped subresource data of the frame to be analyzed.
- * @param frameDesc A reference to a `D3D11_TEXTURE2D_DESC` structure describing the texture properties, including width and height.
- * @param darknessThreshold A floating-point value representing the threshold above which a pixel's RGB values are considered non-dark. The value ranges from 0.0f to 1.0f, with a default value of 0.1f.
- * @return bool Returns `true` if the frame is determined to be entirely dark, otherwise returns `false`.
- */
+  * @brief Determines if a given frame is valid by checking if it contains any non-dark pixels.
+  *
+  * This function analyzes the provided frame to determine if it contains any pixels that exceed a specified darkness threshold.
+  * It iterates over all pixels in the frame, comparing each pixel's RGB values to the defined darkness threshold.
+  * If any pixel's RGB values exceed this threshold, the function concludes that the frame is valid (i.e., not entirely dark) and returns `true`.
+  * If all pixels are below or equal to the threshold, indicating a completely dark frame, the function returns `false`.
+
+  * @param mappedResource A reference to a `D3D11_MAPPED_SUBRESOURCE` structure containing the mapped subresource data of the frame to be analyzed.
+  * @param frameDesc A reference to a `D3D11_TEXTURE2D_DESC` structure describing the texture properties, including width and height.
+  * @param darknessThreshold A floating-point value representing the threshold above which a pixel's RGB values are considered dark. The value ranges from 0.0f to 1.0f, with a default value of 0.1f.
+  * @return bool Returns `true` if the frame contains any non-dark pixels, indicating it is valid; otherwise, returns `false`.
+  */
 bool
 is_valid_frame(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTURE2D_DESC &frameDesc, float darknessThreshold = 0.1f) {
   const uint8_t *pixels = static_cast<const uint8_t *>(mappedResource.pData);

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -147,7 +147,7 @@ test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
     std::cout << "Frame acquired successfully." << std::endl;
 
     ComPtr<ID3D11Texture2D> frameTexture;
-    HRESULT status = frameResource->QueryInterface(IID_PPV_ARGS(&frameTexture));
+    status = frameResource->QueryInterface(IID_PPV_ARGS(&frameTexture));
     if (FAILED(status)) {
       std::cout << "Error: Failed to query texture interface from frame resource [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
       return status;
@@ -176,7 +176,7 @@ test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
     }
 
     auto contextCleanup = util::fail_guard([&context, &stagingTexture]() {
-      context->Unmap(stagingTexture.Get());
+      context->Unmap(stagingTexture.Get(), 0);
     });
 
     if (is_valid_frame(mappedResource, frameDesc)) {

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -116,12 +116,12 @@ is_valid_frame(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTU
  * This function attempts to acquire and analyze up to 10 frames from a DXGI output duplication object (`dup`).
  * It checks if each frame is non-empty (not entirely dark) by using the `is_valid_frame` function.
  * If any non-empty frame is found, the function returns `S_OK`.
- * If all 10 frames are empty, it returns `S_FALSE`, suggesting potential issues with the capture process.
+ * If all 10 frames are empty, it returns `E_FAIL`, suggesting potential issues with the capture process.
  * If any error occurs during the frame acquisition or analysis process, the corresponding `HRESULT` error code is returned.
  *
  * @param dup A reference to the DXGI output duplication object (`dxgi::dup_t&`) used to acquire frames.
  * @param device A ComPtr to the ID3D11Device interface representing the device associated with the Direct3D context.
- * @return HRESULT Returns `S_OK` if a non-empty frame is captured successfully, `E_FAIL` if all frames are empty, or an error code if any failure occurs during the process.
+ * @return Returns `S_OK` if a non-empty frame is captured successfully, `E_FAIL` if all frames are empty, or an error code if any failure occurs during the process.
  */
 HRESULT
 test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -151,7 +151,7 @@ test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
     std::cout << "Frame acquired successfully." << std::endl;
 
     ComPtr<ID3D11Texture2D> frameTexture;
-    status = frameResource->QueryInterface(__uuidof(ID3D11Texture2D), reinterpret_cast<void **>(frameTexture.GetAddressOf()));
+    status = frameResource->QueryInterface(IID_PPV_ARGS(&frameTexture));
     if (FAILED(status)) {
       std::cout << "Error: Failed to query texture interface from frame resource [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
       return status;

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -69,9 +69,132 @@ syncThreadDesktop() {
   CloseDesktop(hDesk);
 }
 
+
+/**
+ * @brief Determines whether a given frame is entirely black by sampling pixels.
+ * 
+ * This function checks if the provided frame is predominantly black by sampling every 10th pixel in both the x and y dimensions. It inspects the RGB channels of each sampled pixel and compares them against a specified black threshold. If any sampled pixel's RGB values exceed this threshold, the frame is considered not black, and the function returns `false`. Otherwise, if all sampled pixels are below the threshold, the function returns `true`.
+ * 
+ * @param mappedResource A reference to a `D3D11_MAPPED_SUBRESOURCE` structure that contains the mapped subresource data of the frame to be analyzed.
+ * @param frameDesc A reference to a `D3D11_TEXTURE2D_DESC` structure that describes the texture properties, including width and height.
+ * @param blackThreshold A floating-point value representing the threshold above which a pixel's RGB channels are considered non-black. The value ranges from 0.0f to 1.0f, with a default value of 0.1f.
+ * @return bool Returns `true` if the frame is determined to be black, otherwise returns `false`.
+ */
+bool
+isFrameBlack(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTURE2D_DESC &frameDesc, float blackThreshold = 0.1f) {
+  const uint8_t *pixels = static_cast<const uint8_t *>(mappedResource.pData);
+  const int bytesPerPixel = 4;  // Assuming RGBA format
+  const int stride = mappedResource.RowPitch;
+  const int width = frameDesc.Width;
+  const int height = frameDesc.Height;
+
+  // Sample every 10th pixel in both dimensions
+  const int sampleStep = 10;
+  const int threshold = static_cast<int>(blackThreshold * 255);
+
+  for (int y = 0; y < height; y += sampleStep) {
+    for (int x = 0; x < width; x += sampleStep) {
+      const uint8_t *pixel = pixels + y * stride + x * bytesPerPixel;
+      // Check if any channel (R, G, B) is significantly above black
+      if (pixel[0] > threshold || pixel[1] > threshold || pixel[2] > threshold) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Attempts to capture and verify the contents of up to 10 consecutive frames from a DXGI output duplication.
+ *
+ * This function tries to acquire the next frame from a provided DXGI output duplication object (`dup`) and inspects its content to determine if the frame is not completely black. If a non-black frame is found within the 10 attempts, the function returns `S_OK`. If all 10 frames are black, it returns `S_FALSE`, indicating that the capture might not be functioning properly. In case of any failure during the process, the appropriate `HRESULT` error code is returned.
+ *
+ * @param dup A reference to the DXGI output duplication object (`dxgi::dup_t&`) used to acquire frames.
+ * @param device A pointer to the ID3D11Device interface that represents the device associated with the Direct3D context.
+ * @return HRESULT Returns `S_OK` if a non-black frame is captured successfully, `S_FALSE` if all frames are black, or an error code if a failure occurs during the process.
+ *
+ * Possible return values:
+ * - `S_OK`: A non-black frame was captured, indicating capture was successful.
+ * - `S_FALSE`: All 10 frames were black, indicating potential capture issues.
+ * - `E_FAIL`, `DXGI_ERROR_*`, or other DirectX HRESULT error codes in case of specific failures during frame capture, texture creation, or resource mapping.
+ */
+HRESULT
+test_frame_capture(dxgi::dup_t &dup, ID3D11Device *device) {
+  for (int i = 0; i < 10; ++i) {
+    std::cout << "Attempting to acquire the next frame (" << i + 1 << "/10)..." << std::endl;
+    IDXGIResource *frameResource = nullptr;
+    DXGI_OUTDUPL_FRAME_INFO frameInfo;
+    HRESULT status = dup->AcquireNextFrame(500, &frameInfo, &frameResource);
+    if (FAILED(status)) {
+      std::cout << "Failed to acquire next frame [0x" << std::hex << status << "]" << std::endl;
+      return status;
+    }
+
+    std::cout << "Frame acquired successfully." << std::endl;
+
+    ID3D11Texture2D *frameTexture = nullptr;
+    status = frameResource->QueryInterface(__uuidof(ID3D11Texture2D), (void **) &frameTexture);
+    frameResource->Release();
+    if (FAILED(status)) {
+      std::cout << "Failed to query texture interface from frame resource [0x" << std::hex << status << "]" << std::endl;
+      return status;
+    }
+
+    D3D11_TEXTURE2D_DESC frameDesc;
+    frameTexture->GetDesc(&frameDesc);
+    frameDesc.Usage = D3D11_USAGE_STAGING;
+    frameDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+    frameDesc.BindFlags = 0;
+    frameDesc.MiscFlags = 0;
+
+    ID3D11Texture2D *stagingTexture = nullptr;
+    status = device->CreateTexture2D(&frameDesc, nullptr, &stagingTexture);
+    if (FAILED(status)) {
+      std::cout << "Failed to create staging texture [0x" << std::hex << status << "]" << std::endl;
+      frameTexture->Release();
+      return status;
+    }
+
+    ID3D11DeviceContext *context = nullptr;
+    device->GetImmediateContext(&context);
+    context->CopyResource(stagingTexture, frameTexture);
+    frameTexture->Release();
+
+    D3D11_MAPPED_SUBRESOURCE mappedResource;
+    status = context->Map(stagingTexture, 0, D3D11_MAP_READ, 0, &mappedResource);
+    if (SUCCEEDED(status)) {
+      std::cout << "Verifying if frame is not empty" << std::endl;
+
+      if (!isFrameBlack(mappedResource, frameDesc)) {
+        std::cout << "Frame " << i + 1 << " is not empty!" << std::endl;
+        context->Unmap(stagingTexture, 0);
+        stagingTexture->Release();
+        context->Release();
+        dup->ReleaseFrame();
+        return S_OK;
+      }
+      context->Unmap(stagingTexture, 0);
+    }
+    else {
+      std::cout << "Failed to map the staging texture for inspection [0x" << std::hex << status << "]" << std::endl;
+      stagingTexture->Release();
+      context->Release();
+      return status;
+    }
+
+    stagingTexture->Release();
+    context->Release();
+    std::cout << "Releasing the frame..." << std::endl;
+    dup->ReleaseFrame();
+  }
+
+  // If all frames are black, then we can assume the capture isn't working properly.
+  return S_FALSE;
+}
+
 HRESULT
 test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
-  D3D_FEATURE_LEVEL featureLevels[] {
+  D3D_FEATURE_LEVEL featureLevels[] = {
     D3D_FEATURE_LEVEL_11_1,
     D3D_FEATURE_LEVEL_11_0,
     D3D_FEATURE_LEVEL_10_1,
@@ -82,7 +205,7 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
   };
 
   dxgi::device_t device;
-  auto status = D3D11CreateDevice(
+  HRESULT status = D3D11CreateDevice(
     adapter.get(),
     D3D_DRIVER_TYPE_UNKNOWN,
     nullptr,
@@ -92,24 +215,41 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
     &device,
     nullptr,
     nullptr);
+
   if (FAILED(status)) {
-    std::cout << "Failed to create D3D11 device for DD test [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
+    std::cout << "Failed to create D3D11 device for DD test [0x" << std::hex << status << "]" << std::endl;
     return status;
   }
 
   dxgi::output1_t output1;
   status = output->QueryInterface(IID_IDXGIOutput1, (void **) &output1);
   if (FAILED(status)) {
-    std::cout << "Failed to query IDXGIOutput1 from the output"sv << std::endl;
+    std::cout << "Failed to query IDXGIOutput1 from the output [0x" << std::hex << status << "]" << std::endl;
     return status;
   }
 
   // Ensure we can duplicate the current display
   syncThreadDesktop();
 
-  // Return the result of DuplicateOutput() to Sunshine
+  // Attempt to duplicate the output
   dxgi::dup_t dup;
-  return output1->DuplicateOutput((IUnknown *) device.get(), &dup);
+  HRESULT result = output1->DuplicateOutput(static_cast<IUnknown *>(device.get()), &dup);
+
+  if (SUCCEEDED(result)) {
+    // If duplication is successful, test frame capture
+    HRESULT captureResult = test_frame_capture(dup, device.get());
+    if (SUCCEEDED(captureResult)) {
+      return S_OK;
+    }
+    else {
+      std::cout << "Frame capture test failed [0x" << std::hex << captureResult << "]" << std::endl;
+      return captureResult;
+    }
+  }
+  else {
+    std::cout << "Failed to duplicate output [0x" << std::hex << result << "]" << std::endl;
+    return result;
+  }
 }
 
 int

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -213,14 +213,14 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
     nullptr);
 
   if (FAILED(status)) {
-    std::cout << "Failed to create D3D11 device for DD test [0x" << std::hex << status << "]" << std::endl;
+    std::cout << "Failed to create D3D11 device for DD test [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
     return status;
   }
 
   dxgi::output1_t output1;
   status = output->QueryInterface(IID_IDXGIOutput1, (void **) &output1);
   if (FAILED(status)) {
-    std::cout << "Failed to query IDXGIOutput1 from the output [0x" << std::hex << status << "]" << std::endl;
+    std::cout << "Failed to query IDXGIOutput1 from the output [0x"sv << util::hex(status).to_string_view() << "]" << std::endl;
     return status;
   }
 
@@ -239,12 +239,12 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
       return S_OK;
     }
     else {
-      std::cout << "Frame capture test failed [0x" << std::hex << captureResult << "]" << std::endl;
+      std::cout << "Frame capture test failed [0x"sv << util::hex(captureResult).to_string_view() << "]" << std::endl;
       return captureResult;
     }
   }
   else {
-    std::cout << "Failed to duplicate output [0x" << std::hex << result << "]" << std::endl;
+    std::cout << "Failed to duplicate output [0x"sv << util::hex(result).to_string_view() << "]" << std::endl;
     return result;
   }
 }

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -248,7 +248,6 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output, bool ver
     }
   }
 
-
   return S_OK;
 }
 

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -127,7 +127,6 @@ HRESULT
 test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
   for (int i = 0; i < 10; ++i) {
     std::cout << "Attempting to acquire frame " << (i + 1) << " of 10..." << std::endl;
-
     ComPtr<IDXGIResource> frameResource;
     DXGI_OUTDUPL_FRAME_INFO frameInfo;
     ComPtr<ID3D11DeviceContext> context;
@@ -136,22 +135,19 @@ test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
     HRESULT status = dup->AcquireNextFrame(500, &frameInfo, &frameResource);
     device->GetImmediateContext(&context);
 
-    auto cleanup = util::fail_guard([&dup, &context, &stagingTexture]() {
-      if (stagingTexture) {
-        context->Unmap(stagingTexture.Get(), 0);
-      }
-      dup->ReleaseFrame();
-    });
-
     if (FAILED(status)) {
       std::cout << "Error: Failed to acquire next frame [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
       return status;
     }
 
+    auto cleanup = util::fail_guard([&dup]() {
+      dup->ReleaseFrame();
+    });
+
     std::cout << "Frame acquired successfully." << std::endl;
 
     ComPtr<ID3D11Texture2D> frameTexture;
-    status = frameResource->QueryInterface(IID_PPV_ARGS(&frameTexture));
+    HRESULT status = frameResource->QueryInterface(IID_PPV_ARGS(&frameTexture));
     if (FAILED(status)) {
       std::cout << "Error: Failed to query texture interface from frame resource [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
       return status;
@@ -178,6 +174,10 @@ test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
       std::cout << "Error: Failed to map the staging texture for inspection [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
       return status;
     }
+
+    auto contextCleanup = util::fail_guard([&context, &stagingTexture]() {
+      context->Unmap(stagingTexture.Get());
+    });
 
     if (is_valid_frame(mappedResource, frameDesc)) {
       std::cout << "Frame " << (i + 1) << " is non-empty (contains visible content)." << std::endl;

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -86,14 +86,14 @@ syncThreadDesktop() {
   */
 bool
 is_valid_frame(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTURE2D_DESC &frameDesc, float darknessThreshold = 0.1f) {
-  const uint8_t *pixels = static_cast<const uint8_t *>(mappedResource.pData);
+  const auto *pixels = static_cast<const uint8_t *>(mappedResource.pData);
   const int bytesPerPixel = 4;  // (8 bits per channel, excluding alpha). Factoring HDR is not needed because it doesn't cause black levels to raise enough to be a concern.
   const int stride = mappedResource.RowPitch;
   const int width = frameDesc.Width;
   const int height = frameDesc.Height;
 
   // Convert the darkness threshold to an integer value for comparison
-  const int threshold = static_cast<int>(darknessThreshold * 255);
+  const auto threshold = static_cast<int>(darknessThreshold * 255);
 
   // Iterate over each pixel in the frame
   for (int y = 0; y < height; ++y) {

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -71,9 +71,9 @@ syncThreadDesktop() {
 
 
 /**
- * @brief Determines whether a given frame is entirely black by sampling pixels.
+ * @brief Determines whether a given frame is entirely black by checking every pixel.
  * 
- * This function checks if the provided frame is predominantly black by sampling every 10th pixel in both the x and y dimensions. It inspects the RGB channels of each sampled pixel and compares them against a specified black threshold. If any sampled pixel's RGB values exceed this threshold, the frame is considered not black, and the function returns `false`. Otherwise, if all sampled pixels are below the threshold, the function returns `true`.
+ * This function checks if the provided frame is entirely black by inspecting each pixel in both the x and y dimensions. It inspects the RGB channels of each pixel and compares them against a specified black threshold. If any pixel's RGB values exceed this threshold, the frame is considered not black, and the function returns `false`. Otherwise, if all pixels are below the threshold, the function returns `true`.
  * 
  * @param mappedResource A reference to a `D3D11_MAPPED_SUBRESOURCE` structure that contains the mapped subresource data of the frame to be analyzed.
  * @param frameDesc A reference to a `D3D11_TEXTURE2D_DESC` structure that describes the texture properties, including width and height.
@@ -88,12 +88,12 @@ isFrameBlack(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTURE
   const int width = frameDesc.Width;
   const int height = frameDesc.Height;
 
-  // Sample every 10th pixel in both dimensions
-  const int sampleStep = 10;
+  // Convert the threshold to an integer value for comparison
   const int threshold = static_cast<int>(blackThreshold * 255);
 
-  for (int y = 0; y < height; y += sampleStep) {
-    for (int x = 0; x < width; x += sampleStep) {
+  // Loop through every pixel
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
       const uint8_t *pixel = pixels + y * stride + x * bytesPerPixel;
       // Check if any channel (R, G, B) is significantly above black
       if (pixel[0] > threshold || pixel[1] > threshold || pixel[2] > threshold) {
@@ -103,6 +103,7 @@ isFrameBlack(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTURE
   }
   return true;
 }
+
 
 /**
  * @brief Attempts to capture and verify the contents of up to 10 consecutive frames from a DXGI output duplication.

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -188,6 +188,7 @@ test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
   // All frames were empty, indicating potential capture issues.
   return S_FALSE;
 }
+
 HRESULT
 test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
   D3D_FEATURE_LEVEL featureLevels[] = {
@@ -232,21 +233,19 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
   ComPtr<ID3D11Device> device_ptr(device.get());
   HRESULT result = output1->DuplicateOutput(device_ptr.Get(), &dup);
 
-  if (SUCCEEDED(result)) {
-    // If duplication is successful, test frame capture
-    HRESULT captureResult = test_frame_capture(dup, device_ptr.Get());
-    if (SUCCEEDED(captureResult)) {
-      return S_OK;
-    }
-    else {
-      std::cout << "Frame capture test failed [0x"sv << util::hex(captureResult).to_string_view() << "]" << std::endl;
-      return captureResult;
-    }
-  }
-  else {
+  if (FAILED(result)) {
     std::cout << "Failed to duplicate output [0x"sv << util::hex(result).to_string_view() << "]" << std::endl;
     return result;
   }
+
+  // If duplication is successful, test frame capture
+  HRESULT captureResult = test_frame_capture(dup, device_ptr.Get());
+  if (FAILED(captureResult)) {
+    std::cout << "Frame capture test failed [0x"sv << util::hex(captureResult).to_string_view() << "]" << std::endl;
+    return captureResult;
+  }
+
+  return S_OK;
 }
 
 int

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -13,9 +13,8 @@
 
 #include "src/utility.h"
 
-using namespace std::literals;
 using Microsoft::WRL::ComPtr;
-
+using namespace std::literals;
 namespace dxgi {
   template <class T>
   void
@@ -191,7 +190,7 @@ test_frame_capture(dxgi::dup_t &dup, ComPtr<ID3D11Device> device) {
 
 HRESULT
 test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
-  D3D_FEATURE_LEVEL featureLevels[] = {
+  D3D_FEATURE_LEVEL featureLevels[] {
     D3D_FEATURE_LEVEL_11_1,
     D3D_FEATURE_LEVEL_11_0,
     D3D_FEATURE_LEVEL_10_1,
@@ -202,7 +201,7 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
   };
 
   dxgi::device_t device;
-  HRESULT status = D3D11CreateDevice(
+  auto status = D3D11CreateDevice(
     adapter.get(),
     D3D_DRIVER_TYPE_UNKNOWN,
     nullptr,
@@ -212,7 +211,6 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
     &device,
     nullptr,
     nullptr);
-
   if (FAILED(status)) {
     std::cout << "Failed to create D3D11 device for DD test [0x"sv << util::hex(status).to_string_view() << ']' << std::endl;
     return status;
@@ -221,7 +219,7 @@ test_dxgi_duplication(dxgi::adapter_t &adapter, dxgi::output_t &output) {
   dxgi::output1_t output1;
   status = output->QueryInterface(IID_IDXGIOutput1, (void **) &output1);
   if (FAILED(status)) {
-    std::cout << "Failed to query IDXGIOutput1 from the output [0x"sv << util::hex(status).to_string_view() << "]" << std::endl;
+    std::cout << "Failed to query IDXGIOutput1 from the output"sv << std::endl;
     return status;
   }
 

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -82,7 +82,7 @@ syncThreadDesktop() {
   * @param mappedResource A reference to a `D3D11_MAPPED_SUBRESOURCE` structure containing the mapped subresource data of the frame to be analyzed.
   * @param frameDesc A reference to a `D3D11_TEXTURE2D_DESC` structure describing the texture properties, including width and height.
   * @param darknessThreshold A floating-point value representing the threshold above which a pixel's RGB values are considered dark. The value ranges from 0.0f to 1.0f, with a default value of 0.1f.
-  * @return bool Returns `true` if the frame contains any non-dark pixels, indicating it is valid; otherwise, returns `false`.
+  * @return Returns `true` if the frame contains any non-dark pixels, indicating it is valid; otherwise, returns `false`.
   */
 bool
 is_valid_frame(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTURE2D_DESC &frameDesc, float darknessThreshold = 0.1f) {

--- a/tools/ddprobe.cpp
+++ b/tools/ddprobe.cpp
@@ -69,12 +69,11 @@ syncThreadDesktop() {
   CloseDesktop(hDesk);
 }
 
-
 /**
  * @brief Determines whether a given frame is entirely black by checking every pixel.
- * 
+ *
  * This function checks if the provided frame is entirely black by inspecting each pixel in both the x and y dimensions. It inspects the RGB channels of each pixel and compares them against a specified black threshold. If any pixel's RGB values exceed this threshold, the frame is considered not black, and the function returns `false`. Otherwise, if all pixels are below the threshold, the function returns `true`.
- * 
+ *
  * @param mappedResource A reference to a `D3D11_MAPPED_SUBRESOURCE` structure that contains the mapped subresource data of the frame to be analyzed.
  * @param frameDesc A reference to a `D3D11_TEXTURE2D_DESC` structure that describes the texture properties, including width and height.
  * @param blackThreshold A floating-point value representing the threshold above which a pixel's RGB channels are considered non-black. The value ranges from 0.0f to 1.0f, with a default value of 0.1f.
@@ -103,7 +102,6 @@ isFrameBlack(const D3D11_MAPPED_SUBRESOURCE &mappedResource, const D3D11_TEXTURE
   }
   return true;
 }
-
 
 /**
  * @brief Attempts to capture and verify the contents of up to 10 consecutive frames from a DXGI output duplication.


### PR DESCRIPTION
## Description
Enhances the ddprobe utility to test to see if frames can be captured and that they are also not empty frames. If one of the 10 frames captured is not empty, it will return back successful. Previously it was only testing to see if it can be duplicated, but would fail on capturing frames which would cause Sunshine to pick the wrong GPU.


### Screenshot
N/A


### Issues Fixed or Closed
- Fixes #2203 
- Fixes #2076
- Fixes #2875
- Fixes #2078
- Fixes #1632




## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
