### PR TITLE
fix(audio/windows): don't set virtual speakers higher than 24-bit mode

### DIFF
--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -124,9 +124,8 @@ namespace {
   create_virtual_sink_waveformats() {
     if constexpr (channel_count == 2) {
       auto channel_mask = waveformat_mask_stereo;
+      // only choose 24 or 16-bit formats to avoid clobbering existing Dolby/DTS spatial audio settings
       return {
-        create_waveformat(sample_format_e::f32, channel_count, channel_mask),
-        create_waveformat(sample_format_e::s32, channel_count, channel_mask),
         create_waveformat(sample_format_e::s24in32, channel_count, channel_mask),
         create_waveformat(sample_format_e::s24, channel_count, channel_mask),
         create_waveformat(sample_format_e::s16, channel_count, channel_mask),


### PR DESCRIPTION
## Description
When the Moonlight "Mute host PC speakers" option is selected, Sunshine will change the audio device to Steam Speakers. The changed block of code cycles through some settings in order and stops on the first one found, which happens to be the 32-bit signed int format. What we really want to happen is to have 24-bit as the highest supported format because this mode won't unset an existing spatial audio mode (Atmos for Headphones only supports 16 and 24-bit at <= 48k. 

This patch simply removes the F32 and S32 checks for stereo. F32 isn't supported by Steam Speakers, but S32 is and that's the one we want to avoid.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
