### PR TITLE
Create a new Guide for how to enable autostart of Sunshine on KDE Plasma and Wayland without enabling autologin

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -489,7 +489,7 @@ for more information.}
 |------------|----------------------------------------------------------|
 | Difficulty | Advanced                                                 |
 
-This is a guide for how to start sunshine automatically at boot without enabling autologin for the desktop. I have tested this guide on Debian 12 with KDE Plasma and Wayland, and running the .deb version of Sunshine version 0.23.1.
+This is a guide for how to start sunshine automatically at boot without enabling autologin for the desktop. I have tested this guide on Debian 12 with KDE Plasma and Wayland, and running the .deb version of Sunshine version 0.23.1. Special thanks to [this user on unix stackexchange](https://unix.stackexchange.com/a/669476) for giving a good run down of how to enable the ssh connection on boot.
 
 #### Expected Behavior after following this guide
 Any time you boot your computer (wake on lan is highly recommended for this setup), sunshine will start automatically and you can remote into your machine from moonlight without performing any additional steps.


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add a new guide for how to enable autostart for Sunshine on KDE Plasma and Wayland without enabling autologin. This guide utilizes the existing guide by Eric Dong as the base, and then expands on it to enable the autostart functionality.

After following the guide,  sunshine will start on boot, and moonlight will connect to the login screen.

There are a few caveats to this guide that I will update as I find workarounds:
1. It does not work with multi monitor setups
2. You cannot change the screen properties with a sunshine application prep command via kscreen-doctor as plasma has not initiated the screens when on the login screen. Attempting to do so will cause moonlight to fail to connect to the sunshine host. You can still modify the screens manually or via kscreen-doctor after you have logged into wayland.

However, if you agree I think it's ready for prime time for advanced users. I am looking to help out with documentation on a couple of projects in the near future so if you have any feedback for me on how I've handled this pull request, please let me know! Thank you for building an amazing FOSS solution!

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
