### PR TITLE
docs(troubleshooting): Remove workaround for "blur" plugin in KDE

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -165,14 +165,6 @@ high as long as the encoder is used.
 ### Gamescope compatibility
 Some users have reported stuttering issues when streaming games running within Gamescope.
 
-### Occasional flickering in KDE
-
-The `blur` plugin causes flickering during streaming for some people. Disable it from the
-KDE System Settings or from the commandline:
-```bash
-qdbus org.kde.KWin /Effects unloadEffect blur
-```
-
 ## macOS
 
 ### Dynamic session lookup failed


### PR DESCRIPTION

This reverts commit 8810c5ccdd3327521eb41a1a17999d87095423b8.

Appears this was fixed with the latest nvidia drivers or KDE 6.2, not sure which, but it's probably good to clean this page up.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
