### PR TITLE
fix(packaging/Arch): use multiple threads for make

### DIFF
--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -86,7 +86,7 @@ build() {
         -D SUNSHINE_PUBLISHER_WEBSITE='https://app.lizardbyte.dev' \
         -D SUNSHINE_PUBLISHER_ISSUE_URL='https://app.lizardbyte.dev/support'
 
-    make -C build
+    make -C build -j$(nproc)
 }
 
 check() {


### PR DESCRIPTION
## Description
Adds -j$(nrpoc) to the make command in the pkgbuild to speed up compilation.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas - Not applicable
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components - not applicable
