### PR TITLE
fix(linux): enable lowlatency mode for AMD

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -612,6 +612,23 @@ namespace platf {
   void
   restart();
 
+  /**
+   * @brief Set an environment variable.
+   * @param name The name of the environment variable.
+   * @param value The value to set the environment variable to.
+   * @return 0 on success, non-zero on failure.
+   */
+  int
+  set_env(const std::string &name, const std::string &value);
+
+  /**
+   * @brief Unset an environment variable.
+   * @param name The name of the environment variable.
+   * @return 0 on success, non-zero on failure.
+   */
+  int
+  unset_env(const std::string &name);
+
   struct buffer_descriptor_t {
     const char *buffer;
     size_t size;

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -326,6 +326,16 @@ namespace platf {
     lifetime::exit_sunshine(0, true);
   }
 
+  int
+  set_env(const std::string &name, const std::string &value) {
+    return setenv(name.c_str(), value.c_str(), 1);
+  }
+
+  int
+  unset_env(const std::string &name) {
+    return unsetenv(name.c_str());
+  }
+
   bool
   request_process_group_exit(std::uintptr_t native_handle) {
     if (kill(-((pid_t) native_handle), SIGTERM) == 0 || errno == ESRCH) {
@@ -913,6 +923,10 @@ namespace platf {
 
   std::unique_ptr<deinit_t>
   init() {
+    // enable low latency mode for AMD
+    // https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30039
+    set_env("AMD_DEBUG", "lowlatency");
+
     // These are allowed to fail.
     gbm::init();
 

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -253,6 +253,16 @@ namespace platf {
     lifetime::exit_sunshine(0, true);
   }
 
+  int
+  set_env(const std::string &name, const std::string &value) {
+    return setenv(name.c_str(), value.c_str(), 1);
+  }
+
+  int
+  unset_env(const std::string &name) {
+    return unsetenv(name.c_str());
+  }
+
   bool
   request_process_group_exit(std::uintptr_t native_handle) {
     if (killpg((pid_t) native_handle, SIGTERM) == 0 || errno == ESRCH) {

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1313,6 +1313,16 @@ namespace platf {
     lifetime::exit_sunshine(0, true);
   }
 
+  int
+  set_env(const std::string &name, const std::string &value) {
+    return _putenv_s(name.c_str(), value.c_str());
+  }
+
+  int
+  unset_env(const std::string &name) {
+    return _putenv_s(name.c_str(), "");
+  }
+
   struct enum_wnd_context_t {
     std::set<DWORD> process_ids;
     bool requested_exit;

--- a/tests/unit/platform/test_common.cpp
+++ b/tests/unit/platform/test_common.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file tests/unit/platform/test_common.cpp
+ * @brief Test src/platform/common.*.
+ */
+#include <src/platform/common.h>
+
+#include "../../tests_common.h"
+
+struct SetEnvTest: ::testing::TestWithParam<std::tuple<std::string, std::string, int>> {
+protected:
+  void
+  TearDown() override {
+    // Clean up environment variable after each test
+    const auto &[name, value, expected] = GetParam();
+    platf::unset_env(name);
+  }
+};
+
+TEST_P(SetEnvTest, SetEnvironmentVariableTests) {
+  const auto &[name, value, expected] = GetParam();
+  platf::set_env(name, value);
+
+  const char *env_value = std::getenv(name.c_str());
+  if (expected == 0 && !value.empty()) {
+    ASSERT_NE(env_value, nullptr);
+    ASSERT_EQ(std::string(env_value), value);
+  }
+  else {
+    ASSERT_EQ(env_value, nullptr);
+  }
+}
+
+TEST_P(SetEnvTest, UnsetEnvironmentVariableTests) {
+  const auto &[name, value, expected] = GetParam();
+  platf::unset_env(name);
+
+  const char *env_value = std::getenv(name.c_str());
+  if (expected == 0) {
+    ASSERT_EQ(env_value, nullptr);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  SetEnvTests,
+  SetEnvTest,
+  ::testing::Values(
+    std::make_tuple("SUNSHINE_UNIT_TEST_ENV_VAR", "test_value_0", 0),
+    std::make_tuple("SUNSHINE_UNIT_TEST_ENV_VAR", "test_value_1", 0),
+    std::make_tuple("", "test_value", -1)));


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Enable low latency mode for AMD by setting the appropriate environment variable. https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30039

This adds back in some helper functions to set env variables that were removed in https://github.com/LizardByte/Sunshine/pull/3059 ... although it was in the tests code before.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
