### PR TITLE
fix(macos/packaging): MacPorts startupitem.executable path

### DIFF
--- a/packaging/macos/Portfile
+++ b/packaging/macos/Portfile
@@ -53,7 +53,7 @@ configure.env-append     BUILD_VERSION=@BUILD_VERSION@
 configure.env-append     COMMIT=@GITHUB_COMMIT@
 
 startupitem.create       yes
-startupitem.executable   "${prefix}/bin/{$name}"
+startupitem.executable   "${prefix}/bin/sunshine"
 startupitem.location     LaunchDaemons
 startupitem.name         ${name}
 startupitem.netchange    yes


### PR DESCRIPTION
## Description
Previously this resolved to: `/opt/local/bin/{Sunshine}`

I have not actually figured out how to get correct permissions for Screen Recording with sunshine in launchd, but at least this now runs the program.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
