### PR TITLE
fix(vaapi): use VBR rate control mode

### DIFF
--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -129,16 +129,6 @@ namespace va {
       return 0;
     }
 
-    void
-    init_codec_options(AVCodecContext *ctx, AVDictionary *options) override {
-      // Don't set the RC buffer size when using H.264 on Intel GPUs. It causes
-      // major encoding quality degradation.
-      auto vendor = vaQueryVendorString(va_display);
-      if (ctx->codec_id != AV_CODEC_ID_H264 || (vendor && !strstr(vendor, "Intel"))) {
-        ctx->rc_buffer_size = ctx->bit_rate * ctx->framerate.den / ctx->framerate.num;
-      }
-    }
-
     int
     set_frame(AVFrame *frame, AVBufferRef *hw_frames_ctx_buf) override {
       this->hwframe.reset(frame);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -860,6 +860,7 @@ namespace video {
         { "low_power"s, 1 },
         { "async_depth"s, 1 },
         { "idr_interval"s, std::numeric_limits<int>::max() },
+        { "rc_mode"s, "VBR"s },
       },
       {},  // SDR-specific options
       {},  // HDR-specific options
@@ -879,6 +880,7 @@ namespace video {
         { "async_depth"s, 1 },
         { "sei"s, 0 },
         { "idr_interval"s, std::numeric_limits<int>::max() },
+        { "rc_mode"s, "VBR"s },
       },
       {},  // SDR-specific options
       {},  // HDR-specific options
@@ -898,6 +900,7 @@ namespace video {
         { "async_depth"s, 1 },
         { "sei"s, 0 },
         { "idr_interval"s, std::numeric_limits<int>::max() },
+        { "rc_mode"s, "VBR"s },
       },
       {},  // SDR-specific options
       {},  // HDR-specific options
@@ -910,8 +913,7 @@ namespace video {
       std::make_optional<encoder_t::option_t>("qp"s, &config::video.qp),
       "h264_vaapi"s,
     },
-    // RC buffer size will be set in platform code if supported
-    LIMITED_GOP_SIZE | PARALLEL_ENCODING | SINGLE_SLICE_ONLY | NO_RC_BUF_LIMIT
+    LIMITED_GOP_SIZE | PARALLEL_ENCODING | SINGLE_SLICE_ONLY
   };
 #endif
 


### PR DESCRIPTION
## Description
This is a possible alternative fix for https://github.com/LizardByte/Sunshine/issues/2864 that could be taken instead of https://github.com/LizardByte/Sunshine/pull/3332.

In the case of single frame VBV size, using CBR with VAAPI seems to have major quality problems with Intel and AMD drivers. VBR behaves much better in my testing (Intel H.264 case) and allows us to still enforce a reasonable frame size limit without causing the video quality to suffer. Interestingly, we also had to do something similar with the QuickSync encoder using the `CBR_WITH_VBR` quirk flag to force VBR mode.

As a nice side effect, it also allows the video bitrate to drop when content is static, rather than adding useless filler data to the bitstream to preserve the exact specified bitrate. This also fixes the decoder compatibility issue reported in #3331.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
