### PR TITLE
build(cmake): allow custom npm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1037,7 +1037,6 @@ jobs:
             mingw-w64-ucrt-x86_64-graphviz \
             mingw-w64-ucrt-x86_64-miniupnpc \
             mingw-w64-ucrt-x86_64-nlohmann-json \
-            mingw-w64-ucrt-x86_64-nodejs \
             mingw-w64-ucrt-x86_64-nsis \
             mingw-w64-ucrt-x86_64-onevpl \
             mingw-w64-ucrt-x86_64-openssl \
@@ -1068,6 +1067,17 @@ jobs:
 
           # Clean up
           Remove-Item -Path doxygen-setup.exe
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+
+      - name: npm Path
+        shell: msys2 {0}
+        run: |
+          echo 'export PATH=$PATH:/c/Program\ Files/nodejs' >> /home/runneradmin/.bashrc
+          cat /home/runneradmin/.bashrc
 
       - name: Setup python
         id: setup-python
@@ -1100,6 +1110,7 @@ jobs:
             -S . \
             -DBUILD_WERROR=ON \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DNPM_EXECUTABLE="C:\\Program Files\\nodejs\\npm" \
             -DSUNSHINE_ASSETS_DIR=assets \
             -DTESTS_SOFTWARE_ENCODER_UNAVAILABLE='skip'
           ninja -C build

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -2,6 +2,9 @@ option(BUILD_DOCS "Build documentation" ON)
 option(BUILD_TESTS "Build tests" ON)
 option(TESTS_ENABLE_PYTHON_TESTS "Enable Python tests" ON)
 
+# provide the NPM executable to use instead of searching for it
+set(NPM_EXECUTABLE "" CACHE FILEPATH "Path to the NPM executable")
+
 # DirectX11 is not available in GitHub runners, so even software encoding fails
 set(TESTS_SOFTWARE_ENCODER_UNAVAILABLE "fail"
         CACHE STRING "How to handle unavailable software encoders in tests. 'fail/skip'")

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -52,7 +52,11 @@ else()
 endif()
 
 #WebUI build
-find_program(NPM npm REQUIRED)
+if(NPM_EXECUTABLE STREQUAL "")
+    find_program(NPM npm REQUIRED)
+else()
+    set(NPM ${NPM_EXECUTABLE})
+endif()
 add_custom_target(web-ui ALL
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Installing NPM Dependencies and Building the Web UI"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Allow a custom npm path, and use it for Windows. This is really just a test for the vite 5.x build issues.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
