### PR TITLE
fix(display): fix logic to remember ddprobe already ran

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -419,11 +419,13 @@ namespace platf::dxgi {
 
     // Try probing with different GPU preferences and verify_frame_capture flag
     if (validate_and_test_gpu_preference(display_name, true)) {
+      set_gpu_preference = true;
       return true;
     }
 
     // If no valid configuration was found, try again with verify_frame_capture == false
     if (validate_and_test_gpu_preference(display_name, false)) {
+      set_gpu_preference = true;
       return true;
     }
 


### PR DESCRIPTION
## Description
This fixes a display capture initialization performance regression from #3002 that was reported in https://github.com/moonlight-stream/moonlight-common-c/issues/93#issuecomment-2400987935. The lines to set `set_gpu_preference` were accidentally refactored away. This caused ddprobe.exe to run every time that display capture initialized rather than just once.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
