### PR TITLE
fix(capture/windows): fix capture when using the basic render driver

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -954,8 +954,7 @@ jobs:
             -DSUNSHINE_ASSETS_DIR=assets \
             -DSUNSHINE_PUBLISHER_NAME='${{ github.repository_owner }}' \
             -DSUNSHINE_PUBLISHER_WEBSITE='https://app.lizardbyte.dev' \
-            -DSUNSHINE_PUBLISHER_ISSUE_URL='https://app.lizardbyte.dev/support' \
-            -DTESTS_SOFTWARE_ENCODER_UNAVAILABLE='skip'
+            -DSUNSHINE_PUBLISHER_ISSUE_URL='https://app.lizardbyte.dev/support'
           ninja -C build
 
       - name: Package Windows

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -12,10 +12,6 @@ option(BUILD_TESTS "Build tests" ON)
 option(NPM_OFFLINE "Use offline npm packages. You must ensure packages are in your npm cache." OFF)
 option(TESTS_ENABLE_PYTHON_TESTS "Enable Python tests" ON)
 
-# DirectX11 is not available in GitHub runners, so even software encoding fails
-set(TESTS_SOFTWARE_ENCODER_UNAVAILABLE "fail"
-        CACHE STRING "How to handle unavailable software encoders in tests. 'fail/skip'")
-
 option(BUILD_WERROR "Enable -Werror flag." OFF)
 
 # if this option is set, the build will exit after configuring special package configuration files

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -23,7 +23,7 @@ namespace platf::dxgi {
 
   // Add D3D11_CREATE_DEVICE_DEBUG here to enable the D3D11 debug runtime.
   // You should have a debugger like WinDbg attached to receive debug messages.
-  auto constexpr D3D11_CREATE_DEVICE_FLAGS = D3D11_CREATE_DEVICE_VIDEO_SUPPORT;
+  auto constexpr D3D11_CREATE_DEVICE_FLAGS = 0;
 
   template <class T>
   void

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -760,7 +760,7 @@ namespace platf::dxgi {
         adapter_p,
         D3D_DRIVER_TYPE_UNKNOWN,
         nullptr,
-        D3D11_CREATE_DEVICE_FLAGS,
+        D3D11_CREATE_DEVICE_FLAGS | D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
         featureLevels, sizeof(featureLevels) / sizeof(D3D_FEATURE_LEVEL),
         D3D11_SDK_VERSION,
         &device,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,12 +35,6 @@ endif ()
 
 set(TEST_DEFINITIONS)  # list will be appended as needed
 
-# make sure TESTS_SOFTWARE_ENCODER_UNAVAILABLE is set to "fail" or "skip"
-if (NOT (TESTS_SOFTWARE_ENCODER_UNAVAILABLE STREQUAL "fail" OR TESTS_SOFTWARE_ENCODER_UNAVAILABLE STREQUAL "skip"))
-    set(TESTS_SOFTWARE_ENCODER_UNAVAILABLE "fail")
-endif ()
-list(APPEND TEST_DEFINITIONS TESTS_SOFTWARE_ENCODER_UNAVAILABLE="${TESTS_SOFTWARE_ENCODER_UNAVAILABLE}")  # fail/skip
-
 # this indicates we're building tests in case sunshine needs to adjust some code or add private tests
 list(APPEND TEST_DEFINITIONS SUNSHINE_TESTS)
 

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -12,8 +12,8 @@ struct EncoderTest: PlatformTestSuite, testing::WithParamInterface<video::encode
     auto &encoder = *GetParam();
     if (!video::validate_encoder(encoder, false)) {
       // Encoder failed validation,
-      // if it's software - fail (unless overriden with compile definition), otherwise skip
-      if (encoder.name == "software" && std::string(TESTS_SOFTWARE_ENCODER_UNAVAILABLE) == "fail") {
+      // if it's software - fail, otherwise skip
+      if (encoder.name == "software") {
         FAIL() << "Software encoder not available";
       }
       else {


### PR DESCRIPTION
## Description
For the longest time, I thought DDA just didn't work on the Microsoft Basic Display Adapter. It turns out that it works fine, but we're passing a D3D11 device flag that it doesn't support so we fail to create the D3D11 device with `DXGI_ERROR_UNSUPPORTED`. I reviewed several DDA samples online (including [the official Microsoft one](https://github.com/microsoft/Windows-classic-samples/blob/main/Samples/DXGIDesktopDuplication/README.md)) and none of them set this `D3D11_CREATE_DEVICE_VIDEO_SUPPORT` flag.

It's not completely clear what `D3D11_CREATE_DEVICE_VIDEO_SUPPORT` even does exactly, but assuming it's required for the device where we do video encoding/processing, let's just set it on the device that FFmpeg uses for encoding.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
