### PR TITLE
fix(macos): Touch input broken

### DIFF
--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -362,6 +362,9 @@ const KeyCodeMap kKeyCodesMap[] = {
     CGEventSetDoubleValueField(event, kCGMouseEventDeltaY, deltaY);
 
     CGEventPost(kCGHIDEventTap, event);
+    // For why this is here, see:
+    // https://stackoverflow.com/questions/15194409/simulated-mouseevent-not-working-properly-osx
+    CGWarpMouseCursorPosition(location);
   }
 
   inline CGEventType


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Pull request #2550 fixed the macOS mouse input mode but broke the touchscreen mode in the process : tapping anywhere on the screen doesn't work anymore. Looking at the changes it seems the [CGWarpMouseCursorPosition(location)](https://github.com/LizardByte/Sunshine/pull/2550/files#diff-730f675bbeb37990b8260140134248992b0606fd99f28ba3c9efea74868eb9e9L345-L347) was removed in `post_mouse()`, restoring it fixes the touchscreen issue. From my testing mouse input mode is unaffected by this change, but I do not have access to Minecraft Java Edition or Tomb Raider as described in https://github.com/LizardByte/Sunshine/pull/2550.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
