### PR TITLE
build(windows): fix resource file name

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -38,7 +38,7 @@ if(NOT DEFINED SUNSHINE_ICON_PATH)
     set(SUNSHINE_ICON_PATH "${CMAKE_SOURCE_DIR}/sunshine.ico")
 endif()
 
-configure_file("${CMAKE_SOURCE_DIR}/src/platform/windows/windows.rs.in" windows.rc @ONLY)
+configure_file("${CMAKE_SOURCE_DIR}/src/platform/windows/windows.rc.in" windows.rc @ONLY)
 
 set(PLATFORM_TARGET_FILES
         "${CMAKE_CURRENT_BINARY_DIR}/windows.rc"

--- a/src/platform/windows/windows.rc.in
+++ b/src/platform/windows/windows.rc.in
@@ -1,7 +1,7 @@
 /**
- * @file src/platform/windows/windows.rs.in
+ * @file src/platform/windows/windows.rc.in
  * @brief Windows resource file template.
- * @note The final `windows.rs` is generated from this file during the CMake build.
+ * @note The final `windows.rc` is generated from this file during the CMake build.
  * @todo Use CMake definitions directly, instead of configuring this file.
  */
 #include "winver.h"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
I noticed this file was named incorrectly when looking at the languages api, and noticed there is rust detected as a language. I think it was because this file is named `.rs`.

https://api.github.com/repos/LizardByte/Sunshine/languages


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
