### PR TITLE
build(vite): fix assets directories with symlinks present

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -20,13 +20,22 @@ if (process.env.SUNSHINE_BUILD_HOMEBREW) {
     console.log("Building for homebrew, using default paths")
 }
 else {
+    // If the paths supplied in the environment variables contain any symbolic links
+    // at any point in the series of directories, the entire build will fail with
+    // a cryptic error message like this:
+    //     RollupError: The "fileName" or "name" properties of emitted chunks and assets
+    //     must be strings that are neither absolute nor relative paths.
+    // To avoid this, we resolve the potential symlinks using `fs.realpathSync` before
+    // doing anything else with the paths.
     if (process.env.SUNSHINE_SOURCE_ASSETS_DIR) {
-        console.log("Using srcdir from Cmake: " + resolve(process.env.SUNSHINE_SOURCE_ASSETS_DIR,"common/assets/web"));
-        assetsSrcPath = resolve(process.env.SUNSHINE_SOURCE_ASSETS_DIR,"common/assets/web")
+        let path = resolve(fs.realpathSync(process.env.SUNSHINE_SOURCE_ASSETS_DIR), "common/assets/web");
+        console.log("Using srcdir from Cmake: " + path);
+        assetsSrcPath = path;
     }
     if (process.env.SUNSHINE_ASSETS_DIR) {
-        console.log("Using destdir from Cmake: " + resolve(process.env.SUNSHINE_ASSETS_DIR,"assets/web"));
-        assetsDstPath = resolve(process.env.SUNSHINE_ASSETS_DIR,"assets/web")
+        let path = resolve(fs.realpathSync(process.env.SUNSHINE_ASSETS_DIR), "assets/web");
+        console.log("Using destdir from Cmake: " + path);
+        assetsDstPath = path;
     }
 }
 


### PR DESCRIPTION
## Description

This commit addresses a situation where the user clones the Sunshine
directory in a location such that an ancestor of the repository is a
symlink. For example, imagine that the `~/git` directory is a symlink
to the `~/Documents/git` directory. Further imagine that the user clones
Sunshine into `~/git/Sunshine`. In this setup, attempting to build
the web-ui will fail with a series of incredibly cryptic error messages,
which look like this:

    RollupError: The "fileName" or "name" properties of emitted chunks
    and assets must be strings that are neither absolute nor relative
    paths, received "../../../../../../Documents/git/Sunshine/src_assets/common/assets/web/password.html".

This seems to occur because vite isn't aware that `Documents/git` and
`git` are actually the same directory as each other.

To fix the problem, this commit resolves the symlinks (if any) in
`vite.config.js` so that vite will only have to deal with one
canonical path, rather than two. This prevents the error when building.

### Screenshot
N/A

### Issues Fixed or Closed
N/A

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components (N/A)
