### PR TITLE
fix(win/input): fix false warnings about missing ViGEmBus

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -860,6 +860,8 @@ namespace platf {
 
   /**
    * @brief Gets the supported gamepads for this platform backend.
+   * @details This may be called prior to `platf::input()`!
+   * @param input Pointer to the platform's `input_t` or `nullptr`.
    * @return Vector of gamepad options and status.
    */
   std::vector<supported_gamepad_t> &

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1728,15 +1728,18 @@ namespace platf {
 
   std::vector<supported_gamepad_t> &
   supported_gamepads(input_t *input) {
-    bool enabled;
-    if (input) {
-      auto vigem = ((input_raw_t *) input)->vigem;
-      enabled = vigem != nullptr;
-    }
-    else {
-      enabled = false;
+    if (!input) {
+      static std::vector gps {
+        supported_gamepad_t { "auto", true, "" },
+        supported_gamepad_t { "x360", false, "" },
+        supported_gamepad_t { "ds4", false, "" },
+      };
+
+      return gps;
     }
 
+    auto vigem = ((input_raw_t *) input)->vigem;
+    auto enabled = vigem != nullptr;
     auto reason = enabled ? "" : "gamepads.vigem-not-available";
 
     // ds4 == ps4


### PR DESCRIPTION
## Description
Invoking `platf::supported_gamepads()` during static initalization of `config_t` was leading to misleading warnings in the logs indicating lack of ViGEmBus. We should handle the `!input` case specially like we do for the `inputino` implementation.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
