### PR TITLE
fix(cmake): configuration generation fails when BUILD_TESTS is OFF

### DIFF
--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -113,9 +113,15 @@ set_source_files_properties("${CMAKE_SOURCE_DIR}/third-party/ViGEmClient/src/ViG
 string(TOUPPER "x${CMAKE_BUILD_TYPE}" BUILD_TYPE)
 if("${BUILD_TYPE}" STREQUAL "XDEBUG")
     if(WIN32)
-        set_source_files_properties("${CMAKE_SOURCE_DIR}/src/nvhttp.cpp"
-                DIRECTORY "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/tests"
-                PROPERTIES COMPILE_FLAGS -O2)
+        if (NOT BUILD_TESTS)
+            set_source_files_properties("${CMAKE_SOURCE_DIR}/src/nvhttp.cpp"
+                    DIRECTORY "${CMAKE_SOURCE_DIR}"
+                    PROPERTIES COMPILE_FLAGS -O2)
+        else()
+            set_source_files_properties("${CMAKE_SOURCE_DIR}/src/nvhttp.cpp"
+                    DIRECTORY "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/tests"
+                    PROPERTIES COMPILE_FLAGS -O2)
+        endif()
     endif()
 else()
     add_definitions(-DNDEBUG)


### PR DESCRIPTION
## Description
Fixed the issue that generating cmake configuration on Windows platform failed after BUILD_TESTS was set to OFF.

Error message:
```shell
CMake Error at cmake/targets/common.cmake:116 (set_source_files_properties):
  set_source_files_properties given non-existent DIRECTORY
```

### Screenshot
None


### Issues Fixed or Closed
None


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
