### PR TITLE
fix(packaging/flatpak): move more xvfb modules to LizardByte mirrors

### DIFF
--- a/packaging/linux/flatpak/modules/xvfb/xvfb.json
+++ b/packaging/linux/flatpak/modules/xvfb/xvfb.json
@@ -50,14 +50,32 @@
       "name": "libXmu",
       "sources": [
         {
-          "type": "archive",
-          "url": "https://xorg.freedesktop.org/archive/individual/lib/libXmu-1.2.1.tar.gz",
-          "sha256": "bf0902583dd1123856c11e0a5085bd3c6e9886fbbd44954464975fd7d52eb599",
+          "type": "git",
+          "url": "https://github.com/LizardByte-infrastructure/libxmu.git",
+          "tag": "libXmu-1.2.1",
+          "commit": "792f80402ee06ce69bca3a8f2a84295999c3a170",
           "x-checker-data": {
             "type": "anitya",
             "project-id": 1785,
             "stable-only": true,
-            "url-template": "https://xorg.freedesktop.org/archive/individual/lib/libXmu-$version.tar.gz"
+            "tag-template": "libXmu-$version"
+          }
+        }
+      ]
+    },
+    {
+      "name": "font-util",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/LizardByte-infrastructure/font-util.git",
+          "tag": "font-util-1.4.1",
+          "commit": "b5ca142f81a6f14eddb23be050291d1c25514777",
+          "x-checker-data": {
+            "type": "anitya",
+            "project-id": 15055,
+            "stable-only": true,
+            "tag-template": "font-util-$version"
           }
         }
       ]
@@ -66,14 +84,15 @@
       "name": "libfontenc",
       "sources": [
         {
-          "type": "archive",
-          "url": "https://xorg.freedesktop.org/archive/individual/lib/libfontenc-1.1.8.tar.xz",
-          "sha256": "7b02c3d405236e0d86806b1de9d6868fe60c313628b38350b032914aa4fd14c6",
+          "type": "git",
+          "url": "https://github.com/LizardByte-infrastructure/libfontenc.git",
+          "tag": "libfontenc-1.1.8",
+          "commit": "92a85fda2acb4e14ec0b2f6d8fe3eaf2b687218c",
           "x-checker-data": {
             "type": "anitya",
             "project-id": 1613,
             "stable-only": true,
-            "url-template": "https://xorg.freedesktop.org/archive/individual/lib/libfontenc-$version.tar.xz"
+            "tag-template": "libfontenc-$version"
           }
         }
       ]
@@ -98,33 +117,18 @@
       ]
     },
     {
-      "name": "font-util",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://xorg.freedesktop.org/archive/individual/font/font-util-1.4.1.tar.gz",
-          "sha256": "f029ae80cdd75d89bee7f7af61c21e07982adfb9f72344a158b99f91f77ef5ed",
-          "x-checker-data": {
-            "type": "anitya",
-            "project-id": 15055,
-            "stable-only": true,
-            "url-template": "https://xorg.freedesktop.org/archive/individual/font/font-util-$version.tar.gz"
-          }
-        }
-      ]
-    },
-    {
       "name": "xvfb-libXfont2",
       "sources": [
         {
-          "type": "archive",
-          "url": "https://xorg.freedesktop.org/archive/individual/lib/libXfont2-2.0.6.tar.gz",
-          "sha256": "a944df7b6837c8fa2067f6a5fc25d89b0acc4011cd0bc085106a03557fb502fc",
+          "type": "git",
+          "url": "https://github.com/LizardByte-infrastructure/libxfont.git",
+          "tag": "libXfont2-2.0.6",
+          "commit": "d54aaf2483df6a1f98fadc09004157e657b7f73e",
           "x-checker-data": {
             "type": "anitya",
             "project-id": 17165,
             "stable-only": true,
-            "url-template": "https://xorg.freedesktop.org/archive/individual/lib/libXfont2-$version.tar.gz"
+            "tag-template": "libXfont2-$version"
           }
         }
       ]


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR moves more xvfb-run dependencies (on Flatpak) to git sources and mirrors on LizardByte-infrastructure org.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
