### PR TITLE
fix(homebrew): codesign binary only on Intel macOS

### DIFF
--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -112,14 +112,11 @@ class @PROJECT_NAME@ < Formula
       system "make"
       system "make", "install"
 
-      # Move binary instead of symlinking it
-      bin.install "sunshine-#{ENV["BUILD_VERSION"]}" => "sunshine" if OS.mac?
-
       bin.install "tests/test_sunshine"
     end
 
-    # Codesign the installed binary
-    system "codesign", "-s", "-", "--force", "--deep", bin/"sunshine" if OS.mac?
+    # codesign the binary on intel macs
+    system "codesign", "-s", "-", "--force", "--deep", bin/"sunshine" if OS.mac? && Hardware::CPU.intel?
 
     bin.install "src_assets/linux/misc/postinst" if OS.linux?
   end

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -113,13 +113,13 @@ class @PROJECT_NAME@ < Formula
       system "make", "install"
 
       # Move binary instead of symlinking it
-      bin.install "sunshine-#{ENV["BUILD_VERSION"]}" => "sunshine"
+      bin.install "sunshine-#{ENV["BUILD_VERSION"]}" => "sunshine" if OS.mac?
 
       bin.install "tests/test_sunshine"
     end
 
     # Codesign the installed binary
-    system "codesign", "-s", "-", "--force", "--deep", "#{bin}/sunshine"
+    system "codesign", "-s", "-", "--force", "--deep", bin/"sunshine" if OS.mac?
 
     bin.install "src_assets/linux/misc/postinst" if OS.linux?
   end

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -112,8 +112,14 @@ class @PROJECT_NAME@ < Formula
       system "make"
       system "make", "install"
 
+      # Move binary instead of symlinking it
+      bin.install "sunshine-#{ENV["BUILD_VERSION"]}" => "sunshine"
+
       bin.install "tests/test_sunshine"
     end
+
+    # Codesign the installed binary
+    system "codesign", "-s", "-", "--force", "--deep", "#{bin}/sunshine"
 
     bin.install "src_assets/linux/misc/postinst" if OS.linux?
   end


### PR DESCRIPTION
## Description
Moving binary after build and adding codesign for macOS as per issue #3340 

### Screenshot

### Issues Fixed or Closed
Issue #3340 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
