### PR TITLE
fix(rtp): improve timestamp accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ package-lock.json
 # Python
 *.pyc
 venv/
+
+# Syncthing
+.stfolder/
+.stversions/

--- a/src/audio.h
+++ b/src/audio.h
@@ -68,7 +68,31 @@ namespace audio {
   };
 
   using buffer_t = util::buffer_t<std::uint8_t>;
-  using packet_t = std::pair<void *, buffer_t>;
+
+  struct packet_raw_t {
+    virtual ~packet_raw_t() = default;
+
+    packet_raw_t(buffer_t &&packet_data):
+        packet_data { std::move(packet_data) }
+    { }
+
+    size_t
+    data_size() {
+      return packet_data.size();
+    }
+
+    buffer_t packet_data;
+    void *channel_data = nullptr;
+    std::chrono::steady_clock::time_point capture_timestamp;
+  };
+
+  using packet_t = std::unique_ptr<packet_raw_t>;
+
+  struct audio_with_timestamp_t {
+    std::vector<float> pcm;
+    std::chrono::steady_clock::time_point capture_timestamp;
+  };
+
   using audio_ctx_ref_t = safe::shared_t<audio_ctx_t>::ptr_t;
 
   void

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -537,7 +537,7 @@ namespace platf {
   class mic_t {
   public:
     virtual capture_e
-    sample(std::vector<float> &frame_buffer) = 0;
+    sample(std::vector<float> &frame_buffer, std::chrono::steady_clock::time_point &capture_timestamp_out) = 0;
 
     virtual ~mic_t() = default;
   };

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -54,8 +54,9 @@ namespace platf {
     util::safe_ptr<pa_simple, pa_simple_free> mic;
 
     capture_e
-    sample(std::vector<float> &sample_buf) override {
+    sample(std::vector<float> &sample_buf, std::chrono::steady_clock::time_point &capture_timestamp_out) override {
       auto sample_size = sample_buf.size();
+      capture_timestamp_out = std::chrono::steady_clock::now();
 
       auto buf = sample_buf.data();
       int status;

--- a/src/platform/macos/microphone.mm
+++ b/src/platform/macos/microphone.mm
@@ -19,8 +19,9 @@ namespace platf {
     }
 
     capture_e
-    sample(std::vector<float> &sample_in) override {
+    sample(std::vector<float> &sample_in, std::chrono::steady_clock::time_point &capture_timestamp_out) override {
       auto sample_size = sample_in.size();
+      capture_timestamp_out = std::chrono::steady_clock::now();
 
       uint32_t length = 0;
       void *byteSampleBuffer = TPCircularBufferTail(&av_audio_capture->audioSampleBuffer, &length);

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -9,6 +9,17 @@
 #include <windows.h>
 #include <winnt.h>
 
+// Windows provides a timestamp from GetBuffer() indicating exactly when audio was captured.
+// Before trusting this timestamp, we check if it is compatible with our other time code.
+
+#define MAX_QPC_TIMESTAMP_OFFSET_MS 50  ///< QPC is allowed to be +/- this many milliseconds from now().
+
+enum qpc_status_t : int {
+  QPC_PENDING,   ///< QPC offset will be checked after capturing the first audio packet
+  QPC_INVALID,   ///< QPC offset exceeded MAX_QPC_TIMESTAMP_OFFSET_MS and we will generate timestamps
+  QPC_VALID      ///< QPC offset fell within acceptable range and will be used
+};
+
 namespace platf {
   void
   print_status(const std::string_view &prefix, HRESULT status);

--- a/tests/unit/test_audio.cpp
+++ b/tests/unit/test_audio.cpp
@@ -54,7 +54,7 @@ TEST_P(AudioTest, TestEncode) {
       if (shutdown_event->peek()) {
         break;
       }
-      auto packet_data = packet->second;
+      auto packet_data = packet->packet_data;
       if (packet_data.size() == 0) {
         FAIL() << "Empty packet data";
       }


### PR DESCRIPTION
## Background

I am [experimenting](https://github.com/andygrundman/moonlight-ios/tree/andyg.ios-spatial-audio) with the iOS AVSampleBufferAudioRenderer and AVSampleBufferRenderSynchronizer APIs, which include the ability to use RTP timestamps as a way to pace playback, provide a/v sync that won't drift, use variable-speed playback to cover for short glitches (such as Game Mode's drop in Bluetooth latency), proper spatial audio support for free, and more. It should also be nicely compatible with the AVSampleBufferDisplayLayer API currently used by the iOS video code.  The biggest challenge with these APIs is their higher latency, but I'm hopeful it can get to a reasonable level. Worst case, it could be a good option when you are willing to trade a little latency for solid playback.

## Description

* Video: instead of using now() when the RTP packet is created, use the earlier packet->frame_timestamp that we're already collecting for host latency stats. This timestamp should be more accurate to when we captured the frame. I am not sure if all backends support this timestamp, so there is a fallback to the current method.
* Audio: fix a bug where the RTP timestamps stop advancing when no audio is being sent. Audio now uses the same timer-based source for this field, but remains as milliseconds. Because of this bug, I am pretty sure no client is using these timestamps for anything.
* Both use steady_clock and microseconds / 1000 to maintain precision. Video still uses 90khz time base per the spec, and audio is effectively at packet duration resolution of 5ms/10ms.

Known issue: I had to comment out one assert in Moonlight, because this patch changes one of the FEC timestamps. The FEC RFC says "The timestamp SHALL be set to a time corresponding to the repair packet's transmission time.  Note that the timestamp value has no use in the actual FEC protection process and is usually useful for jitter calculations.", so I don't think this assert is correct anyway. Even though this shouldn't affect Moonlight release builds which don't use asserts or the extra FEC verification code, this probably needs to be resolved before this can be accepted, either by only sending correct timestamp packets to newer Moonlight versions, or fixing it in the FEC code. (Not to get too sidetracked but was the Opus FEC support ever tried? I sometimes wonder if the 40% FEC overhead on audio is too high for benefit.)

RtpAudioQueue.c:300
```LC_ASSERT_VT(existingBlock->fecHeader.baseTimestamp == fecBlockBaseTs);```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
