### PR TITLE
fix(macos): prevent indefinite hanging if screen capture is not granted

### DIFF
--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -5,6 +5,7 @@
 #include "src/platform/common.h"
 #include "src/platform/macos/av_img_t.h"
 #include "src/platform/macos/av_video.h"
+#include "src/platform/macos/misc.h"
 #include "src/platform/macos/nv12_zero_device.h"
 
 #include "src/config.h"
@@ -100,6 +101,13 @@ namespace platf {
 
     int
     dummy_img(img_t *img) override {
+      if (!platf::is_screen_capture_allowed()) {
+        // If we don't have the screen capture permission, this function will hang
+        // indefinitely without doing anything useful. Exit instead to avoid this.
+        // A non-zero return value indicates failure to the calling function.
+        return 1;
+      }
+
       auto signal = [av_capture capture:^(CMSampleBufferRef sampleBuffer) {
         auto new_sample_buffer = std::make_shared<av_sample_buf_t>(sampleBuffer);
         auto new_pixel_buffer = std::make_shared<av_pixel_buf_t>(new_sample_buffer->buf);

--- a/src/platform/macos/misc.h
+++ b/src/platform/macos/misc.h
@@ -8,6 +8,11 @@
 
 #include <CoreGraphics/CoreGraphics.h>
 
+namespace platf {
+  bool
+  is_screen_capture_allowed();
+}
+
 namespace dyn {
   typedef void (*apiproc)();
 

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -42,6 +42,16 @@ namespace platf {
   CGRequestScreenCaptureAccess(void) __attribute__((weak_import));
 #endif
 
+  namespace {
+    auto screen_capture_allowed = std::atomic<bool> { false };
+  }  // namespace
+
+  // Return whether screen capture is allowed for this process.
+  bool
+  is_screen_capture_allowed() {
+    return screen_capture_allowed;
+  }
+
   std::unique_ptr<deinit_t>
   init() {
     // This will generate a warning about CGPreflightScreenCaptureAccess and
@@ -68,6 +78,8 @@ namespace platf {
       return nullptr;
     }
 #pragma clang diagnostic pop
+    // Record that we determined that we have the screen capture permission.
+    screen_capture_allowed = true;
     return std::make_unique<deinit_t>();
   }
 


### PR DESCRIPTION
## Description

Currently, if Sunshine has not yet been granted the screen capture
permission, the program simply hangs indefinitely on startup when it
attempts to probe for usable encoders. This is not desirable because
it prevents testing and using all of the parts of Sunshine that do not
require the screen capture permission.

With this patch, the encoder probing will simply fail instead of
hanging indefinitely if Sunshine does not yet have the screen capture
permission.

Note that Sunshine already prints out an error message telling the user
that the screen capture permission is needed. The bug is that Sunshine
currently indefinitely hangs shortly after printing that message.

### Screenshot
N/A

### Issues Fixed or Closed
N/A

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components