### PR TITLE
fix(nvenc): Enable opt-in client refresh by client

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -322,10 +322,20 @@ namespace nvenc {
         set_minqp_if_enabled(config.min_qp_hevc);
         fill_h264_hevc_vui(format_config.hevcVUIParameters);
         if (client_config.enableIntraRefresh == 1) {
-          format_config.enableIntraRefresh = 1;
-          format_config.singleSliceIntraRefresh = 1;
-          format_config.intraRefreshPeriod = 300;
-          format_config.intraRefreshCnt = 299;
+          if (get_encoder_cap(NV_ENC_CAPS_SUPPORT_INTRA_REFRESH)) {
+            format_config.enableIntraRefresh = 1;
+            format_config.intraRefreshPeriod = 300;
+            format_config.intraRefreshCnt = 299;
+            if (get_encoder_cap(NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH)) {
+              format_config.singleSliceIntraRefresh = 1;
+            }
+            else {
+              BOOST_LOG(warning) << "NvEnc: Single Slice Intra Refresh not supported";
+            }
+          }
+          else {
+            BOOST_LOG(error) << "NvEnc: Client asked for intra-refresh but the encoder does not support intra-refresh";
+          }
         }
         break;
       }

--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -321,6 +321,12 @@ namespace nvenc {
         set_ref_frames(format_config.maxNumRefFramesInDPB, format_config.numRefL0, 5);
         set_minqp_if_enabled(config.min_qp_hevc);
         fill_h264_hevc_vui(format_config.hevcVUIParameters);
+        if (client_config.enableIntraRefresh == 1) {
+          format_config.enableIntraRefresh = 1;
+          format_config.singleSliceIntraRefresh = 1;
+          format_config.intraRefreshPeriod = 300;
+          format_config.intraRefreshCnt = 299;
+        }
         break;
       }
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -976,6 +976,7 @@ namespace rtsp_stream {
     args.try_emplace("x-ml-video.configuredBitrateKbps"sv, "0"sv);
     args.try_emplace("x-ss-general.encryptionEnabled"sv, "0"sv);
     args.try_emplace("x-ss-video[0].chromaSamplingType"sv, "0"sv);
+    args.try_emplace("x-ss-video[0].intraRefresh"sv, "0"sv);
 
     stream::config_t config;
 
@@ -1012,6 +1013,7 @@ namespace rtsp_stream {
       config.monitor.videoFormat = util::from_view(args.at("x-nv-vqos[0].bitStreamFormat"sv));
       config.monitor.dynamicRange = util::from_view(args.at("x-nv-video[0].dynamicRangeMode"sv));
       config.monitor.chromaSamplingType = util::from_view(args.at("x-ss-video[0].chromaSamplingType"sv));
+      config.monitor.enableIntraRefresh = util::from_view(args.at("x-ss-video[0].intraRefresh"sv));
 
       configuredBitrateKbps = util::from_view(args.at("x-ml-video.configuredBitrateKbps"sv));
     }

--- a/src/video.h
+++ b/src/video.h
@@ -38,6 +38,8 @@ namespace video {
     int dynamicRange;
 
     int chromaSamplingType;  // 0 - 4:2:0, 1 - 4:4:4
+
+    int enableIntraRefresh;  // 0 - disabled, 1 - enabled
   };
 
   platf::mem_type_e


### PR DESCRIPTION
## Description
Context in https://github.com/TheElixZammuto/moonlight-xbox/issues/117

This type of degradation can be fixed on nvidia cards by implementing intra-refresh.
I do not have an nvidia card so I wasn't be able to test, but this change has been validated by the commenters in the issue above using a custom Sunshine build made by me and by other forks of Sunshine made by other people, and it seems to fix the issue.

This change is completely opt-in by the client, so this change should only apply to the Xbox/UWP Client

Related to:

**moonlight-xbox:** https://github.com/TheElixZammuto/moonlight-xbox/pull/155
**moonlight-common-c:** https://github.com/moonlight-stream/moonlight-common-c/pull/97


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
https://github.com/TheElixZammuto/moonlight-xbox/issues/117

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
