### PR TITLE
build(docs): parallelize generation of dot graphs

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -30,6 +30,7 @@ PROJECT_LOGO = ../sunshine.png
 PROJECT_NAME = Sunshine
 
 # project specific settings
+DOT_NUM_THREADS = 0
 DOT_GRAPH_MAX_NODES = 60
 IMAGE_PATH = ../docs/images
 INCLUDE_PATH = ../third-party/build-deps/dist/Linux-x86_64/include/


### PR DESCRIPTION
Building the Sunshine docs is currently agonizingly slow because it
generates many hundreds of dot graphs in serial, without any
parallelization.

This commits sets `DOT_NUM_THREADS` to 0, which causes `doxygen` to
determine on its own a reasonable level of parallelization, based on
the number of processors available on the system.

The speed difference with this change is incredibly dramatic. I haven't
performed particularly rigorous testing, but on my fairly weak laptop
building the docs after applying this patch takes about 35 seconds.
Without applying this patch, building the docs instead takes a
ridiculous 135 seconds. This is on an M1 machine with only 4 performance
cores and 4 efficiency cores. On a more powerful machine, the difference
will be even more marked.

Unless there's some reason I'm not aware of why the doc files need to
be created in serial, I recommend enabling parallelization so that it
isn't so painful to build the documentation.

See also:
    https://xkcd.com/303

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components