### PR TITLE
fix(shaders/directx): replace modulus with bitwise operator

### DIFF
--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -24,7 +24,10 @@ vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float2 subsample_of
                                      sin(rotation_radians), cos(rotation_radians) };
         float2 rotation_center = { 0.5, 0.5 };
         tex_coord = round(rotation_center + mul(rotation_matrix, tex_coord - rotation_center));
-
+/* 
+bitwise operation used in place of modulus operation as mod operator on integer does not compile optimally generating warnings, 
+bitwise operation "& 1" is equivalent to "% 2" in a form that results in optimized lower level code.
+*/
         if (rotate_texture_steps & 1) {
             subsample_offset.xy = subsample_offset.yx;
         }

--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -24,8 +24,10 @@ vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float2 subsample_of
                                      sin(rotation_radians), cos(rotation_radians) };
         float2 rotation_center = { 0.5, 0.5 };
         tex_coord = round(rotation_center + mul(rotation_matrix, tex_coord - rotation_center));
+
         // Swap the xy offset coordinates if the texture is rotated an odd number of times.
         if (rotate_texture_steps & 1) {
+
 
             subsample_offset.xy = subsample_offset.yx;
         }

--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -27,7 +27,6 @@ vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float2 subsample_of
 
         // Swap the xy offset coordinates if the texture is rotated an odd number of times.
         if (rotate_texture_steps & 1) {
-
             subsample_offset.xy = subsample_offset.yx;
         }
     }

--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -25,7 +25,7 @@ vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float2 subsample_of
         float2 rotation_center = { 0.5, 0.5 };
         tex_coord = round(rotation_center + mul(rotation_matrix, tex_coord - rotation_center));
 
-        if (rotate_texture_steps % 2) {
+        if (rotate_texture_steps & 1) {
             subsample_offset.xy = subsample_offset.yx;
         }
     }

--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -28,7 +28,6 @@ vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float2 subsample_of
         // Swap the xy offset coordinates if the texture is rotated an odd number of times.
         if (rotate_texture_steps & 1) {
 
-
             subsample_offset.xy = subsample_offset.yx;
         }
     }

--- a/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/base_vs.hlsl
@@ -24,11 +24,9 @@ vertex_t generate_fullscreen_triangle_vertex(uint vertex_id, float2 subsample_of
                                      sin(rotation_radians), cos(rotation_radians) };
         float2 rotation_center = { 0.5, 0.5 };
         tex_coord = round(rotation_center + mul(rotation_matrix, tex_coord - rotation_center));
-/* 
-bitwise operation used in place of modulus operation as mod operator on integer does not compile optimally generating warnings, 
-bitwise operation "& 1" is equivalent to "% 2" in a form that results in optimized lower level code.
-*/
+        // Swap the xy offset coordinates if the texture is rotated an odd number of times.
         if (rotate_texture_steps & 1) {
+
             subsample_offset.xy = subsample_offset.yx;
         }
     }


### PR DESCRIPTION
Replace modulo operation with bitwise operation to optimize performance and remove warning messages on some GPUs
