### PR TITLE
Revert "ci(windows): pin gcovr to < 8.0"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1189,7 +1189,7 @@ jobs:
         shell: msys2 {0}
         working-directory: build
         run: |
-          ${{ steps.python-path.outputs.python-path }} -m pip install "gcovr<8.0"
+          ${{ steps.python-path.outputs.python-path }} -m pip install gcovr
           ${{ steps.python-path.outputs.python-path }} -m gcovr -r .. \
             --exclude-noncode-lines \
             --exclude-throw-branches \


### PR DESCRIPTION
Reverts LizardByte/Sunshine#3277

See https://github.com/gcovr/gcovr/issues/984#issuecomment-2403375747 and https://github.com/gcovr/gcovr/pull/987