### PR TITLE
build(cmake): check for MinHook during configure

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -64,23 +64,27 @@ set(OPENSSL_LIBRARIES
         libcrypto.a)
 
 list(PREPEND PLATFORM_LIBRARIES
+        ${CURL_STATIC_LIBRARIES}
+        avrt
+        d3d11
+        D3DCompiler
+        dwmapi
+        dxgi
+        iphlpapi
+        ksuser
+        libssp.a
         libstdc++.a
         libwinpthread.a
-        libssp.a
+        minhook::minhook
+        nlohmann_json::nlohmann_json
         ntdll
-        ksuser
-        wsock32
-        ws2_32
-        d3d11 dxgi D3DCompiler
         setupapi
-        dwmapi
-        userenv
-        synchronization.lib
-        avrt
-        iphlpapi
         shlwapi
-        PkgConfig::NLOHMANN_JSON
-        ${CURL_STATIC_LIBRARIES})
+        synchronization.lib
+        userenv
+        ws2_32
+        wsock32
+)
 
 if(SUNSHINE_ENABLE_TRAY)
     list(APPEND PLATFORM_TARGET_FILES

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -28,7 +28,7 @@ include_directories(SYSTEM ${MINIUPNP_INCLUDE_DIRS})
 # ffmpeg pre-compiled binaries
 if(NOT DEFINED FFMPEG_PREPARED_BINARIES)
     if(WIN32)
-        set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid vpl MinHook)
+        set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid vpl)
     elseif(UNIX AND NOT APPLE)
         set(FFMPEG_PLATFORM_LIBRARIES numa va va-drm va-x11 X11)
     endif()

--- a/cmake/dependencies/windows.cmake
+++ b/cmake/dependencies/windows.cmake
@@ -1,4 +1,12 @@
 # windows specific dependencies
 
 # nlohmann_json
-pkg_check_modules(NLOHMANN_JSON nlohmann_json REQUIRED IMPORTED_TARGET)
+find_package(nlohmann_json CONFIG 3.11 REQUIRED)
+
+# Make sure MinHook is installed
+find_library(MINHOOK_LIBRARY minhook REQUIRED)
+find_path(MINHOOK_INCLUDE_DIR MinHook.h PATH_SUFFIXES include REQUIRED)
+
+add_library(minhook::minhook UNKNOWN IMPORTED)
+set_property(TARGET minhook::minhook PROPERTY IMPORTED_LOCATION ${MINHOOK_LIBRARY})
+target_include_directories(minhook::minhook INTERFACE ${MINHOOK_INCLUDE_DIR})


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR will check for MinHook during cmake configure step instead of failing during the build step.

PLATFORM_LIBRARIES is also listed alphabetically.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
