### PR TITLE
fix(httpcommon): sonarqube warning cleanup

### DIFF
--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -58,7 +58,9 @@ namespace http {
         create_creds(config::nvhttp.pkey, config::nvhttp.cert)) {
       return -1;
     }
-    if (user_creds_exist(config::sunshine.credentials_file) && reload_user_creds(config::sunshine.credentials_file)) {
+    if (!user_creds_exist(config::sunshine.credentials_file)) {
+      BOOST_LOG(info) << "Open the Web UI to set your new username and password and getting started";
+    } else if (reload_user_creds(config::sunshine.credentials_file)) {
       return -1;
     }
     return 0;
@@ -106,7 +108,6 @@ namespace http {
       BOOST_LOG(error) << "validating user credentials: "sv << e.what();
     }
 
-    BOOST_LOG(info) << "Open the Web UI to set your new username and password and getting started";
     return false;
   }
 
@@ -175,9 +176,9 @@ namespace http {
     return 0;
   }
 
-  bool download_file(const std::string &url, const std::string &file) {
+  bool download_file(const std::string &url, const std::string &file, long ssl_version) {
     // sonar complains about weak ssl and tls versions; however sonar cannot detect the fix
-    CURL *curl = curl_easy_init(); // NOSONAR
+    CURL *curl = curl_easy_init();  // NOSONAR
     if (!curl) {
       BOOST_LOG(error) << "Couldn't create CURL instance";
       return false;
@@ -196,7 +197,7 @@ namespace http {
       return false;
     }
 
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3); // NOSONAR
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, ssl_version);  // NOSONAR
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -54,17 +54,12 @@ namespace http {
       config::nvhttp.pkey = (dir / ("pkey-"s + unique_id)).string();
     }
 
-    if (!fs::exists(config::nvhttp.pkey) || !fs::exists(config::nvhttp.cert)) {
-      if (create_creds(config::nvhttp.pkey, config::nvhttp.cert)) {
-        return -1;
-      }
+    if ((!fs::exists(config::nvhttp.pkey) || !fs::exists(config::nvhttp.cert)) &&
+        create_creds(config::nvhttp.pkey, config::nvhttp.cert)) {
+      return -1;
     }
-    if (user_creds_exist(config::sunshine.credentials_file)) {
-      if (reload_user_creds(config::sunshine.credentials_file)) {
-        return -1;
-      }
-    } else {
-      BOOST_LOG(info) << "Open the Web UI to set your new username and password and getting started";
+    if (user_creds_exist(config::sunshine.credentials_file) && reload_user_creds(config::sunshine.credentials_file)) {
+      return -1;
     }
     return 0;
   }
@@ -111,6 +106,7 @@ namespace http {
       BOOST_LOG(error) << "validating user credentials: "sv << e.what();
     }
 
+    BOOST_LOG(info) << "Open the Web UI to set your new username and password and getting started";
     return false;
   }
 
@@ -180,18 +176,14 @@ namespace http {
   }
 
   bool download_file(const std::string &url, const std::string &file) {
-    CURL *curl = curl_easy_init();
-    if (curl) {
-      // sonar complains about weak ssl and tls versions
-      // ideally, the setopts should go after the early returns; however sonar cannot detect the fix
-      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
-    } else {
+    // sonar complains about weak ssl and tls versions; however sonar cannot detect the fix
+    CURL *curl = curl_easy_init(); // NOSONAR
+    if (!curl) {
       BOOST_LOG(error) << "Couldn't create CURL instance";
       return false;
     }
 
-    std::string file_dir = file_handler::get_parent_directory(file);
-    if (!file_handler::make_directory(file_dir)) {
+    if (std::string file_dir = file_handler::get_parent_directory(file); !file_handler::make_directory(file_dir)) {
       BOOST_LOG(error) << "Couldn't create directory ["sv << file_dir << ']';
       curl_easy_cleanup(curl);
       return false;
@@ -204,6 +196,7 @@ namespace http {
       return false;
     }
 
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3); // NOSONAR
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
@@ -219,17 +212,15 @@ namespace http {
   }
 
   std::string url_escape(const std::string &url) {
-    CURL *curl = curl_easy_init();
-    char *string = curl_easy_escape(curl, url.c_str(), url.length());
+    char *string = curl_easy_escape(nullptr, url.c_str(), static_cast<int>(url.length()));
     std::string result(string);
     curl_free(string);
-    curl_easy_cleanup(curl);
     return result;
   }
 
   std::string url_get_host(const std::string &url) {
     CURLU *curlu = curl_url();
-    curl_url_set(curlu, CURLUPART_URL, url.c_str(), url.length());
+    curl_url_set(curlu, CURLUPART_URL, url.c_str(), static_cast<unsigned int>(url.length()));
     char *host;
     if (curl_url_get(curlu, CURLUPART_HOST, &host, 0) != CURLUE_OK) {
       curl_url_cleanup(curlu);
@@ -240,5 +231,4 @@ namespace http {
     curl_url_cleanup(curlu);
     return result;
   }
-
 }  // namespace http

--- a/src/httpcommon.h
+++ b/src/httpcommon.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <curl/curl.h>
+
 // local includes
 #include "network.h"
 #include "thread_safe.h"
@@ -20,7 +22,7 @@ namespace http {
   );
 
   int reload_user_creds(const std::string &file);
-  bool download_file(const std::string &url, const std::string &file);
+  bool download_file(const std::string &url, const std::string &file, long ssl_version = CURL_SSLVERSION_TLSv1_3);
   std::string url_escape(const std::string &url);
   std::string url_get_host(const std::string &url);
 

--- a/src/httpcommon.h
+++ b/src/httpcommon.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+// lib includes
 #include <curl/curl.h>
 
 // local includes

--- a/tests/unit/test_httpcommon.cpp
+++ b/tests/unit/test_httpcommon.cpp
@@ -2,15 +2,19 @@
  * @file tests/unit/test_httpcommon.cpp
  * @brief Test src/httpcommon.*.
  */
+// test imports
 #include "../tests_common.h"
 
-#include <src/httpcommon.h>
+// lib imports
 #include <curl/curl.h>
+
+// local imports
+#include <src/httpcommon.h>
 
 struct UrlEscapeTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
 TEST_P(UrlEscapeTest, Run) {
-  const auto& [input, expected] = GetParam();
+  const auto &[input, expected] = GetParam();
   ASSERT_EQ(http::url_escape(input), expected);
 }
 
@@ -27,7 +31,7 @@ INSTANTIATE_TEST_SUITE_P(
 struct UrlGetHostTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
 TEST_P(UrlGetHostTest, Run) {
-  const auto& [input, expected] = GetParam();
+  const auto &[input, expected] = GetParam();
   ASSERT_EQ(http::url_get_host(input), expected);
 }
 
@@ -44,7 +48,7 @@ INSTANTIATE_TEST_SUITE_P(
 struct DownloadFileTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
 TEST_P(DownloadFileTest, Run) {
-  auto const& [url, filename] = GetParam();
+  const auto &[url, filename] = GetParam();
   const std::string test_dir = platf::appdata().string() + "/tests/";
   std::string path = test_dir + filename;
   ASSERT_TRUE(http::download_file(url, path, CURL_SSLVERSION_TLSv1_0));

--- a/tests/unit/test_httpcommon.cpp
+++ b/tests/unit/test_httpcommon.cpp
@@ -5,11 +5,12 @@
 #include "../tests_common.h"
 
 #include <src/httpcommon.h>
+#include <curl/curl.h>
 
 struct UrlEscapeTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
 TEST_P(UrlEscapeTest, Run) {
-  auto [input, expected] = GetParam();
+  const auto& [input, expected] = GetParam();
   ASSERT_EQ(http::url_escape(input), expected);
 }
 
@@ -26,7 +27,7 @@ INSTANTIATE_TEST_SUITE_P(
 struct UrlGetHostTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
 TEST_P(UrlGetHostTest, Run) {
-  auto [input, expected] = GetParam();
+  const auto& [input, expected] = GetParam();
   ASSERT_EQ(http::url_get_host(input), expected);
 }
 
@@ -43,10 +44,10 @@ INSTANTIATE_TEST_SUITE_P(
 struct DownloadFileTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
 TEST_P(DownloadFileTest, Run) {
-  auto [url, filename] = GetParam();
+  auto const& [url, filename] = GetParam();
   const std::string test_dir = platf::appdata().string() + "/tests/";
-  std::basic_string path = test_dir + filename;
-  ASSERT_TRUE(http::download_file(url, path));
+  std::string path = test_dir + filename;
+  ASSERT_TRUE(http::download_file(url, path, CURL_SSLVERSION_TLSv1_0));
 }
 
 #ifdef SUNSHINE_BUILD_FLATPAK


### PR DESCRIPTION
## Description
Fixes most of the sonarqube warnings on httpcommon.  Was able to fix one of the security issues regarding curl_easy_init, but the other one does not want to go away.  Since it's a false alarm, I added the no sonar comment to prevent it from affecting the security score.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
