### PR TITLE
fix(macos/linux): import boost headers normally

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -11,6 +11,10 @@
 #include <string>
 
 #include <boost/core/noncopyable.hpp>
+#ifndef _WIN32
+#include <boost/process.hpp>
+#include <boost/asio.hpp>
+#endif
 
 #include "src/config.h"
 #include "src/logging.h"
@@ -31,6 +35,7 @@ struct AVHWFramesContext;
 struct AVCodecContext;
 struct AVDictionary;
 
+#ifdef _WIN32
 // Forward declarations of boost classes to avoid having to include boost headers
 // here, which results in issues with Windows.h and WinSock2.h include order.
 namespace boost {
@@ -50,6 +55,7 @@ namespace boost {
     typedef basic_environment<char> environment;
   }  // namespace process
 }  // namespace boost
+#endif
 namespace video {
   struct config_t;
 }  // namespace video

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -12,8 +12,8 @@
 
 #include <boost/core/noncopyable.hpp>
 #ifndef _WIN32
-#include <boost/process.hpp>
-#include <boost/asio.hpp>
+  #include <boost/asio.hpp>
+  #include <boost/process.hpp>
 #endif
 
 #include "src/config.h"


### PR DESCRIPTION
## Description
macOS build seems to be broken because of boost headers, linux seems to be working as is, but since the forward headers issue is windows only, I think we should handle it as a Windows only flag.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
- Fixes #3052
- Fixes #3098


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
