### PR TITLE
fix(nvenc): disable filler data in AV1 bitstream

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -513,6 +513,7 @@ namespace video {
         { "forced-idr"s, 1 },
         { "zerolatency"s, 1 },
         { "surfaces"s, 1 },
+        { "filler_data"s, false },
         { "preset"s, &config::video.nv_legacy.preset },
         { "tune"s, NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY },
         { "rc"s, NV_ENC_PARAMS_RC_CBR },


### PR DESCRIPTION
## Description
Disable padding OBU insertion in AV1 bitstreams from FFmpeg NVENC to match the standalone NVENC implementation and avoid wasted bandwidth and compatibility issues with Snapdragon 8 Gen 3 decoders.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #3331
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
