### PR TITLE
fix(capture/macos): fix implicit conversion of NSArray

### DIFF
--- a/src/platform/macos/av_video.m
+++ b/src/platform/macos/av_video.m
@@ -32,8 +32,7 @@
 }
 
 + (NSString *)getDisplayName:(CGDirectDisplayID)displayID {
-  NSScreen *screens = [NSScreen screens];
-  for (NSScreen *screen in screens) {
+  for (NSScreen *screen in [NSScreen screens]) {
     if (screen.deviceDescription[@"NSScreenNumber"] == [NSNumber numberWithUnsignedInt:displayID]) {
       return screen.localizedName;
     }


### PR DESCRIPTION
## Description
Fixes the following compiler warnings on macOS:
```
src/platform/macos/av_video.m:35:13: warning: incompatible pointer types initializing 'NSScreen *' with an expression of type 'NSArray<NSScreen *> * _Nonnull' [-Wincompatible-pointer-types]
   35 |   NSScreen *screens = [NSScreen screens];
      |             ^         ~~~~~~~~~~~~~~~~~~
src/platform/macos/av_video.m:36:3: warning: collection expression type 'NSScreen *' may not respond to 'countByEnumeratingWithState:objects:count:'
   36 |   for (NSScreen *screen in screens) {
      |   ^  
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
