### PR TITLE
ci(docker): fix debian arm builds

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -123,7 +123,7 @@ jobs:
   docker:
     needs: [check_dockerfiles, setup_release]
     if: ${{ needs.check_dockerfiles.outputs.dockerfiles }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
       contents: write

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -3,6 +3,7 @@ set -e
 
 # Default value for arguments
 appimage_build=0
+num_processors=$(nproc)
 publisher_name="Third Party Publisher"
 publisher_website=""
 publisher_issue_url="https://app.lizardbyte.dev/support"
@@ -27,6 +28,7 @@ Options:
   -h, --help               Display this help message.
   -s, --sudo-off           Disable sudo command.
   --appimage-build         Compile for AppImage, this will not create the AppImage, just the executable.
+  --num-processors         The number of processors to use for compilation. Default is the value of 'nproc'.
   --publisher-name         The name of the publisher (not developer) of the application.
   --publisher-website      The URL of the publisher's website.
   --publisher-issue-url    The URL of the publisher's support site or issue tracker.
@@ -52,6 +54,9 @@ while getopts ":hs-:" opt; do
         appimage-build)
           appimage_build=1
           skip_libva=1
+          ;;
+        num-processors=*)
+          num_processors="${OPTARG#*=}"
           ;;
         publisher-name=*)
           publisher_name="${OPTARG#*=}"
@@ -367,7 +372,7 @@ function run_install() {
       tar -xzf "${build_dir}/doxygen.tar.gz"
       cd "doxygen-${doxygen_min}"
       cmake -DCMAKE_BUILD_TYPE=Release -G="Ninja" -B="build" -S="."
-      ninja -C "build"
+      ninja -C "build" -j"${num_processors}"
       ninja -C "build" install
     else
       echo "Doxygen version too low, skipping docs"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
ARM builds fail when using ubuntu-24.04 images, probably due to running out of space issues. It was discovered their was a segmentation fault occurring at random times. For now the runner is being rolled back to ubuntu-22.04.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
