### PR TITLE
fix(linux): ensure NvFBC capture works after multiple sessions

### DIFF
--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -574,7 +574,7 @@ namespace cuda {
         if (func.nvFBCBindContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't bind NvFBC context to current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
-        BOOST_LOG(error) << "Bound context"sv;
+        
 
         this->handle = handle;
       }
@@ -584,7 +584,7 @@ namespace cuda {
         if (func.nvFBCReleaseContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't release NvFBC context from current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
-        BOOST_LOG(error) << "Released context"sv;
+        
       }
 
       NVFBC_SESSION_HANDLE handle;

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -574,7 +574,7 @@ namespace cuda {
         if (func.nvFBCBindContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't bind NvFBC context to current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
-        BOOST_LOG(error) << "Bound context"
+        BOOST_LOG(error) << "Bound context"sv;
 
         this->handle = handle;
       }
@@ -584,7 +584,7 @@ namespace cuda {
         if (func.nvFBCReleaseContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't release NvFBC context from current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
-        BOOST_LOG(error) << "Released context"
+        BOOST_LOG(error) << "Released context"sv;
       }
 
       NVFBC_SESSION_HANDLE handle;

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -702,7 +702,7 @@ namespace cuda {
 
         NVFBC_DESTROY_HANDLE_PARAMS params { NVFBC_DESTROY_HANDLE_PARAMS_VER };
 
-        ctx_t ctx { handle.handle};
+        ctx_t ctx { handle->handle };
         if (func.nvFBCDestroyHandle(handle, &params)) {
           BOOST_LOG(error) << "Couldn't destroy session handle: "sv << func.nvFBCGetLastErrorStr(handle);
         }

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -702,6 +702,7 @@ namespace cuda {
 
         NVFBC_DESTROY_HANDLE_PARAMS params { NVFBC_DESTROY_HANDLE_PARAMS_VER };
 
+        ctx_t ctx { handle.handle};
         if (func.nvFBCDestroyHandle(handle, &params)) {
           BOOST_LOG(error) << "Couldn't destroy session handle: "sv << func.nvFBCGetLastErrorStr(handle);
         }

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -702,7 +702,7 @@ namespace cuda {
 
         NVFBC_DESTROY_HANDLE_PARAMS params { NVFBC_DESTROY_HANDLE_PARAMS_VER };
 
-        ctx_t ctx { handle->handle };
+        ctx_t ctx { handle };
         if (func.nvFBCDestroyHandle(handle, &params)) {
           BOOST_LOG(error) << "Couldn't destroy session handle: "sv << func.nvFBCGetLastErrorStr(handle);
         }

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -574,6 +574,7 @@ namespace cuda {
         if (func.nvFBCBindContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't bind NvFBC context to current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
+        BOOST_LOG(error) << "Bound context"
 
         this->handle = handle;
       }
@@ -583,6 +584,7 @@ namespace cuda {
         if (func.nvFBCReleaseContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't release NvFBC context from current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
+        BOOST_LOG(error) << "Released context"
       }
 
       NVFBC_SESSION_HANDLE handle;

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -574,7 +574,6 @@ namespace cuda {
         if (func.nvFBCBindContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't bind NvFBC context to current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
-        
 
         this->handle = handle;
       }
@@ -584,7 +583,6 @@ namespace cuda {
         if (func.nvFBCReleaseContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't release NvFBC context from current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
-        
       }
 
       NVFBC_SESSION_HANDLE handle;


### PR DESCRIPTION
## Description
Please excuse the code. Basically I had a suspicion that the 'ctx_t' helper in the NvFBC code path was releasing the context early and that the exhaustion of session handles was causing the "can only reconnect 2-4 times" before it fails to reconnect bug. #2974 

So I tried a dirty workaround of binding the context before destroying the session handle. And guess what, it works. 

I also added some error logs around when it binds and unbinds the context to confirm my suspicions. 

Really the whole code needs to be reworked to ensure the ctx_t class remains in scope correctly. But that's a little above my skill level. 



### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Fixes #2974 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
