### PR TITLE
fix(config): ensure logging config settings are properly loaded

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1049,6 +1049,7 @@ namespace config {
 
     for (auto &[name, val] : vars) {
       BOOST_LOG(info) << "config: '"sv << name << "' = "sv << val;
+      modified_config_settings[name] = val;
     }
 
     int_f(vars, "qp", video.qp);

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,9 @@
 #include "nvenc/nvenc_config.h"
 
 namespace config {
+  // track modified config options
+  inline std::unordered_map<std::string, std::string> modified_config_settings;
+
   struct video_t {
     // ffmpeg params
     int qp;  // higher == more compression and less quality

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,6 +106,11 @@ int main(int argc, char *argv[]) {
 
   mail::man = std::make_shared<safe::mail_raw_t>();
 
+  // parse config file
+  if (config::parse(argc, argv)) {
+    return 0;
+  }
+
   auto log_deinit_guard = logging::init(config::sunshine.min_log_level, config::sunshine.log_file);
   if (!log_deinit_guard) {
     BOOST_LOG(error) << "Logging failed to initialize"sv;
@@ -119,10 +124,11 @@ int main(int argc, char *argv[]) {
   // Log publisher metadata
   log_publisher_data();
 
-  // parse config file
-  if (config::parse(argc, argv)) {
-    return 0;
+  // Log modified_config_settings
+  for (auto &[name, val] : config::modified_config_settings) {
+    BOOST_LOG(info) << "config: '"sv << name << "' = "sv << val;
   }
+  config::modified_config_settings.clear();
 
   if (!config::sunshine.cmd.name.empty()) {
     auto fn = cmd_to_func.find(config::sunshine.cmd.name);


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
A bug was introduced by https://github.com/LizardByte/Sunshine/pull/3769 where the logging level would not be respected since it was parsed after logging was initialized. This PR changes the behavior to parse the config before logging is initialized (as it previously was); however the modified config values are stored in a global variable so they can be logged during startup.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
