### PR TITLE
Remove unnecessary tray_update() calls

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -248,19 +248,16 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
-    tray.icon = TRAY_ICON_PLAYING;
-    tray_update(&tray);
-    tray.icon = TRAY_ICON_PLAYING;
-    tray.notification_title = "Stream Started";
     char msg[256];
     snprintf(msg, std::size(msg), "Streaming started for %s", app_name.c_str());
-    tray.notification_text = msg;
+
+    tray.icon = TRAY_ICON_PLAYING;
     tray.tooltip = msg;
     tray.notification_icon = TRAY_ICON_PLAYING;
+    tray.notification_title = "Stream Started";
+    tray.notification_text = msg;
+    tray.notification_cb = NULL;
+
     tray_update(&tray);
   }
 
@@ -270,19 +267,16 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
-    tray.icon = TRAY_ICON_PAUSING;
-    tray_update(&tray);
     char msg[256];
     snprintf(msg, std::size(msg), "Streaming paused for %s", app_name.c_str());
+
     tray.icon = TRAY_ICON_PAUSING;
-    tray.notification_title = "Stream Paused";
-    tray.notification_text = msg;
     tray.tooltip = msg;
     tray.notification_icon = TRAY_ICON_PAUSING;
+    tray.notification_title = "Stream Paused";
+    tray.notification_text = msg;
+    tray.notification_cb = NULL;
+
     tray_update(&tray);
   }
 
@@ -292,19 +286,16 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
-    tray.icon = TRAY_ICON;
-    tray_update(&tray);
     char msg[256];
     snprintf(msg, std::size(msg), "Application %s successfully stopped", app_name.c_str());
+
     tray.icon = TRAY_ICON;
+    tray.tooltip = PROJECT_NAME;
     tray.notification_icon = TRAY_ICON;
     tray.notification_title = "Application Stopped";
     tray.notification_text = msg;
-    tray.tooltip = PROJECT_NAME;
+    tray.notification_cb = NULL;
+
     tray_update(&tray);
   }
 
@@ -314,20 +305,13 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
     tray.icon = TRAY_ICON;
-    tray_update(&tray);
-    tray.icon = TRAY_ICON;
+    tray.tooltip = PROJECT_NAME;
+    tray.notification_icon = TRAY_ICON_LOCKED;
     tray.notification_title = "Incoming Pairing Request";
     tray.notification_text = "Click here to complete the pairing process";
-    tray.notification_icon = TRAY_ICON_LOCKED;
-    tray.tooltip = PROJECT_NAME;
-    tray.notification_cb = []() {
-      launch_ui_with_path("/pin");
-    };
+    tray.notification_cb = [] { launch_ui_with_path("/pin"); };
+
     tray_update(&tray);
   }
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Remove unnecessary tray_update() calls.
They're unsafe on Windows outside of UI thread.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #2065

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
