### PR TITLE
feat(ddprobe): allow to manually specify gpu preference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -848,6 +848,37 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### gpu_preference
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Specify the GPU preference for the Sunshine process.
+            <br>
+            <br>
+            If set to negative number (-1 by default), Sunshine will try to detect the best GPU for the streamed display, but if it fails you will get a black screen.
+            <br>
+            Setting it to 0 will allow Windows to try and select the best GPU.
+            <br>
+            Setting it to 1 and above will prioritize the GPU that matches this number (the number has to be guessed, but it starts at 1 and increases).
+            @note{Applies to Windows only.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}
+            -1
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            2
+            @endcode</td>
+    </tr>
+</table>
+
 ### output_name
 
 <table>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -436,6 +436,7 @@ namespace config {
     {},  // capture
     {},  // encoder
     {},  // adapter_name
+    -1,  // gpu_preference
     {},  // output_name
 
     {
@@ -1088,6 +1089,7 @@ namespace config {
     string_f(vars, "capture", video.capture);
     string_f(vars, "encoder", video.encoder);
     string_f(vars, "adapter_name", video.adapter_name);
+    int_f(vars, "gpu_preference", video.gpu_preference);
     string_f(vars, "output_name", video.output_name);
 
     generic_f(vars, "dd_configuration_option", video.dd.configuration_option, dd::config_option_from_view);

--- a/src/config.h
+++ b/src/config.h
@@ -77,6 +77,7 @@ namespace config {
     std::string capture;
     std::string encoder;
     std::string adapter_name;
+    int gpu_preference;
     std::string output_name;
 
     struct dd_t {

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -386,12 +386,7 @@ namespace platf::dxgi {
       // would have been raised first if it wasn't.
       if (result == S_OK || result == E_ACCESSDENIED) {
         // We found a working GPU preference, so set ourselves to use that.
-        if (set_gpu_preference_on_self(i)) {
-          return true;
-        }
-        else {
-          return false;
-        }
+        return set_gpu_preference_on_self(i);
       }
     }
 
@@ -418,16 +413,25 @@ namespace platf::dxgi {
       return true;
     }
 
-    // Try probing with different GPU preferences and verify_frame_capture flag
-    if (validate_and_test_gpu_preference(display_name, true)) {
-      set_gpu_preference = true;
-      return true;
+    // If the GPU preference was manually specified, we can skip the probe.
+    if (config::video.gpu_preference >= 0) {
+      if (set_gpu_preference_on_self(config::video.gpu_preference)) {
+        set_gpu_preference = true;
+        return true;
+      }
     }
+    else {
+      // Try probing with different GPU preferences and verify_frame_capture flag
+      if (const auto pref = validate_and_test_gpu_preference(display_name, true); pref) {
+        set_gpu_preference = true;
+        return true;
+      }
 
-    // If no valid configuration was found, try again with verify_frame_capture == false
-    if (validate_and_test_gpu_preference(display_name, false)) {
-      set_gpu_preference = true;
-      return true;
+      // If no valid configuration was found, try again with verify_frame_capture == false
+      if (validate_and_test_gpu_preference(display_name, false)) {
+        set_gpu_preference = true;
+        return true;
+      }
     }
 
     // If neither worked, return false

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -422,7 +422,7 @@ namespace platf::dxgi {
     }
     else {
       // Try probing with different GPU preferences and verify_frame_capture flag
-      if (const auto pref = validate_and_test_gpu_preference(display_name, true); pref) {
+      if (validate_and_test_gpu_preference(display_name, true)) {
         set_gpu_preference = true;
         return true;
       }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -169,6 +169,7 @@
               "virtual_sink": "",
               "install_steam_audio_drivers": "enabled",
               "adapter_name": "",
+              "gpu_preference": -1,
               "output_name": "",
               "dd_configuration_option": "verify_only",
               "dd_resolution_option": "auto",

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -74,7 +74,7 @@ const config = ref(props.config)
         <!-- GPU Preference -->
         <div class="mb-3">
           <label for="gpu_preference" class="form-label">{{ $t('config.gpu_preference') }}</label>
-          <input type="text" class="form-control" id="gpu_preference" placeholder="-1"
+          <input type="number" class="form-control" id="gpu_preference" placeholder="-1" min="-1"
                  v-model="config.gpu_preference" />
           <div class="form-text">{{ $t('config.gpu_preference_desc') }}</div>
         </div>

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -69,6 +69,18 @@ const config = ref(props.config)
         :config="config"
     />
 
+    <PlatformLayout :platform="platform">
+      <template #windows>
+        <!-- GPU Preference -->
+        <div class="mb-3">
+          <label for="gpu_preference" class="form-label">{{ $t('config.gpu_preference') }}</label>
+          <input type="text" class="form-control" id="gpu_preference" placeholder="-1"
+                 v-model="config.gpu_preference" />
+          <div class="form-text">{{ $t('config.gpu_preference_desc') }}</div>
+        </div>
+      </template>
+    </PlatformLayout>
+
     <DisplayOutputSelector
       :platform="platform"
       :config="config"

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
@@ -108,7 +108,7 @@ const config = ref(props.config)
                 <label for="dd_config_revert_delay" class="form-label">
                   {{ $t('config.dd_config_revert_delay') }}
                 </label>
-                <input type="text" class="form-control" id="dd_config_revert_delay" placeholder="3000"
+                <input type="number" class="form-control" id="dd_config_revert_delay" placeholder="3000" min="0"
                        v-model="config.dd_config_revert_delay" />
                 <div class="form-text">
                   {{ $t('config.dd_config_revert_delay_desc') }}

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -186,6 +186,8 @@
     "fec_percentage": "FEC Percentage",
     "fec_percentage_desc": "Percentage of error correcting packets per data packet in each video frame. Higher values can correct for more network packet loss, but at the cost of increasing bandwidth usage.",
     "ffmpeg_auto": "auto -- let ffmpeg decide (default)",
+    "gpu_preference": "GPU Preference",
+    "gpu_preference_desc": "Specify the GPU preference for the Sunshine process. If set to negative number (-1 by default), Sunshine will try to detect the best GPU for the streamed display, but if it fails you will get a black screen. Setting it to 0 will allow Windows to try and select the best GPU. Setting it to 1 and above will prioritize the GPU that matches this number (the number has to be guessed, but it starts at 1 and increases).",
     "file_apps": "Apps File",
     "file_apps_desc": "The file where current apps of Sunshine are stored.",
     "file_state": "State File",


### PR DESCRIPTION
## Description
At the moment `ddprobe` does not always work (see https://github.com/LizardByte/Sunshine/pull/3414). This PR allows to manually specify the GPU preference instead of relying on the `ddprobe`.

### Screenshot
![image](https://github.com/user-attachments/assets/b1001ecf-6c8a-45f8-ac6d-0de25b7df4cd)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
