### PR TITLE
chore(macos)!: drop monterey support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -471,8 +471,6 @@ jobs:
         include:
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           # while GitHub has larger macOS runners, they are not available for our repos :(
-          - os_version: "12"
-            os_name: "macos"
           - os_version: "13"
             os_name: "macos"
           - os_version: "14"
@@ -650,9 +648,8 @@ jobs:
         include:
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           # while GitHub has larger macOS runners, they are not available for our repos :(
-          - os_version: "12"
-            release: true
           - os_version: "13"
+            release: true
           - os_version: "14"
     name: Macports (macOS-${{ matrix.os_version }})
     runs-on: macos-${{ matrix.os_version }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ the local server or any mobile device.
         <td>Windows: 10+ (Windows Server does not support virtual gamepads)</td>
     </tr>
     <tr>
-        <td>macOS: 12+</td>
+        <td>macOS: 13+</td>
     </tr>
     <tr>
         <td>Linux/Debian: 12+ (bookworm)</td>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
macOS-12 doesn't support some newer c++ syntax, probably time to drop it. From my research many are dropping support for it in November (~1 month from now).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
