### PR TITLE
build(deps): remove unused dependency on libvdpau

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -27,7 +27,7 @@ if(NOT DEFINED FFMPEG_PREPARED_BINARIES)
     if(WIN32)
         set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid vpl)
     elseif(UNIX AND NOT APPLE)
-        set(FFMPEG_PLATFORM_LIBRARIES numa va va-drm va-x11 vdpau X11)
+        set(FFMPEG_PLATFORM_LIBRARIES numa va va-drm va-x11 X11)
     endif()
     set(FFMPEG_PREPARED_BINARIES
             "${CMAKE_SOURCE_DIR}/third-party/build-deps/ffmpeg/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -51,7 +51,6 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
             libpulse0, \
             libva2, \
             libva-drm2, \
-            libvdpau1, \
             libwayland-client0, \
             libx11-6, \
             miniupnpc, \
@@ -64,7 +63,6 @@ set(CPACK_RPM_PACKAGE_REQUIRES "\
             libevdev >= 1.5.6, \
             libopusenc >= 0.2.1, \
             libva >= 2.14.0, \
-            libvdpau >= 1.5, \
             libwayland-client >= 1.20.0, \
             libX11 >= 1.7.3.1, \
             miniupnpc >= 2.2.4, \

--- a/docker/clion-toolchain.dockerfile
+++ b/docker/clion-toolchain.dockerfile
@@ -46,7 +46,6 @@ apt-get install -y --no-install-recommends \
   libpulse-dev \
   libssl-dev \
   libva-dev \
-  libvdpau-dev \
   libwayland-dev \
   libx11-dev \
   libxcb-shm0-dev \

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -23,7 +23,6 @@ depends=(
   'libnotify'
   'libpulse'
   'libva'
-  'libvdpau'
   'libx11'
   'libxcb'
   'libxfixes'

--- a/packaging/linux/fedora/Sunshine.spec
+++ b/packaging/linux/fedora/Sunshine.spec
@@ -27,7 +27,6 @@ BuildRequires: libevdev-devel
 BuildRequires: libgudev
 BuildRequires: libnotify-devel
 BuildRequires: libva-devel
-BuildRequires: libvdpau-devel
 BuildRequires: libX11-devel
 BuildRequires: libxcb-devel
 BuildRequires: libXcursor-devel
@@ -66,7 +65,6 @@ Requires: libdrm > 2.4.97
 Requires: libevdev >= 1.5.6
 Requires: libopusenc >= 0.2.1
 Requires: libva >= 2.14.0
-Requires: libvdpau >= 1.5
 Requires: libwayland-client >= 1.20.0
 Requires: libX11 >= 1.7.3.1
 Requires: miniupnpc >= 2.2.4

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -44,7 +44,6 @@ class @PROJECT_NAME@ < Formula
     depends_on "libdrm"
     depends_on "libnotify"
     depends_on "libva"
-    depends_on "libvdpau"
     depends_on "libx11"
     depends_on "libxcb"
     depends_on "libxcursor"

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -106,7 +106,6 @@ function add_debain_based_deps() {
     "libopus-dev"
     "libpulse-dev"
     "libssl-dev"
-    "libvdpau-dev"
     "libwayland-dev"  # Wayland
     "libx11-dev"  # X11
     "libxcb-shm0-dev"  # X11
@@ -162,7 +161,6 @@ function add_fedora_deps() {
     "libdrm-devel"
     "libevdev-devel"
     "libnotify-devel"
-    "libvdpau-devel"
     "libX11-devel"  # X11
     "libxcb-devel"  # X11
     "libXcursor-devel"  # X11


### PR DESCRIPTION
## Description
VDPAU is a decode-only API, so we have no foreseeable need for that in Sunshine.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
