### PR TITLE
build(macos): fix libcurl linking

### DIFF
--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -38,6 +38,10 @@ class @PROJECT_NAME@ < Formula
   depends_on "boost" => :recommended
   depends_on "icu4c" => :recommended
 
+  on_macos do
+    depends_on "openldap" # curl requires this
+  end
+
   on_linux do
     depends_on "avahi"
     depends_on "libcap"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
libcurl is no longer linking properly on macOS under homebrew.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes comment https://github.com/LizardByte/Sunshine/issues/3180#issuecomment-2463975526


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
