### PR TITLE
fix(windows): disable shortcut mode for WGC

### DIFF
--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -101,10 +101,13 @@ set(CPACK_NSIS_CREATE_ICONS_EXTRA
         "${CPACK_NSIS_CREATE_ICONS_EXTRA}
         CreateShortCut '\$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\${CMAKE_PROJECT_NAME}.lnk' \
             '\$INSTDIR\\\\${CMAKE_PROJECT_NAME}.exe' '--shortcut'
+        CreateShortCut '\$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\${CMAKE_PROJECT_NAME} (WGC).lnk' \
+            '\$INSTDIR\\\\${CMAKE_PROJECT_NAME}.exe' 'capture=wgc'
         ")
 set(CPACK_NSIS_DELETE_ICONS_EXTRA
         "${CPACK_NSIS_DELETE_ICONS_EXTRA}
         Delete '\$SMPROGRAMS\\\\$MUI_TEMP\\\\${CMAKE_PROJECT_NAME}.lnk'
+        Delete '\$SMPROGRAMS\\\\$MUI_TEMP\\\\${CMAKE_PROJECT_NAME} (WGC).lnk'
         ")
 
 # Checking for previous installed versions

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,7 @@ basic authentication with the admin username and password.
 ## POST /api/apps
 @copydoc confighttp::saveApp()
 
-## DELETE /api/apps{index}
+## DELETE /api/apps/{index}
 @copydoc confighttp::deleteApp()
 
 ## POST /api/covers/upload

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1259,6 +1259,15 @@ namespace config {
       // the path is incorrect or inaccessible.
       apply_config(std::move(vars));
       config_loaded = true;
+
+      // Disable shortcut launch modes if capture mode is wgc
+#ifdef _WIN32
+      if (config::video.capture == "wgc" && (shortcut_launch || service_admin_launch)) {
+        BOOST_LOG(info) << "Disabling service launch because WGC capture mode is enabled"sv;
+        shortcut_launch = false;
+        service_admin_launch = false;
+      }
+#endif
     }
     catch (const std::filesystem::filesystem_error &err) {
       BOOST_LOG(fatal) << "Failed to apply config: "sv << err.what();


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR slightly improves WGC experience by doing the following:

- Disables "shortcut" mode when WGC is enabled (either from CLI args or from the config option).
- Add a WGC specific start menu shortcut. This works if running as "Admin", but fails otherwise due to permissions accessing the config directory. I'm not sure how to make the shortcut have "run as administrator" mode, which I know is possible in Windows, but I don't know if it's possible from NSIS.

Additional ideas I have, but not really sure the best way to handle are:

- Auto toggle the service on or off when changing capture mode.

This PR also fixes one small typo from #3343.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
