### PR TITLE
fix(linux): make service start after desktop target

### DIFF
--- a/packaging/linux/sunshine.service.in
+++ b/packaging/linux/sunshine.service.in
@@ -2,10 +2,9 @@
 Description=@PROJECT_DESCRIPTION@
 StartLimitIntervalSec=500
 StartLimitBurst=5
+After=xdg-desktop-autostart.target
 
 [Service]
-# Avoid starting Sunshine before the desktop is fully initialized.
-ExecStartPre=/bin/sleep 5
 @SUNSHINE_SERVICE_START_COMMAND@
 @SUNSHINE_SERVICE_STOP_COMMAND@
 Restart=on-failure


### PR DESCRIPTION
## Description
Starting the Sunshine service at the same time as the desktop causes a race condition, this is currently solved with a delay.
My service file was missing the delay (#3653), but I wanted to find a solution without the delay.
I've added an After= dependency for the desktop, which should prevent the service from starting until the desktop has loaded. This avoids the need for the delay, so I've removed it.
This is working on my system (Fedora 41 with KDE), but I'm not sure whether other desktop environments need testing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
