### PR TITLE
docs(hrefs): update readthedocs hrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
   <a href="https://github.com/LizardByte/Sunshine/actions/workflows/localize.yml?query=branch%3Amaster">
     <img src="https://img.shields.io/github/actions/workflow/status/lizardbyte/sunshine/localize.yml.svg?branch=master&label=localize%20build&logo=github&style=for-the-badge" alt="GitHub Workflow Status (localize)">
   </a>
-  <a href="https://sunshinestream.readthedocs.io">
+  <a href="https://docs.lizardbyte.dev/projects/sunshine">
     <img src="https://img.shields.io/readthedocs/sunshinestream.svg?label=Docs&style=for-the-badge&logo=readthedocs" alt="Read the Docs">
   </a>
   <a href="https://codecov.io/gh/LizardByte/Sunshine">
@@ -51,10 +51,10 @@ encoding. Software encoding is also available. You can connect to Sunshine from 
 devices. A web UI is provided to allow configuration, and client pairing, from your favorite web browser. Pair from
 the local server or any mobile device.
 
-LizardByte has the full documentation hosted on [Read the Docs](https://app.readthedocs.org)
+LizardByte has the full documentation hosted on [Read the Docs](https://docs.lizardbyte.dev/projects/sunshine)
 
-* [Stable](https://sunshinestream.readthedocs.io/en/latest/)
-* [Beta](https://sunshinestream.readthedocs.io/en/master/)
+* [Stable](https://docs.lizardbyte.dev/projects/sunshine/latest/)
+* [Beta](https://docs.lizardbyte.dev/projects/sunshine/master/)
 
 ## 🖥️ System Requirements
 
@@ -186,7 +186,7 @@ LizardByte has the full documentation hosted on [Read the Docs](https://app.read
 
 ## ❓ Support
 
-Our support methods are listed in our [LizardByte Docs](https://lizardbyte.readthedocs.io/en/latest/about/support.html).
+Our support methods are listed in our [LizardByte Docs](https://docs.lizardbyte.dev/latest/about/support.html).
 
 <div class="section_buttons">
 

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -62,7 +62,7 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_NAME}")
 SET(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
         "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
         IfSilent +2 0
-        ExecShell 'open' 'https://sunshinestream.readthedocs.io/'
+        ExecShell 'open' 'https://docs.lizardbyte.dev/projects/sunshine'
         nsExec::ExecToLog 'icacls \\\"$INSTDIR\\\" /reset'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\migrate-config.bat\\\"'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\add-firewall-rule.bat\\\"'
@@ -109,12 +109,12 @@ set(CPACK_NSIS_DELETE_ICONS_EXTRA
 # Checking for previous installed versions
 set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL "ON")
 
-set(CPACK_NSIS_HELP_LINK "https://sunshinestream.readthedocs.io/en/latest/about/installation.html")
+set(CPACK_NSIS_HELP_LINK "https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2getting__started.html")
 set(CPACK_NSIS_URL_INFO_ABOUT "${CMAKE_PROJECT_HOMEPAGE_URL}")
 set(CPACK_NSIS_CONTACT "${CMAKE_PROJECT_HOMEPAGE_URL}/support")
 
 set(CPACK_NSIS_MENU_LINKS
-        "https://sunshinestream.readthedocs.io" "Sunshine documentation"
+        "https://docs.lizardbyte.dev/projects/sunshine" "Sunshine documentation"
         "https://app.lizardbyte.dev" "LizardByte Web Site"
         "https://app.lizardbyte.dev/support" "LizardByte Support")
 set(CPACK_NSIS_MANIFEST_DPI_AWARE true)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 Read our contribution guide in our organization level
-[docs](https://lizardbyte.readthedocs.io/en/latest/developers/contributing.html).
+[docs](https://docs.lizardbyte.dev/latest/developers/contributing.html).
 
 ## Project Patterns
 

--- a/packaging/linux/flatpak/README.md
+++ b/packaging/linux/flatpak/README.md
@@ -3,7 +3,7 @@
 [![Flathub installs](https://img.shields.io/flathub/downloads/dev.lizardbyte.app.Sunshine?style=for-the-badge&logo=flathub)](https://flathub.org/apps/dev.lizardbyte.app.Sunshine)
 [![Flathub Version](https://img.shields.io/flathub/v/dev.lizardbyte.app.Sunshine?style=for-the-badge&logo=flathub)](https://flathub.org/apps/dev.lizardbyte.app.Sunshine)
 
-LizardByte has the full documentation hosted on [Read the Docs](https://sunshinestream.readthedocs.io).
+LizardByte has the full documentation hosted on [Read the Docs](https://docs.lizardbyte.dev/projects/sunshine).
 
 ## About
 

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -130,7 +130,7 @@ class @PROJECT_NAME@ < Formula
       Thanks for installing @PROJECT_NAME@!
 
       To get started, review the documentation at:
-        https://docs.lizardbyte.dev/projects/sunshine/en/latest/
+        https://docs.lizardbyte.dev/projects/sunshine
     EOS
 
     if OS.linux?

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1685,7 +1685,7 @@ namespace platf {
           BOOST_LOG((window_system != window_system_e::X11 || config::video.capture == "kms") ? fatal : error)
             << "You must run [sudo setcap cap_sys_admin+p $(readlink -f $(which sunshine))] for KMS display capture to work!\n"sv
             << "If you installed from AppImage or Flatpak, please refer to the official documentation:\n"sv
-            << "https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/setup.html#install"sv;
+            << "https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2getting__started.html#linux"sv;
           break;
         }
 

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -337,7 +337,7 @@
             <pre>sh -c "displayplacer "id:&lt;screenId&gt; res:${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT} hz:${SUNSHINE_CLIENT_FPS} scaling:on origin:(0,0) degree:0""</pre>
           </div>
           <div class="form-text"><a
-              href="https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/guides/app_examples.html"
+              href="https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2app__examples.html"
               target="_blank">{{ $t('_common.see_more') }}</a></div>
         </div>
         <!-- Save buttons -->


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR updates hrefs to docs, mainly so they will continue to work with the doxygen version of the docs.

This PR should not be merged until right before the next stable release.

Additionally, directly before this is merged, we need to update a setting on readthedocs, to not put docs under an `en` subdirectory (also for the `.github` repo).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
