### PR TITLE
fix(packaging): apply udev rules for uhid

### DIFF
--- a/packaging/linux/AppImage/AppRun
+++ b/packaging/linux/AppImage/AppRun
@@ -49,6 +49,7 @@ function install() {
   cat "$SUNSHINE_SHARE_HERE/udev/rules.d/60-sunshine.rules" | sudo tee /etc/udev/rules.d/60-sunshine.rules
   sudo udevadm control --reload-rules
   sudo udevadm trigger --property-match=DEVNAME=/dev/uinput
+  sudo udevadm trigger --property-match=DEVNAME=/dev/uhid
 
   # sunshine service
   mkdir -p ~/.config/systemd/user

--- a/packaging/linux/Arch/sunshine.install
+++ b/packaging/linux/Arch/sunshine.install
@@ -5,7 +5,9 @@ do_setcap() {
 do_udev_reload() {
   udevadm control --reload-rules
   udevadm trigger --property-match=DEVNAME=/dev/uinput
+  udevadm trigger --property-match=DEVNAME=/dev/uhid
   modprobe uinput || true
+  modprobe uhid || true
 }
 
 post_install() {

--- a/src_assets/linux/misc/postinst
+++ b/src_assets/linux/misc/postinst
@@ -8,9 +8,10 @@ if [ -x "$path_to_setcap" ] ; then
         $path_to_setcap cap_sys_admin+p $path_to_sunshine
 fi
 
-# Trigger udev rule reload for /dev/uinput
+# Trigger udev rule reload for /dev/uinput and /dev/uhid
 path_to_udevadm=$(which udevadm)
 if [ -x "$path_to_udevadm" ] ; then
   $path_to_udevadm control --reload-rules
   $path_to_udevadm trigger --property-match=DEVNAME=/dev/uinput
+  $path_to_udevadm trigger --property-match=DEVNAME=/dev/uhid
 fi


### PR DESCRIPTION
## Description
#2606 missed several places where we need to reload uhid rules, so DS5 emulation is broken after installation on most distros.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
