### PR TITLE
build(deps): bump third party/build-deps from `1977d9c` to `8c7caa1`

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -32,6 +32,7 @@ PROJECT_NAME = Sunshine
 # project specific settings
 DOT_GRAPH_MAX_NODES = 60
 IMAGE_PATH = ../docs/images
+INCLUDE_PATH = ../third-party/build-deps/ffmpeg/Linux-x86_64/include/
 PREDEFINED += SUNSHINE_BUILD_WAYLAND
 PREDEFINED += SUNSHINE_TRAY=1
 

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -39,9 +39,7 @@ depends=(
 makedepends=(
   'cmake'
   'cuda'
-  'doxygen'
   "gcc${_gcc_version}"
-  'graphviz'
   'git'
   'make'
   'nodejs'
@@ -80,6 +78,7 @@ build() {
         -S "$pkgname" \
         -B build \
         -Wno-dev \
+        -D BUILD_DOCS=OFF \
         -D BUILD_WERROR=ON \
         -D CMAKE_INSTALL_PREFIX=/usr \
         -D SUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -22,7 +22,7 @@ class @PROJECT_NAME@ < Formula
     end
   end
 
-  option "with-docs-off", "Disable docs"
+  option "with-docs", "Enable docs"
   option "with-dynamic-boost", "Dynamically link Boost libraries"
   option "without-dynamic-boost", "Statically link Boost libraries" # default option
 
@@ -76,12 +76,12 @@ class @PROJECT_NAME@ < Formula
       -DSUNSHINE_PUBLISHER_ISSUE_URL='https://app.lizardbyte.dev/support'
     ]
 
-    if build.with? "docs-off"
-      ohai "Building docs: disabled"
-      args << "-DBUILD_DOCS=OFF"
-    else
+    if build.with? "docs"
       ohai "Building docs: enabled"
       args << "-DBUILD_DOCS=ON"
+    else
+      ohai "Building docs: disabled"
+      args << "-DBUILD_DOCS=OFF"
     end
 
     if build.without? "dynamic-boost"

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -59,7 +59,7 @@ namespace config {
   }  // namespace nv
 
   namespace amd {
-#ifdef __APPLE__
+#ifndef _WIN32
   // values accurate as of 27/12/2022, but aren't strictly necessary for MacOS build
   #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_SPEED 100
   #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_QUALITY 30
@@ -101,6 +101,9 @@ namespace config {
   #define AMF_VIDEO_ENCODER_CABAC 1
   #define AMF_VIDEO_ENCODER_CALV 2
 #else
+  #ifdef _GLIBCXX_USE_C99_INTTYPES
+    #undef _GLIBCXX_USE_C99_INTTYPES
+  #endif
   #include <AMF/components/VideoEncoderAV1.h>
   #include <AMF/components/VideoEncoderHEVC.h>
   #include <AMF/components/VideoEncoderVCE.h>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Manually update build-deps (ffmpeg), and:

- Workaround build error for AMF
- Revert #3286
- Disable docs for some builds (ArchLinux and brew)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Closes #3275
- Fixes #3273

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
