### PR TITLE
feat(display): Add revert display config on disconnect option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1203,6 +1203,31 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+
+### dd_config_revert_on_disconnect
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            When enabled, display configuration is reverted upon disconnect of all clients instead of app close or last session termination.
+            This can be useful for returning to physical usage of the host machine without closing the active app.
+            @warning{Some applications may not function properly when display configuration is changed while active.}
+            @note{Applies to Windows only.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}enabled@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            dd_config_revert_on_disconnect = enabled
+            @endcode</td>
+    </tr>
+</table>
+
 ### dd_mode_remapping
 
 <table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1218,7 +1218,7 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
     <tr>
         <td>Default</td>
-        <td colspan="2">@code{}enabled@endcode</td>
+        <td colspan="2">@code{}disabled@endcode</td>
     </tr>
     <tr>
         <td>Example</td>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -504,6 +504,7 @@ namespace config {
       {},  // manual_refresh_rate
       video_t::dd_t::hdr_option_e::automatic,  // hdr_option
       3s,  // config_revert_delay
+      {},  // config_revert_on_disconnect
       {},  // mode_remapping
       {}  // wa
     },  // display_device
@@ -1132,6 +1133,7 @@ namespace config {
         video.dd.config_revert_delay = std::chrono::milliseconds {value};
       }
     }
+    bool_f(vars, "dd_config_revert_on_disconnect", video.dd.config_revert_on_disconnect);
     generic_f(vars, "dd_mode_remapping", video.dd.mode_remapping, dd::mode_remapping_from_view);
     bool_f(vars, "dd_wa_hdr_toggle", video.dd.wa.hdr_toggle);
 

--- a/src/config.h
+++ b/src/config.h
@@ -132,6 +132,7 @@ namespace config {
       std::string manual_refresh_rate;  ///< Manual refresh rate in case `refresh_rate_option == refresh_rate_option_e::manual`.
       hdr_option_e hdr_option;
       std::chrono::milliseconds config_revert_delay;  ///< Time to wait until settings are reverted (after stream ends/app exists).
+      bool config_revert_on_disconnect;  ///< Specify whether to revert display configuration on client disconnect.
       mode_remapping_t mode_remapping;
       workarounds_t wa;
     } dd;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1882,15 +1882,18 @@ namespace stream {
 
       // If this is the last session, invoke the platform callbacks
       if (--running_sessions == 0) {
+        bool revert_display_config{config::video.dd.config_revert_on_disconnect};
         if (proc::proc.running()) {
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
           system_tray::update_tray_pausing(proc::proc.get_last_run_app_name());
 #endif
-          if(config::video.dd.config_revert_on_disconnect)
-          {
-            display_device::revert_configuration();
-          }
         } else {
+          // We have no app running and also no clients anymore.
+          revert_display_config = true;
+        }
+
+        if(revert_display_config)
+        {
           display_device::revert_configuration();
         }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1882,7 +1882,7 @@ namespace stream {
 
       // If this is the last session, invoke the platform callbacks
       if (--running_sessions == 0) {
-        bool revert_display_config{config::video.dd.config_revert_on_disconnect};
+        bool revert_display_config {config::video.dd.config_revert_on_disconnect};
         if (proc::proc.running()) {
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
           system_tray::update_tray_pausing(proc::proc.get_last_run_app_name());
@@ -1892,8 +1892,7 @@ namespace stream {
           revert_display_config = true;
         }
 
-        if(revert_display_config)
-        {
+        if (revert_display_config) {
           display_device::revert_configuration();
         }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1886,6 +1886,10 @@ namespace stream {
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
           system_tray::update_tray_pausing(proc::proc.get_last_run_app_name());
 #endif
+          if(config::video.dd.config_revert_on_disconnect)
+          {
+            display_device::revert_configuration();
+          }
         } else {
           display_device::revert_configuration();
         }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -175,6 +175,7 @@
               "dd_manual_refresh_rate": "",
               "dd_hdr_option": "auto",
               "dd_config_revert_delay": 3000,
+              "dd_config_revert_on_disconnect": "disabled",
               "dd_mode_remapping": {"mixed": [], "resolution_only": [], "refresh_rate_only": []},
               "dd_wa_hdr_toggle": "disabled",
               "min_fps_factor": 1,

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
@@ -151,6 +151,15 @@ function addRemappingEntry() {
                 </div>
               </div>
 
+              <!-- Config revert on disconnect -->
+              <div class="mb-3" v-if="config.dd_configuration_option !== 'disabled'">
+                <Checkbox id="dd_config_revert_on_disconnect"
+                  locale-prefix="config"
+                  v-model="config.dd_config_revert_on_disconnect"
+                  default="false"
+                ></Checkbox>
+              </div>
+
               <!-- Display mode remapping -->
               <div class="mb-3" v-if="canBeRemapped()">
                 <label for="dd_mode_remapping" class="form-label">

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -159,7 +159,7 @@
     "dd_config_revert_delay": "Config revert delay",
     "dd_config_revert_delay_desc": "Additional delay in milliseconds to wait before reverting configuration when the app has been closed or the last session terminated. Main purpose is to provide a smoother transition when quickly switching between apps.",
     "dd_config_revert_on_disconnect": "Config revert on disconnect",
-    "dd_config_revert_on_disconnect_desc": "Revert configuration upon disconnect of client instead of session termination.",
+    "dd_config_revert_on_disconnect_desc": "Revert configuration upon disconnect of all clients instead of session termination.",
     "dd_config_verify_only": "Verify that the display is enabled (default)",
     "dd_hdr_option": "HDR",
     "dd_hdr_option_auto": "Switch on/off the HDR mode as requested by the client (default)",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -158,6 +158,8 @@
     "dd_config_label": "Device configuration",
     "dd_config_revert_delay": "Config revert delay",
     "dd_config_revert_delay_desc": "Additional delay in milliseconds to wait before reverting configuration when the app has been closed or the last session terminated. Main purpose is to provide a smoother transition when quickly switching between apps.",
+    "dd_config_revert_on_disconnect": "Config revert on disconnect",
+    "dd_config_revert_on_disconnect_desc": "Revert configuration upon disconnect of client instead of session termination.",
     "dd_config_verify_only": "Verify that the display is enabled (default)",
     "dd_hdr_option": "HDR",
     "dd_hdr_option_auto": "Switch on/off the HDR mode as requested by the client (default)",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -159,7 +159,7 @@
     "dd_config_revert_delay": "Config revert delay",
     "dd_config_revert_delay_desc": "Additional delay in milliseconds to wait before reverting configuration when the app has been closed or the last session terminated. Main purpose is to provide a smoother transition when quickly switching between apps.",
     "dd_config_revert_on_disconnect": "Config revert on disconnect",
-    "dd_config_revert_on_disconnect_desc": "Revert configuration upon disconnect of all clients instead of session termination.",
+    "dd_config_revert_on_disconnect_desc": "Revert configuration upon disconnect of all clients instead of app close or last session termination.",
     "dd_config_verify_only": "Verify that the display is enabled (default)",
     "dd_hdr_option": "HDR",
     "dd_hdr_option_auto": "Switch on/off the HDR mode as requested by the client (default)",


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This adds the option to revert the display configuration changes on disconnect of the client instead of waiting for the termination of the session or app. It's set off by default as I expect some applications don't always play well with a resolution change while active and many users may just not want this behavior by default.

This was a feature I found a use for and figured some others may as well. Happy to make any changes as desired!

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
![Screenshot_20250130_130859](https://github.com/user-attachments/assets/d7ed47cd-650f-43f7-8ad4-37bd475ba100)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
None

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
