### PR TITLE
build(deps): fix boost 1.87 compatibility

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -46,8 +46,8 @@ namespace nvhttp {
 
   class SunshineHTTPS: public SimpleWeb::HTTPS {
   public:
-    SunshineHTTPS(boost::asio::io_service &io_service, boost::asio::ssl::context &ctx):
-        SimpleWeb::HTTPS(io_service, ctx) {}
+    SunshineHTTPS(boost::asio::io_context &io_context, boost::asio::ssl::context &ctx):
+        SimpleWeb::HTTPS(io_context, ctx) {}
 
     virtual ~SunshineHTTPS() {
       // Gracefully shutdown the TLS connection

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -324,10 +324,10 @@ namespace stream {
     std::thread audio_thread;
     std::thread control_thread;
 
-    asio::io_service io;
+    asio::io_context io_context;
 
-    udp::socket video_sock { io };
-    udp::socket audio_sock { io };
+    udp::socket video_sock { io_context };
+    udp::socket audio_sock { io_context };
 
     control_server_t control_server;
   };
@@ -1183,7 +1183,7 @@ namespace stream {
     auto &message_queue_queue = ctx.message_queue_queue;
     auto broadcast_shutdown_event = mail::man->event<bool>(mail::broadcast_shutdown);
 
-    auto &io = ctx.io;
+    auto &io = ctx.io_context;
 
     udp::endpoint peer;
 
@@ -1777,7 +1777,7 @@ namespace stream {
     audio_packets->stop();
 
     ctx.message_queue_queue->stop();
-    ctx.io.stop();
+    ctx.io_context.stop();
 
     ctx.video_sock.close();
     ctx.audio_sock.close();


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Boost 1.87 removes `asio::io_service`. See: https://github.com/boostorg/asio/issues/110

These changes seem compatible with 1.86 and 1.87 so technically we don't need to update to 1.87.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
