### PR TITLE
feat(capture): add AMD Display Capture for AFMF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 
 # VSCode IDE
 .vscode/
+.vs/
 
 # build directories
 build/

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -51,6 +51,7 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_vram.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_ram.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_wgc.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/display_amd.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/audio.cpp"
         "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/src/ViGEmClient.cpp"
         "${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/include/ViGEm/Client.h"

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -13,6 +13,8 @@
 
 #include <Unknwn.h>
 #include <winrt/Windows.Graphics.Capture.h>
+#include <AMF/core/Factory.h>
+#include <AMF/core/CurrentTime.h>
 
 #include "src/platform/common.h"
 #include "src/utility.h"
@@ -31,6 +33,13 @@ namespace platf::dxgi {
     dxgi->Release();
   }
 
+  inline
+  void
+  FreeLibraryHelper(void *item) {
+    FreeLibrary((HMODULE) item);
+  }
+
+  using hmodule_t = util::safe_ptr<void, FreeLibraryHelper>;
   using factory1_t = util::safe_ptr<IDXGIFactory1, Release<IDXGIFactory1>>;
   using dxgi_t = util::safe_ptr<IDXGIDevice, Release<IDXGIDevice>>;
   using dxgi1_t = util::safe_ptr<IDXGIDevice1, Release<IDXGIDevice1>>;
@@ -177,6 +186,8 @@ namespace platf::dxgi {
     int height_before_rotation;
 
     int client_frame_rate;
+    int adapter_index;
+    int output_index;
 
     DXGI_FORMAT capture_format;
     D3D_FEATURE_LEVEL feature_level;
@@ -429,4 +440,45 @@ namespace platf::dxgi {
     capture_e
     release_snapshot() override;
   };
+
+  class amd_capture_t {
+
+  public:
+    amd_capture_t();
+    ~amd_capture_t();
+
+    int
+    init(display_base_t *display, const ::video::config_t &config, int output_index);
+    capture_e
+    next_frame(std::chrono::milliseconds timeout, amf::AMFData** out);
+    capture_e
+    release_frame();
+
+    hmodule_t amfrt_lib;
+    amf_uint64 amf_version;
+    amf::AMFFactory *amf_factory;
+
+    amf::AMFContextPtr context;
+    amf::AMFComponentPtr captureComp;
+    amf::AMFSurfacePtr capturedSurface;
+    amf_int64 capture_format;
+    AMFSize resolution;
+  };
+
+
+  /**
+   * Display backend that uses Windows.Graphics.Capture with a hardware encoder.
+   */
+  class display_amd_vram_t: public display_vram_t {
+    amd_capture_t dup;
+
+  public:
+    int
+    init(const ::video::config_t &config, const std::string &display_name);
+    capture_e
+    snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor_visible) override;
+    capture_e
+    release_snapshot() override;
+  };
+
 }  // namespace platf::dxgi

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <AMF/core/CurrentTime.h>
+#include <AMF/core/Factory.h>
 #include <d3d11.h>
 #include <d3d11_4.h>
 #include <d3dcommon.h>
@@ -13,8 +15,6 @@
 
 #include <Unknwn.h>
 #include <winrt/Windows.Graphics.Capture.h>
-#include <AMF/core/Factory.h>
-#include <AMF/core/CurrentTime.h>
 
 #include "src/platform/common.h"
 #include "src/utility.h"
@@ -33,6 +33,10 @@ namespace platf::dxgi {
     dxgi->Release();
   }
 
+  /**
+   * Windows DLL loader function helper for AMD Display Capture
+   * @param item library dll
+   */
   inline
   void
   FreeLibraryHelper(void *item) {
@@ -467,7 +471,8 @@ namespace platf::dxgi {
 
 
   /**
-   * Display backend that uses Windows.Graphics.Capture with a hardware encoder.
+   * Display backend that uses AMD Display Capture with a hardware encoder.
+   * Main purpose is to capture AMD Fluid Motion Frames (AFMF)
    */
   class display_amd_vram_t: public display_vram_t {
     amd_capture_t dup;

--- a/src/platform/windows/display_amd.cpp
+++ b/src/platform/windows/display_amd.cpp
@@ -1,0 +1,202 @@
+/**
+ * @file src/platform/windows/display_amd.cpp
+ * @brief Display capture implementation using AMD Direct Capture
+ */
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavutil/hwcontext_d3d11va.h>
+}
+
+#include "display.h"
+#include "misc.h"
+#include "src/config.h"
+#include "src/main.h"
+#include "src/video.h"
+
+#include <AMF/components/DisplayCapture.h>
+#include <AMF/components/VideoConverter.h>
+#include <AMF/core/Trace.h>
+
+namespace platf {
+  using namespace std::literals;
+}
+
+namespace platf::dxgi {
+  amd_capture_t::amd_capture_t() {
+  }
+
+  amd_capture_t::~amd_capture_t() {
+    captureComp->Flush();
+    captureComp->Terminate();
+    context->Terminate();
+    // capturedSurface = nullptr;
+    // free(context);
+    // free(captureComp);
+    // capturedSurface.Release();
+    // free(capturedSurface);
+  }
+
+  capture_e
+  amd_capture_t::release_frame() {
+    // BOOST_LOG(error) << "### R.G. release_frame, null pointer?: " << (capturedSurface == nullptr);
+    // if (capturedSurface != nullptr)
+    // {
+    //   BOOST_LOG(error) << "### R.G. Releasing frame";
+    //   Sleep(10);
+    //   capturedSurface->Release();
+    // }
+
+    return capture_e::ok;
+  }
+
+   /**
+   * @brief Get the next frame from the producer thread.
+   * If not available, the capture thread blocks until one is, or the wait times out.
+   * @param timeout how long to wait for the next frame
+   * @param out a texture containing the frame just captured
+   * @param out_time the timestamp of the frame just captured
+   */
+  capture_e
+  amd_capture_t::next_frame(std::chrono::milliseconds timeout, amf::AMFData** out) {
+    release_frame();
+    // this CONSUMER runs in the capture thread
+    // Poll for the next frame
+    AMF_RESULT result;
+    auto capture_start = std::chrono::steady_clock::now();
+    do {
+      result = captureComp->QueryOutput(out);
+      if (result == AMF_REPEAT) {
+        // Check for capture timeout expiration
+        if (std::chrono::steady_clock::now() - capture_start >= timeout) {
+          return platf::capture_e::timeout;
+        }
+        Sleep(1);
+      }
+    } while (result == AMF_REPEAT);
+
+    if (result != AMF_OK) {
+      BOOST_LOG(error) << "DisplayCapture::QueryOutput() failed: "sv << result;
+      return capture_e::timeout;
+    }
+    return capture_e::ok;
+  }
+
+
+  int
+  amd_capture_t::init(display_base_t *display, const ::video::config_t &config, int output_index) {
+    // We have to load AMF before calling the base init() because we will need it loaded
+    // when our test_capture() function is called.
+    amfrt_lib.reset(LoadLibraryW(AMF_DLL_NAME));
+    if (!amfrt_lib) {
+      // Probably not an AMD GPU system
+      return -1;
+    }
+
+    auto fn_AMFQueryVersion = (AMFQueryVersion_Fn) GetProcAddress((HMODULE) amfrt_lib.get(), AMF_QUERY_VERSION_FUNCTION_NAME);
+    auto fn_AMFInit = (AMFInit_Fn) GetProcAddress((HMODULE) amfrt_lib.get(), AMF_INIT_FUNCTION_NAME);
+
+    if (!fn_AMFQueryVersion || !fn_AMFInit) {
+      BOOST_LOG(error) << "Missing required AMF function!"sv;
+      return -1;
+    }
+
+    auto result = fn_AMFQueryVersion(&amf_version);
+    if (result != AMF_OK) {
+      BOOST_LOG(error) << "AMFQueryVersion() failed: "sv << result;
+      return -1;
+    }
+
+    // We don't support anything older than AMF 1.4.30. We'll gracefully fall back to DDAPI.
+    if (amf_version < AMF_MAKE_FULL_VERSION(1, 4, 30, 0)) {
+      BOOST_LOG(warning) << "AMD Direct Capture is not supported on AMF version"sv
+                        << AMF_GET_MAJOR_VERSION(amf_version) << '.'
+                        << AMF_GET_MINOR_VERSION(amf_version) << '.'
+                        << AMF_GET_SUBMINOR_VERSION(amf_version) << '.'
+                        << AMF_GET_BUILD_VERSION(amf_version);
+      BOOST_LOG(warning) << "Consider updating your AMD graphics driver for better capture performance!"sv;
+      return -1;
+    }
+
+    // Initialize AMF library
+    result = fn_AMFInit(AMF_FULL_VERSION, &amf_factory);
+    if (result != AMF_OK) {
+      BOOST_LOG(error) << "AMFInit() failed: "sv << result;
+      return -1;
+    }
+
+    DXGI_ADAPTER_DESC adapter_desc;
+    display->adapter->GetDesc(&adapter_desc);
+
+    amf::AMFTrace* traceAMF;
+    amf_factory->GetTrace(&traceAMF);
+    traceAMF->SetGlobalLevel(AMF_TRACE_DEBUG);
+    traceAMF->EnableWriter(AMF_TRACE_WRITER_FILE, true);
+    traceAMF->SetWriterLevel(AMF_TRACE_WRITER_FILE, AMF_TRACE_DEBUG);
+    traceAMF->SetPath(L"D:/amflog.txt");
+
+    amf::AMFDebug* debugAMF;
+    amf_factory->GetDebug(&debugAMF);
+    debugAMF->AssertsEnable(false);
+
+    // Bail if this is not an AMD GPU
+    if (adapter_desc.VendorId != 0x1002) {
+      return -1;
+    }
+
+    // BOOST_LOG(info) << "### framerate " << config.framerate << " dynamicRange " << config.dynamicRange;
+
+    // // FIXME: Don't use Direct Capture for a SDR P010 stream. The output is very dim.
+    // // This seems like a possible bug in VideoConverter when upconverting 8-bit to 10-bit.
+    // if (config.dynamicRange && !display->is_hdr()) {
+    //   BOOST_LOG(info) << "AMD Direct Capture is disabled while 10-bit stream is in SDR mode"sv;
+    //   return -1;
+    // }
+
+    // Create the capture context
+    result = amf_factory->CreateContext(&context);
+
+    if (result != AMF_OK) {
+      BOOST_LOG(error) << "CreateContext() failed: "sv << result;
+      return -1;
+    }
+
+    // Associate the context with our ID3D11Device. This will enable multithread protection on the device.
+    result = context->InitDX11(display->device.get());
+    if (result != AMF_OK) {
+      BOOST_LOG(error) << "InitDX11() failed: "sv << result;
+      return -1;
+    }
+
+    display->capture_format = DXGI_FORMAT_UNKNOWN;
+
+    // Create the DisplayCapture component
+    result = amf_factory->CreateComponent(context, AMFDisplayCapture, &(captureComp));
+    if (result != AMF_OK) {
+      BOOST_LOG(error) << "CreateComponent(AMFDisplayCapture) failed: "sv << result;
+      return -1;
+    }
+
+    // Set parameters for non-blocking capture
+    captureComp->SetProperty(AMF_DISPLAYCAPTURE_MONITOR_INDEX, output_index);
+    captureComp->SetProperty(AMF_DISPLAYCAPTURE_FRAMERATE, AMFConstructRate(0, 1));
+    captureComp->SetProperty(AMF_DISPLAYCAPTURE_MODE, AMF_DISPLAYCAPTURE_MODE_GET_CURRENT_SURFACE);
+    captureComp->SetProperty(AMF_DISPLAYCAPTURE_DUPLICATEOUTPUT, true);
+
+    // Initialize capture
+    result = captureComp->Init(amf::AMF_SURFACE_UNKNOWN, 0, 0);
+    if (result != AMF_OK) {
+      BOOST_LOG(error) << "DisplayCapture::Init() failed: "sv << result;
+      return -1;
+    }
+
+    captureComp->GetProperty(AMF_DISPLAYCAPTURE_FORMAT, &(capture_format));
+    captureComp->GetProperty(AMF_DISPLAYCAPTURE_RESOLUTION, &(resolution));
+    BOOST_LOG(info) << "Desktop resolution ["sv << resolution.width << 'x' << resolution.height << ']';
+
+    BOOST_LOG(info) << "Using AMD Direct Capture API for display capture"sv;
+
+    return 0;
+  }
+
+}  // namespace platf::dxgi

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -565,6 +565,7 @@ namespace platf::dxgi {
           }
 
           if (desc.AttachedToDesktop && test_dxgi_duplication(adapter_tmp, output_tmp, false)) {
+            output_index = y;
             output = std::move(output_tmp);
 
             offset_x = desc.DesktopCoordinates.left;
@@ -593,6 +594,7 @@ namespace platf::dxgi {
         }
 
         if (output) {
+          adapter_index = x;
           adapter = std::move(adapter_tmp);
           break;
         }
@@ -1062,6 +1064,16 @@ namespace platf {
       }
       else if (hwdevice_type == mem_type_e::system) {
         auto disp = std::make_shared<dxgi::display_ddup_ram_t>();
+
+        if (!disp->init(config, display_name)) {
+          return disp;
+        }
+      }
+    }
+
+    if (config::video.capture == "amd") {
+      if (hwdevice_type == mem_type_e::dxgi) {
+        auto disp = std::make_shared<dxgi::display_amd_vram_t>();
 
         if (!disp->init(config, display_name)) {
           return disp;

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1054,6 +1054,16 @@ namespace platf {
    */
   std::shared_ptr<display_t>
   display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config) {
+    if (config::video.capture == "amd" || config::video.capture.empty()) {
+      if (hwdevice_type == mem_type_e::dxgi) {
+        auto disp = std::make_shared<dxgi::display_amd_vram_t>();
+
+        if (!disp->init(config, display_name)) {
+          return disp;
+        }
+      }
+    }
+
     if (config::video.capture == "ddx" || config::video.capture.empty()) {
       if (hwdevice_type == mem_type_e::dxgi) {
         auto disp = std::make_shared<dxgi::display_ddup_vram_t>();
@@ -1064,16 +1074,6 @@ namespace platf {
       }
       else if (hwdevice_type == mem_type_e::system) {
         auto disp = std::make_shared<dxgi::display_ddup_ram_t>();
-
-        if (!disp->init(config, display_name)) {
-          return disp;
-        }
-      }
-    }
-
-    if (config::video.capture == "amd") {
-      if (hwdevice_type == mem_type_e::dxgi) {
-        auto disp = std::make_shared<dxgi::display_amd_vram_t>();
 
         if (!disp->init(config, display_name)) {
           return disp;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1643,7 +1643,7 @@ namespace platf::dxgi {
   }
 
 
-/**
+  /**
    * @brief Get the next frame from the Windows.Graphics.Capture API and copy it into a new snapshot texture.
    * @param pull_free_image_cb call this to get a new free image from the video subsystem.
    * @param img_out the captured frame is returned here

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1662,9 +1662,6 @@ namespace platf::dxgi {
     }
     dup.capturedSurface = output;
 
-    // // Line below breaks reinit
-    // dup.capturedSurface->Acquire();
-
     texture2d_t src = (ID3D11Texture2D*) dup.capturedSurface->GetPlaneAt(0)->GetNative();
     src->GetDesc(&desc);
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -709,6 +709,7 @@ namespace video {
         { "rc"s, &config::video.amd.amd_rc_av1 },
         { "usage"s, &config::video.amd.amd_usage_av1 },
         { "enforce_hrd"s, &config::video.amd.amd_enforce_hrd },
+        { "loglevel"s, "debug"s},
       },
       {},  // SDR-specific options
       {},  // HDR-specific options
@@ -734,6 +735,7 @@ namespace video {
         { "usage"s, &config::video.amd.amd_usage_hevc },
         { "vbaq"s, &config::video.amd.amd_vbaq },
         { "enforce_hrd"s, &config::video.amd.amd_enforce_hrd },
+        { "loglevel"s, "debug"s},
       },
       {},  // SDR-specific options
       {},  // HDR-specific options
@@ -757,6 +759,7 @@ namespace video {
         { "usage"s, &config::video.amd.amd_usage_h264 },
         { "vbaq"s, &config::video.amd.amd_vbaq },
         { "enforce_hrd"s, &config::video.amd.amd_enforce_hrd },
+        { "loglevel"s, "debug"s},
       },
       {},  // SDR-specific options
       {},  // HDR-specific options
@@ -1248,6 +1251,7 @@ namespace video {
       };
 
       auto status = disp->capture(push_captured_image_callback, pull_free_image_callback, &display_cursor);
+
 
       if (artificial_reinit && status != platf::capture_e::error) {
         status = platf::capture_e::reinit;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1252,7 +1252,6 @@ namespace video {
 
       auto status = disp->capture(push_captured_image_callback, pull_free_image_callback, &display_cursor);
 
-
       if (artificial_reinit && status != platf::capture_e::error) {
         status = platf::capture_e::reinit;
 

--- a/src_assets/common/assets/web/configs/tabs/Advanced.vue
+++ b/src_assets/common/assets/web/configs/tabs/Advanced.vue
@@ -73,6 +73,7 @@ const config = ref(props.config)
           <template #windows>
             <option value="ddx">Desktop Duplication API</option>
             <option value="wgc">Windows.Graphics.Capture {{ $t('_common.beta') }}</option>
+            <option value="amd">AMD Display Capture {{ $t('_common.beta') }}</option>
           </template>
         </PlatformLayout>
       </select>


### PR DESCRIPTION
## Description
This PR adds a new capture option under advanced settings - AMD Display capture.
The main purpose of this new capture method would be to capture AFMF frames.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Known bugs
- Mouse isn't captured unless it's of a very large size
- When using AFMF, frames might be captured out of order during and could result in temporary "ghosted" image. Some testing showed that it's caused by display changes and moonlight pause and resume. This is fixed after disabling and re-enabling AFMF or sometimes waiting. Different capturing mode parameters might fix this issue and a proper testing methodology should prove the current best approach.

## Known limitations
- AMD card is required to use this capturing mode, regardless of use of AFMF
- AFMF can't be used with VDD because it Adrenaline doesn't recognize the virtual display and therefore no special features can be used. So a monitor or edid emulator has to be used as the capturing display.

## To do:
- Fix mouse cursor streaming
- Add screenshot showing new UI option
- Fix quality check
- Maybe add a new field for changing Display Capture, capturing mode parameter. 