### PR TITLE
fix(packaging/flatpak): reload udev rules during install

### DIFF
--- a/packaging/linux/flatpak/scripts/additional-install.sh
+++ b/packaging/linux/flatpak/scripts/additional-install.sh
@@ -2,12 +2,23 @@
 
 # User Service
 mkdir -p ~/.config/systemd/user
-cp /app/share/sunshine/systemd/user/sunshine.service $HOME/.config/systemd/user/sunshine.service
+cp /app/share/sunshine/systemd/user/sunshine.service "${HOME}/.config/systemd/user/sunshine.service"
 echo Sunshine User Service has been installed.
 echo Use [systemctl --user enable sunshine] once to autostart Sunshine on login.
 
 # Udev rule
 UDEV=$(cat /app/share/sunshine/udev/rules.d/60-sunshine.rules)
-echo Configuring mouse permission.
+echo Configuring input permissions.
 flatpak-spawn --host pkexec sh -c "echo '$UDEV' > /etc/udev/rules.d/60-sunshine.rules"
-echo Restart computer for mouse permission to take effect.
+
+# Reload udev rules
+path_to_udevadm=$(flatpak-spawn --host which udevadm)
+if [ -x "$path_to_udevadm" ] ; then
+  echo "Reloading udev rules."
+  flatpak-spawn --host "$path_to_udevadm" control --reload-rules
+  flatpak-spawn --host "$path_to_udevadm" trigger --property-match=DEVNAME=/dev/uinput
+  flatpak-spawn --host "$path_to_udevadm" trigger --property-match=DEVNAME=/dev/uhid
+  echo "Udev rules reloadeded successfully."
+else
+  echo "error: udevadm not found or not executable."
+fi

--- a/packaging/linux/flatpak/scripts/remove-additional-install.sh
+++ b/packaging/linux/flatpak/scripts/remove-additional-install.sh
@@ -2,10 +2,22 @@
 
 # User Service
 systemctl --user stop sunshine
-rm $HOME/.config/systemd/user/sunshine.service
+rm "${HOME}/.config/systemd/user/sunshine.service"
 systemctl --user daemon-reload
 echo Sunshine User Service has been removed.
 
 # Udev rule
+echo Removing input permissions.
 flatpak-spawn --host pkexec sh -c "rm /etc/udev/rules.d/60-sunshine.rules"
-echo Input rules removed. Restart computer to take effect.
+
+# Reload udev rules
+path_to_udevadm=$(flatpak-spawn --host which udevadm)
+if [ -x "$path_to_udevadm" ] ; then
+  echo "Reloading udev rules."
+  flatpak-spawn --host "$path_to_udevadm" control --reload-rules
+  flatpak-spawn --host "$path_to_udevadm" trigger --property-match=DEVNAME=/dev/uinput
+  flatpak-spawn --host "$path_to_udevadm" trigger --property-match=DEVNAME=/dev/uhid
+  echo "Udev rules reloadeded successfully."
+else
+  echo "error: udevadm not found or not executable."
+fi


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Auto reload udev rules when additional-install is run or removed on Flatpak version.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
