### PR TITLE
docs: improve flatpak start commands

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -224,7 +224,7 @@ flatpak run dev.lizardbyte.app.Sunshine
 
 ##### Run with KMS capture (Wayland & X11)
 ```bash
-sudo -i PULSE_SERVER=unix:$(pactl info | awk '/Server String/{print$3}') flatpak run dev.lizardbyte.app.Sunshine
+sudo -i PULSE_SERVER=unix:/run/user/$(id -u $whoami)/pulse/native flatpak run dev.lizardbyte.app.Sunshine
 ```
 
 ##### Uninstall

--- a/packaging/linux/flatpak/dev.lizardbyte.app.Sunshine.metainfo.xml
+++ b/packaging/linux/flatpak/dev.lizardbyte.app.Sunshine.metainfo.xml
@@ -32,7 +32,7 @@
     <p>flatpak run --command=additional-install.sh @PROJECT_FQDN@</p>
     <p>NOTE: Sunshine uses a self-signed certificate. The web browser will report it as not secure, but it is safe.</p>
     <p>NOTE: KMS Grab (Optional)</p>
-    <p>sudo -i PULSE_SERVER=unix:$(pactl info | awk '/Server String/{print$3}') flatpak run @PROJECT_FQDN@</p>
+    <p>sudo -i PULSE_SERVER=unix:/run/user/$(id -u $whoami)/pulse/native flatpak run @PROJECT_FQDN@</p>
   </description>
 
   <releases>


### PR DESCRIPTION
## Description
Corrected documentation of startup calls for Linux+Flatpak: I have removed `$(pactl info | awk '/Server String/{print$3}')` and replaced it with `$(id -u $whoami)`. This should allow Sunshine to find the Pulse audio server also on Linux installations that are not English.


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #3261
- Fixes #2840
- Fixes #2839 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
