### PR TITLE
feat(web): use shared-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
     "dev": "vite build --watch"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.6.0",
-    "@popperjs/core": "2.11.8",
-    "@vitejs/plugin-vue": "4.6.2",
-    "bootstrap": "5.3.3",
-    "vite": "4.5.2",
-    "vite-plugin-ejs": "1.6.4",
+    "@lizardbyte/shared-web": "2024.901.195233",
     "vue": "3.5.2",
     "vue-i18n": "9.14.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "4.6.2",
+    "vite": "4.5.2",
+    "vite-plugin-ejs": "1.6.4"
   }
 }

--- a/src_assets/common/assets/web/Navbar.vue
+++ b/src_assets/common/assets/web/Navbar.vue
@@ -39,6 +39,7 @@
 
 <script>
 import ThemeToggle from './ThemeToggle.vue'
+import { initDiscord } from '@lizardbyte/shared-web/src/js/discord.js'
 
 export default {
   components: { ThemeToggle },
@@ -48,9 +49,7 @@ export default {
   mounted() {
     let el = document.querySelector("a[href='" + document.location.pathname + "']");
     if (el) el.classList.add("active")
-    let discordWidget = document.createElement('script')
-    discordWidget.setAttribute('src', 'https://app.lizardbyte.dev/js/discord.js')
-    document.head.appendChild(discordWidget)
+    initDiscord();
   }
 }
 </script>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR does the following:

- Use `shared-web` package for `discord.js` instead of using the online version.
- Moves vite packages to dev dependencies.
- Removes `bootstrap` and `fontawesome` as they are dependencies of `shared-web` (reduces dependabot PRs)
- Removes `@popperjs/core` as it is unused?

Todo:
- [ ] create a gh-action to handle the gh-pages using webpack (I'm planning to handle this separately)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
