### PR TITLE
feat(tray): add button to reset display device settings on Windows

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -37,6 +37,7 @@
 
   // local includes
   #include "confighttp.h"
+  #include "display_device.h"
   #include "logging.h"
   #include "platform/common.h"
   #include "process.h"
@@ -68,6 +69,13 @@ namespace system_tray {
   void
   tray_donate_paypal_cb(struct tray_menu *item) {
     platf::open_url("https://www.paypal.com/paypalme/ReenigneArcher");
+  }
+
+  void
+  tray_reset_display_device_config_cb(struct tray_menu *item) {
+    BOOST_LOG(info) << "Resetting display device config from system tray"sv;
+
+    std::ignore = display_device::reset_persistence();
   }
 
   void
@@ -110,6 +118,10 @@ namespace system_tray {
               { .text = "PayPal", .cb = tray_donate_paypal_cb },
               { .text = nullptr } } },
         { .text = "-" },
+  // Currently display device settings are only supported on Windows
+  #ifdef _WIN32
+        { .text = "Reset Display Device Config", .cb = tray_reset_display_device_config_cb },
+  #endif
         { .text = "Restart", .cb = tray_restart_cb },
         { .text = "Quit", .cb = tray_quit_cb },
         { .text = nullptr } },

--- a/src/system_tray.h
+++ b/src/system_tray.h
@@ -37,6 +37,13 @@ namespace system_tray {
   tray_donate_paypal_cb(struct tray_menu *item);
 
   /**
+   * @brief Callback for resetting display device configuration.
+   * @param item The tray menu item.
+   */
+  void
+  tray_reset_display_device_config_cb(struct tray_menu *item);
+
+  /**
    * @brief Callback for restarting Sunshine from the system tray.
    * @param item The tray menu item.
    */


### PR DESCRIPTION
## Description
Add button to reset display device settings on Windows. Also, remove the callbacks from the header file (where they should not be located in my opinion) and into cpp file.

Also check https://stackoverflow.com/questions/4422507/how-are-unnamed-namespaces-superior-to-the-static-keyword regarding the anonymous namespace.

### Screenshot
![image](https://github.com/user-attachments/assets/4d77d80f-7156-4600-b308-98bcf0f85d57)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
