### PR TITLE
fix(win/input): use active keyboard layout for non-normalized key events

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -618,11 +618,15 @@ namespace platf {
     auto &ki = i.ki;
 
     // If the client did not normalize this VK code to a US English layout, we can't accurately convert it to a scancode.
-    bool send_scancode = !(flags & SS_KBE_FLAG_NON_NORMALIZED) || config::input.always_send_scancodes;
-
-    if (send_scancode) {
+    // If we're set to always send scancodes, we will use the current keyboard layout to convert to a scancode. This will
+    // assume the client and host have the same keyboard layout, but it's probably better than always using US English.
+    if (!(flags & SS_KBE_FLAG_NON_NORMALIZED)) {
       // Mask off the extended key byte
       ki.wScan = VK_TO_SCANCODE_MAP[modcode & 0xFF];
+    }
+    else if (config::input.always_send_scancodes && modcode != VK_LWIN && modcode != VK_RWIN && modcode != VK_PAUSE) {
+      // For some reason, MapVirtualKey(VK_LWIN, MAPVK_VK_TO_VSC) doesn't seem to work :/
+      ki.wScan = MapVirtualKey(modcode, MAPVK_VK_TO_VSC);
     }
 
     // If we can map this to a scancode, send it as a scancode for maximum game compatibility.


### PR DESCRIPTION
## Description
When the client couldn't normalize their keyboard event to a US English layout, we don't know for sure which scan code to use in the keyboard event. Instead of assuming the non-normalized event is from a US English layout, make a better guess by using the host's current keyboard layout. As before, users can still disable the "Always Send Scancodes" option to send the VK code, which will always be correct but has reduced game compatibility.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #2463
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
