### PR TITLE
style(Web UI): Add 1rem margin between Save and Apply buttons for better UI/UX

### DIFF
--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -87,7 +87,7 @@
       <b>{{ $t('_common.success') }}</b> {{ $t('config.restart_note') }}
     </div>
     <div class="mb-3 buttons">
-      <button class="btn btn-primary" @click="save">{{ $t('_common.save') }}</button>
+      <button class="btn btn-primary mr-3" @click="save">{{ $t('_common.save') }}</button>
       <button class="btn btn-success" @click="apply" v-if="saved && !restarted">{{ $t('_common.apply') }}</button>
     </div>
   </div>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
I have added a 1rem margin between the Save and Apply buttons with Bootstrap's `mr-3` class.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
![image](https://github.com/user-attachments/assets/e70dcaed-8c32-479b-b8fe-f54a06946daf)



### Issues Fixed or Closed
No specific issue closed. I can make one if necessary for PR acceptance.
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
