### PR TITLE
build(script): fix missing sudo for dnf group install

### DIFF
--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -304,7 +304,7 @@ function run_install() {
     add_ubuntu_deps
   elif [ "$distro" == "fedora" ]; then
     add_fedora_deps
-    dnf group install "Development Tools" -y
+    ${sudo_cmd} dnf group install "Development Tools" -y
   fi
 
   # Install the dependencies


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`dnf group install` command was missing `sudo`.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
