### PR TITLE
docs(doxygen): remove INCLUDE_PATH from config

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -32,7 +32,6 @@ PROJECT_NAME = Sunshine
 # project specific settings
 DOT_GRAPH_MAX_NODES = 60
 IMAGE_PATH = ../docs/images
-INCLUDE_PATH = ../third-party/build-deps/dist/Linux-x86_64/include/
 PREDEFINED += SUNSHINE_BUILD_WAYLAND
 PREDEFINED += SUNSHINE_TRAY=1
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -59,7 +59,7 @@ namespace config {
   }  // namespace nv
 
   namespace amd {
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(DOXYGEN)
   // values accurate as of 27/12/2022, but aren't strictly necessary for MacOS build
   #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_SPEED 100
   #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_QUALITY 30


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Using the INCLUDE_PATH causes errors when building in some cases.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
