### PR TITLE
fix(rtsp): fix RTSP timeout after quitting an app

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -87,7 +87,8 @@ namespace proc {
 
       // We always call terminate() even if we waited successfully for all processes above.
       // This ensures the process group state is consistent with the OS in boost.
-      group.terminate();
+      std::error_code ec;
+      group.terminate(ec);
       group.detach();
     }
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -588,10 +588,6 @@ namespace rtsp_stream {
           i++;
         }
       }
-
-      if (all && !ios.stopped()) {
-        ios.stop();
-      }
     }
 
     /**


### PR DESCRIPTION
## Description
Remove permanent side-effect in `rtsp_server_t::clear(true)` that prevents RTSP server from accepting new connections. I have no idea why this was there, since the destructor of `rtsp_server_t` should handle teardown of the `io_context`.

Also a drive-by fix for an unhandled exception I saw when testing this scenario on Linux due to us calling `terminate()` after we had already successfully terminated the process group.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Fixes #3371
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
