### PR TITLE
fix(config): parse config after logging initialized

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1044,7 +1044,7 @@ namespace config {
     }
 
     for (auto &[name, val] : vars) {
-      std::cout << "["sv << name << "] -- ["sv << val << ']' << std::endl;
+      BOOST_LOG(info) << "config: '"sv << name << "' = "sv << val;
     }
 
     int_f(vars, "qp", video.qp);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -653,7 +653,7 @@ namespace config {
     if (*begin_val == '[') {
       endl = skip_list(begin_val + 1, end);
       if (endl == end) {
-        std::cout << "Warning: Config option ["sv << to_string(begin, end_name) << "] Missing ']'"sv;
+        BOOST_LOG(warning) << "config: Missing ']' in config option: " << to_string(begin, end_name);
 
         return std::make_pair(endl, std::nullopt);
       }
@@ -988,7 +988,7 @@ namespace config {
 
     // The list needs to be a multiple of 2
     if (list.size() % 2) {
-      std::cout << "Warning: expected "sv << name << " to have a multiple of two elements --> not "sv << list.size() << std::endl;
+      BOOST_LOG(warning) << "config: expected "sv << name << " to have a multiple of two elements --> not "sv << list.size();
       return;
     }
 
@@ -1018,7 +1018,7 @@ namespace config {
           config::sunshine.flags[config::flag::UPNP].flip();
           break;
         default:
-          std::cout << "Warning: Unrecognized flag: ["sv << *line << ']' << std::endl;
+          BOOST_LOG(warning) << "config: Unrecognized flag: ["sv << *line << ']' << std::endl;
           ret = -1;
       }
 
@@ -1425,7 +1425,7 @@ namespace config {
         shell_exec_info.nShow = SW_NORMAL;
         if (!ShellExecuteExW(&shell_exec_info)) {
           auto winerr = GetLastError();
-          std::cout << "Error: ShellExecuteEx() failed:"sv << winerr << std::endl;
+          BOOST_LOG(error) << "Failed executing shell command: " << winerr << std::endl;
           return 1;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,10 +106,6 @@ int main(int argc, char *argv[]) {
 
   mail::man = std::make_shared<safe::mail_raw_t>();
 
-  if (config::parse(argc, argv)) {
-    return 0;
-  }
-
   auto log_deinit_guard = logging::init(config::sunshine.min_log_level, config::sunshine.log_file);
   if (!log_deinit_guard) {
     BOOST_LOG(error) << "Logging failed to initialize"sv;
@@ -122,6 +118,11 @@ int main(int argc, char *argv[]) {
 
   // Log publisher metadata
   log_publisher_data();
+
+  // parse config file
+  if (config::parse(argc, argv)) {
+    return 0;
+  }
 
   if (!config::sunshine.cmd.name.empty()) {
     auto fn = cmd_to_func.find(config::sunshine.cmd.name);


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The config was parsed before logging was initialized. The ideal case is that it's parsed after logging is initialized so it can be included when users submit logs in bug reports or when asking for support.


TODO:

- [x] This works when running Sunshine from terminal, but not when running the service. When running the service the config flags do not appear in the browser/troubleshooting tab log viewer.
- [x] Sometimes the modified config flags print out of order. They should all be after publisher metadata, not in between.
  ```
  [2025-03-29 18:32:04.747]: Info: Sunshine version: 0.0.0.868eb8054cb658fd5412cc3a1d6d4be19d3c83cc
  [2025-03-29 18:32:04.748]: Info: Package Publisher: LizardByte
  [2025-03-29 18:32:04.748]: Info: Publisher Website: https://app.lizardbyte.dev
  [notify_pre_releases] -- [enabled]
  [min_fps_factor] -- [30]
  [2025-03-29 18:32:04.748]: Info: Get support: https://app.lizardbyte.dev/support
  ```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
