### PR TITLE
fix(video): encode at least one frame before capture reinit

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1857,7 +1857,14 @@ namespace video {
     }
 
     while (true) {
-      if (shutdown_event->peek() || reinit_event.peek() || !images->running()) {
+      // Break out of the encoding loop if any of the following are true:
+      // a) The stream is ending
+      // b) Sunshine is quitting
+      // c) The capture side is waiting to reinit and we've encoded at least one frame
+      //
+      // If we have to reinit before we have received any captured frames, we will encode
+      // the blank dummy frame just to let Moonlight know that we're alive.
+      if (shutdown_event->peek() || !images->running() || (reinit_event.peek() && frame_nr > 1)) {
         break;
       }
 


### PR DESCRIPTION
## Description
Hyper-V GPU Paravirtualization (with https://github.com/jamesstringerparsec/Easy-GPU-PV) causes some strange behavior in DXGI DDA where `AcquireNextFrame()` will succeed (giving us a black frame) then `ReleaseFrame()` will fail with `DXGI_ERROR_ACCESS_LOST` immediately afterwards (which is turned into `capture_e::reinit`). DDA is left in a strange state after this happens, where further calls to _both_ `AcquireNextFrame()` and `ReleaseFrame()` fail with `DXGI_ERROR_INVALID_CALL` (indicating both that there is and is not a pending frame to release).

Capture does seem to eventually recover and stabilize (when DWM renders a fresh frame?), but this pattern of pushing a frame then immediately failing with `capture_e::reinit` causes the encode thread to break into the reinit loop without actually encoding the pending frame. As a result, Moonlight is left waiting for the first encoded frame for an extended period of time, which causes it to eventually give up and tell the user that something is wrong with the host or network.

I'm still working to see if there is a way to avoid the extended delays when switching to the UAC Secure Desktop, but this at least allows the stream to start consistently.

Reported at: https://github.com/moonlight-stream/moonlight-common-c/issues/93

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
