### PR TITLE
build(mingw): work around broken windows.foundation.h

### DIFF
--- a/src/platform/windows/display_wgc.cpp
+++ b/src/platform/windows/display_wgc.cpp
@@ -9,6 +9,9 @@
 #include "misc.h"
 #include "src/logging.h"
 
+// Gross hack to work around MINGW-packages#22160
+#define ____FIReference_1_boolean_INTERFACE_DEFINED__
+
 #include <windows.graphics.capture.interop.h>
 #include <winrt/windows.foundation.h>
 #include <winrt/windows.foundation.metadata.h>


### PR DESCRIPTION
## Description
Workaround for build break due to https://github.com/msys2/MINGW-packages/issues/22160

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
