### PR TITLE
fix(mdns): don't hardcode mDNS instance name

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -206,4 +206,32 @@ namespace net {
 
     return mapped_port;
   }
+
+  /**
+   * @brief Returns a string for use as the instance name for mDNS.
+   * @return Hostname-based instance name or "Sunshine" if hostname is invalid.
+   */
+  std::string
+  mdns_instance_name() {
+    std::string hostname = boost::asio::ip::host_name();
+
+    // Truncate to 63 characters per RFC 6763 section 7.2.
+    if (hostname.size() > 63) {
+      hostname.resize(63);
+    }
+
+    for (auto i = 0; i < hostname.size(); i++) {
+      // Replace any spaces with dashes
+      if (hostname[i] == ' ') {
+        hostname[i] = '-';
+      }
+      else if (!std::isalnum(hostname[i]) && hostname[i] != '-') {
+        // Stop at the first invalid character
+        hostname.resize(i);
+        break;
+      }
+    }
+
+    return !hostname.empty() ? hostname : "Sunshine";
+  }
 }  // namespace net

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -209,29 +209,31 @@ namespace net {
 
   /**
    * @brief Returns a string for use as the instance name for mDNS.
+   * @param hostname The hostname to use for instance name generation.
    * @return Hostname-based instance name or "Sunshine" if hostname is invalid.
    */
   std::string
-  mdns_instance_name() {
-    std::string hostname = boost::asio::ip::host_name();
+  mdns_instance_name(const std::string_view &hostname) {
+    // Start with the unmodified hostname
+    std::string instancename { hostname.data(), hostname.size() };
 
     // Truncate to 63 characters per RFC 6763 section 7.2.
-    if (hostname.size() > 63) {
-      hostname.resize(63);
+    if (instancename.size() > 63) {
+      instancename.resize(63);
     }
 
-    for (auto i = 0; i < hostname.size(); i++) {
+    for (auto i = 0; i < instancename.size(); i++) {
       // Replace any spaces with dashes
-      if (hostname[i] == ' ') {
-        hostname[i] = '-';
+      if (instancename[i] == ' ') {
+        instancename[i] = '-';
       }
-      else if (!std::isalnum(hostname[i]) && hostname[i] != '-') {
+      else if (!std::isalnum(instancename[i]) && instancename[i] != '-') {
         // Stop at the first invalid character
-        hostname.resize(i);
+        instancename.resize(i);
         break;
       }
     }
 
-    return !hostname.empty() ? hostname : "Sunshine";
+    return !instancename.empty() ? instancename : "Sunshine";
   }
 }  // namespace net

--- a/src/network.h
+++ b/src/network.h
@@ -108,8 +108,9 @@ namespace net {
 
   /**
    * @brief Returns a string for use as the instance name for mDNS.
+   * @param hostname The hostname to use for instance name generation.
    * @return Hostname-based instance name or "Sunshine" if hostname is invalid.
    */
   std::string
-  mdns_instance_name();
+  mdns_instance_name(const std::string_view &hostname);
 }  // namespace net

--- a/src/network.h
+++ b/src/network.h
@@ -105,4 +105,11 @@ namespace net {
    */
   int
   encryption_mode_for_address(boost::asio::ip::address address);
+
+  /**
+   * @brief Returns a string for use as the instance name for mDNS.
+   * @return Hostname-based instance name or "Sunshine" if hostname is invalid.
+   */
+  std::string
+  mdns_instance_name();
 }  // namespace net

--- a/src/platform/linux/publish.cpp
+++ b/src/platform/linux/publish.cpp
@@ -426,7 +426,7 @@ namespace platf::publish {
       return nullptr;
     }
 
-    auto instance_name = net::mdns_instance_name();
+    auto instance_name = net::mdns_instance_name(boost::asio::ip::host_name());
     name.reset(avahi::strdup(instance_name.c_str()));
 
     client.reset(

--- a/src/platform/linux/publish.cpp
+++ b/src/platform/linux/publish.cpp
@@ -426,7 +426,8 @@ namespace platf::publish {
       return nullptr;
     }
 
-    name.reset(avahi::strdup(SERVICE_NAME));
+    auto instance_name = net::mdns_instance_name();
+    name.reset(avahi::strdup(instance_name.c_str()));
 
     client.reset(
       avahi::client_new(avahi::simple_poll_get(poll.get()), avahi::ClientFlags(0), client_callback, nullptr, &avhi_error));

--- a/src/platform/macos/publish.cpp
+++ b/src/platform/macos/publish.cpp
@@ -105,7 +105,8 @@ namespace platf::publish {
       &serviceRef,
       0,  // flags
       0,  // interfaceIndex
-      SERVICE_NAME, SERVICE_TYPE,
+      nullptr,  // name
+      SERVICE_TYPE,
       nullptr,  // domain
       nullptr,  // host
       htons(net::map_port(nvhttp::PORT_HTTP)),

--- a/src/platform/windows/publish.cpp
+++ b/src/platform/windows/publish.cpp
@@ -37,7 +37,6 @@ constexpr auto DNS_QUERY_RESULTS_VERSION1 = 0x1;
 
 #define SERVICE_DOMAIN "local"
 
-constexpr auto SERVICE_INSTANCE_NAME = SV(SERVICE_NAME "." SERVICE_TYPE "." SERVICE_DOMAIN);
 constexpr auto SERVICE_TYPE_DOMAIN = SV(SERVICE_TYPE "." SERVICE_DOMAIN);
 
 #ifndef __MINGW32__
@@ -107,8 +106,8 @@ namespace platf::publish {
   service(bool enable, PDNS_SERVICE_INSTANCE &existing_instance) {
     auto alarm = safe::make_alarm<PDNS_SERVICE_INSTANCE>();
 
-    std::wstring name { SERVICE_INSTANCE_NAME.data(), SERVICE_INSTANCE_NAME.size() };
     std::wstring domain { SERVICE_TYPE_DOMAIN.data(), SERVICE_TYPE_DOMAIN.size() };
+    std::wstring name = from_utf8(net::mdns_instance_name() + '.') + domain;
 
     auto host = from_utf8(boost::asio::ip::host_name() + ".local");
 

--- a/src/platform/windows/publish.cpp
+++ b/src/platform/windows/publish.cpp
@@ -107,9 +107,10 @@ namespace platf::publish {
     auto alarm = safe::make_alarm<PDNS_SERVICE_INSTANCE>();
 
     std::wstring domain { SERVICE_TYPE_DOMAIN.data(), SERVICE_TYPE_DOMAIN.size() };
-    std::wstring name = from_utf8(net::mdns_instance_name() + '.') + domain;
 
-    auto host = from_utf8(boost::asio::ip::host_name() + ".local");
+    auto hostname = boost::asio::ip::host_name();
+    auto name = from_utf8(net::mdns_instance_name(hostname) + '.') + domain;
+    auto host = from_utf8(hostname + ".local");
 
     DNS_SERVICE_INSTANCE instance {};
     instance.pszInstanceName = name.data();

--- a/tests/unit/test_network.cpp
+++ b/tests/unit/test_network.cpp
@@ -6,18 +6,21 @@
 
 #include "../tests_common.h"
 
-TEST(MdnsInstanceNameTests, ValidLength) {
-  auto name = net::mdns_instance_name();
+struct MdnsInstanceNameTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
-  // The instance name must be 63 characters or less
-  EXPECT_LT(name.size(), 64);
+TEST_P(MdnsInstanceNameTest, Run) {
+  auto [input, expected] = GetParam();
+  ASSERT_EQ(net::mdns_instance_name(input), expected);
 }
 
-TEST(MdnsInstanceNameTests, ValidCharacters) {
-  auto name = net::mdns_instance_name();
-
-  // The string must not contain invalid hostname characters
-  for (const char& c : name) {
-    EXPECT_TRUE(std::isalnum(c) || c == '-');
-  }
-}
+INSTANTIATE_TEST_SUITE_P(
+  MdnsInstanceNameTests,
+  MdnsInstanceNameTest,
+  testing::Values(
+    std::make_tuple("shortname-123", "shortname-123"),
+    std::make_tuple("space 123", "space-123"),
+    std::make_tuple("hostname.domain.test", "hostname"),
+    std::make_tuple("&", "Sunshine"),
+    std::make_tuple("", "Sunshine"),
+    std::make_tuple("😁", "Sunshine"),
+    std::make_tuple(std::string(128, 'a'), std::string(63, 'a'))));

--- a/tests/unit/test_network.cpp
+++ b/tests/unit/test_network.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file tests/unit/test_network.cpp
+ * @brief Test src/network.*
+ */
+#include <src/network.h>
+
+#include "../tests_common.h"
+
+TEST(MdnsInstanceNameTests, ValidLength) {
+  auto name = net::mdns_instance_name();
+
+  // The instance name must be 63 characters or less
+  EXPECT_LT(name.size(), 64);
+}
+
+TEST(MdnsInstanceNameTests, ValidCharacters) {
+  auto name = net::mdns_instance_name();
+
+  // The string must not contain invalid hostname characters
+  for (const char& c : name) {
+    EXPECT_TRUE(std::isalnum(c) || c == '-');
+  }
+}


### PR DESCRIPTION
## Description
All platform mDNS implemenations currently hardcode the instance name to `Sunshine`. This causes reliable name collisions during mDNS registration when more than one Sunshine host is running on the same network. The collision is eventually resolved by appending a number to the name, but this is unnecessary work and delay for nothing. We should just register using our hostname as the instance name most other mDNS services do.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
