### PR TITLE
fix: handle wide-character output on Windows console to avoid truncation

### DIFF
--- a/tools/audio.cpp
+++ b/tools/audio.cpp
@@ -212,9 +212,9 @@ namespace audio {
     std::wcout
       << L"===== Device ====="sv << std::endl
       << L"Device ID          : "sv << wstring.get() << std::endl
-      << L"Device name        : "sv << no_null((LPWSTR) device_friendly_name.prop.pszVal) << std::endl
-      << L"Adapter name       : "sv << no_null((LPWSTR) adapter_friendly_name.prop.pszVal) << std::endl
-      << L"Device description : "sv << no_null((LPWSTR) device_desc.prop.pszVal) << std::endl
+      << L"Device name        : "sv << converter.to_bytes(no_null((LPWSTR) device_friendly_name.prop.pszVal)).c_str() << std::endl
+      << L"Adapter name       : "sv << converter.to_bytes(no_null((LPWSTR) adapter_friendly_name.prop.pszVal)).c_str() << std::endl
+      << L"Device description : "sv << converter.to_bytes(no_null((LPWSTR) device_desc.prop.pszVal)).c_str() << std::endl
       << L"Device state       : "sv << device_state_string << std::endl
       << L"Current format     : "sv << current_format << std::endl
       << std::endl;


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This change fixes a bug where the console would stop printing any subsequent output if it encountered Chinese characters. By converting the wide-string output to UTF-8 with `converter.to_bytes()`, the console now continues to properly display messages containing Chinese characters without interruption.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
<img width="865" alt="Snipaste_2025-03-27_23-16-13" src="https://github.com/user-attachments/assets/26f037da-b26d-42ee-89ba-08dfcab7dd81" />
<img width="865" alt="Snipaste_2025-03-27_23-16-44" src="https://github.com/user-attachments/assets/1ab03760-ceb3-483f-87ec-138b834decc5" />


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
No specific issue references.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
