### PR TITLE
fix(cmake/windows): static link MinHook

### DIFF
--- a/cmake/dependencies/windows.cmake
+++ b/cmake/dependencies/windows.cmake
@@ -4,9 +4,9 @@
 find_package(nlohmann_json CONFIG 3.11 REQUIRED)
 
 # Make sure MinHook is installed
-find_library(MINHOOK_LIBRARY minhook REQUIRED)
+find_library(MINHOOK_LIBRARY libMinHook.a REQUIRED)
 find_path(MINHOOK_INCLUDE_DIR MinHook.h PATH_SUFFIXES include REQUIRED)
 
-add_library(minhook::minhook UNKNOWN IMPORTED)
+add_library(minhook::minhook STATIC IMPORTED)
 set_property(TARGET minhook::minhook PROPERTY IMPORTED_LOCATION ${MINHOOK_LIBRARY})
 target_include_directories(minhook::minhook INTERFACE ${MINHOOK_INCLUDE_DIR})


### PR DESCRIPTION
## Description
Static linking for minhook.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
