### PR TITLE
fix(config): fix parse error when list ends on last line of config file

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -652,9 +652,13 @@ namespace config {
     // Lists might contain newlines
     if (*begin_val == '[') {
       endl = skip_list(begin_val + 1, end);
-      if (endl == end) {
-        BOOST_LOG(warning) << "config: Missing ']' in config option: " << to_string(begin, end_name);
 
+      // Check if we reached the end of the file without finding a closing bracket
+      // We know we have a valid closing bracket if:
+      // 1. We didn't reach the end, or
+      // 2. We reached the end but the last character was the matching closing bracket
+      if (endl == end && end == begin_val + 1) {
+        BOOST_LOG(warning) << "config: Missing ']' in config option: " << to_string(begin, end_name);
         return std::make_pair(endl, std::nullopt);
       }
     }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #3285


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
