### PR TITLE
fix(win/qsv): skip unsupported 4:4:4 codecs

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1871,6 +1871,13 @@ namespace platf::dxgi {
       if (!boost::algorithm::ends_with(name, "_qsv")) {
         return false;
       }
+      if (config.chromaSamplingType == 1) {
+        if (config.videoFormat == 0 || config.videoFormat == 2) {
+          // QSV doesn't support 4:4:4 in H.264 or AV1
+          return false;
+        }
+        // TODO: Blacklist HEVC 4:4:4 based on adapter model
+      }
     }
     else if (adapter_desc.VendorId == 0x10de) {  // Nvidia
       // If it's not an NVENC encoder, it's not compatible with an Nvidia GPU

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1434,9 +1434,7 @@ namespace video {
 
     bool hardware = platform_formats->avcodec_base_dev_type != AV_HWDEVICE_TYPE_NONE;
 
-    auto &video_format = config.videoFormat == 0 ? encoder.h264 :
-                         config.videoFormat == 1 ? encoder.hevc :
-                                                   encoder.av1;
+    auto &video_format = encoder.codec_from_config(config);
     if (!video_format[encoder_t::PASSED] || !disp->is_codec_supported(video_format.name, config)) {
       BOOST_LOG(error) << encoder.name << ": "sv << video_format.name << " mode not supported"sv;
       return nullptr;
@@ -1950,10 +1948,7 @@ namespace video {
     }
 
     {
-      auto encoder_name = config.videoFormat == 0 ? encoder.h264.name :
-                          config.videoFormat == 1 ? encoder.hevc.name :
-                          config.videoFormat == 2 ? encoder.av1.name :
-                                                    "unknown";
+      auto encoder_name = encoder.codec_from_config(config).name;
 
       BOOST_LOG(info) << "Creating encoder " << logging::bracket(encoder_name);
 
@@ -2516,7 +2511,8 @@ namespace video {
       // H.264 is special because encoders may support YUV 4:4:4 without supporting 10-bit color depth
       if (encoder.flags & YUV444_SUPPORT) {
         config_t config_h264_yuv444 { 1920, 1080, 60, 1000, 1, 0, 1, 0, 0, 1 };
-        encoder.h264[encoder_t::YUV444] = validate_config(disp, encoder, config_h264_yuv444);
+        encoder.h264[encoder_t::YUV444] = disp->is_codec_supported(encoder.h264.name, config_h264_yuv444) &&
+                                          validate_config(disp, encoder, config_h264_yuv444) >= 0;
       }
       else {
         encoder.h264[encoder_t::YUV444] = false;
@@ -2536,10 +2532,7 @@ namespace video {
 
         if (!flag_map[encoder_t::PASSED]) return;
 
-        auto encoder_codec_name = (video_format == 0) ? encoder.h264.name :
-                                  (video_format == 1) ? encoder.hevc.name :
-                                  (video_format == 2) ? encoder.av1.name :
-                                                        "unknown"s;
+        auto encoder_codec_name = encoder.codec_from_config(config).name;
 
         // Test 4:4:4 HDR first. If 4:4:4 is supported, 4:2:0 should also be supported.
         config.chromaSamplingType = 1;


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Skip particular QSV 4:4:4 codecs bypassing ffmpeg.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
