### PR TITLE
fix(packaging/flatpak): move xvfb modules to LizardByte mirrors

### DIFF
--- a/packaging/linux/flatpak/modules/xvfb/xvfb.json
+++ b/packaging/linux/flatpak/modules/xvfb/xvfb.json
@@ -11,14 +11,15 @@
   ],
   "sources": [
     {
-      "type": "archive",
-      "url": "https://gitlab.freedesktop.org/xorg/xserver/-/archive/xorg-server-21.1.13/xserver-xorg-server-21.1.13.tar.bz2",
-      "sha256": "ee2bf6d65f4b111ce86ca817c3327dc1e70d9c958aa16876f2820caf7bf7cffa",
+      "type": "git",
+      "url": "https://github.com/LizardByte-infrastructure/xserver.git",
+      "tag": "xorg-server-21.1.13",
+      "commit": "be2767845d6ed3c6dbd25a151051294d0908a995",
       "x-checker-data": {
         "type": "anitya",
         "project-id": 5250,
         "stable-only": true,
-        "url-template": "https://gitlab.freedesktop.org/xorg/xserver/-/archive/xorg-server-$version/xserver-xorg-server-$version.tar.bz2"
+        "tag-template": "xorg-server-$version"
       }
     },
     {
@@ -32,14 +33,15 @@
       "buildsystem": "meson",
       "sources": [
         {
-          "type": "archive",
-          "url": "https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-0.1.2/libxcvt-libxcvt-0.1.2.tar.bz2",
-          "sha256": "590e5a6da87ace7aa7857026b207a2c4d378620035441e20ea97efedd15d6d4a",
+          "type": "git",
+          "url": "https://github.com/LizardByte-infrastructure/libxcvt.git",
+          "tag": "libxcvt-0.1.2",
+          "commit": "d9ca87eea9eecddaccc3a77227bcb3acf84e89df",
           "x-checker-data": {
             "type": "anitya",
             "project-id": 235147,
             "stable-only": true,
-            "url-template": "https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-$version/libxcvt-libxcvt-$version.tar.bz2"
+            "tag-template": "libxcvt-$version"
           }
         }
       ]
@@ -131,14 +133,15 @@
       "name": "xvfb-xauth",
       "sources": [
         {
-          "type": "archive",
-          "url": "https://gitlab.freedesktop.org/xorg/app/xauth/-/archive/xauth-1.1.1/xauth-xauth-1.1.3.tar.bz2",
-          "sha256": "3cee16ebe9de0e85c62513f6d6353710407c8ebb1f855b18d03807c27d38a215",
+          "type": "git",
+          "url": "https://github.com/LizardByte-infrastructure/xauth.git",
+          "tag": "xauth-1.1.3",
+          "commit": "c29eef23683f0e3575a3c60d9314de8156fbe2c2",
           "x-checker-data": {
             "type": "anitya",
             "project-id": 5253,
             "stable-only": true,
-            "url-template": "https://gitlab.freedesktop.org/xorg/app/xauth/-/archive/xauth-1.1.1/xauth-xauth-$version.tar.bz2"
+            "tag-template": "xauth-$version"
           }
         }
       ]


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This moves a few xvfb-run dependencies to LizardByte hosted mirrors.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
