### PR TITLE
fix(input): Removed batching of move events of PEN_PACKET

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1392,9 +1392,9 @@ namespace input {
    */
   batch_result_e
   batch(PSS_PEN_PACKET dest, PSS_PEN_PACKET src) {
-    // Only batch hover or move events
-    if (dest->eventType != LI_TOUCH_EVENT_MOVE &&
-        dest->eventType != LI_TOUCH_EVENT_HOVER) {
+    // Only batch hover events
+    // Move events may not be batched due to graphics programs.
+    if (dest->eventType != LI_TOUCH_EVENT_HOVER) {
       return batch_result_e::terminate_batch;
     }
 


### PR DESCRIPTION
## Description
The changes ensure that move events from pens are no longer batched.
This is necessary when Sunshine is used to work with graphics programs.

### Issues Fixed
<!--- Fix bug issue example: `- Fixes #1` --->
[moonlight-stream/moonlight-android#1427](https://github.com/moonlight-stream/moonlight-android/issues/1427)

### Associated pull requests
[moonlight-stream/moonlight-common-c#99](https://github.com/moonlight-stream/moonlight-common-c/pull/99)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
