### PR TITLE
fix(openssl): fix build with OPENSSL_NO_DEPRECATED

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -4,6 +4,7 @@
  */
 #include "crypto.h"
 #include <openssl/pem.h>
+#include <openssl/rsa.h>
 
 namespace crypto {
   using asn1_string_t = util::safe_ptr<ASN1_STRING, ASN1_STRING_free>;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1033,7 +1033,13 @@ namespace nvhttp {
 
     // Verify certificates after establishing connection
     https_server.verify = [add_cert](SSL *ssl) {
-      crypto::x509_t x509 { SSL_get_peer_certificate(ssl) };
+      crypto::x509_t x509 {
+#if OPENSSL_VERSION_MAJOR >= 3
+        SSL_get1_peer_certificate(ssl)
+#else
+        SSL_get_peer_certificate(ssl)
+#endif
+      };
       if (!x509) {
         BOOST_LOG(info) << "unknown -- denied"sv;
         return 0;


### PR DESCRIPTION
## Description
Remove dependency on functions that were deprecated in OpenSSL 3.0. No behavior changes at runtime (`SSL_get_peer_certificate` is defined to be an alias of `SSL_get1_peer_certificate()`).

The missing `openssl/rsa.h` include is used for `EVP_PKEY_CTX_set_rsa_keygen_bits()`. `openssl/rsa.h` was pulled in indirectly via `openssl/pem.h` when deprecated APIs are enabled. 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
