### PR TITLE
build(deps): pin boost to 1.87

### DIFF
--- a/.codeql-prebuild-cpp-Windows.sh
+++ b/.codeql-prebuild-cpp-Windows.sh
@@ -7,7 +7,6 @@ pacman --noconfirm -Syu
 # install dependencies
 dependencies=(
   "git"
-  "mingw-w64-ucrt-x86_64-boost"
   "mingw-w64-ucrt-x86_64-cmake"
   "mingw-w64-ucrt-x86_64-cppwinrt"
   "mingw-w64-ucrt-x86_64-curl-winssl"

--- a/.codeql-prebuild-cpp-macOS.sh
+++ b/.codeql-prebuild-cpp-macOS.sh
@@ -7,7 +7,6 @@ eval "$(/usr/local/bin/brew shellenv)"
 
 # install dependencies
 dependencies=(
-  "boost"
   "cmake"
   "miniupnpc"
   "ninja"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -833,7 +833,6 @@ jobs:
           update: true
           install: >-
             git
-            mingw-w64-ucrt-x86_64-boost
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-cppwinrt
             mingw-w64-ucrt-x86_64-curl-winssl

--- a/cmake/dependencies/Boost_Sunshine.cmake
+++ b/cmake/dependencies/Boost_Sunshine.cmake
@@ -3,13 +3,25 @@
 #
 include_guard(GLOBAL)
 
-set(BOOST_VERSION 1.86)
+set(BOOST_VERSION "1.87.0")
 set(BOOST_COMPONENTS
         filesystem
         locale
         log
         program_options
-        system)  # system is not used by Sunshine, but by Simple-Web-Server, added here for convenience
+        system
+)
+# system is not used by Sunshine, but by Simple-Web-Server, added here for convenience
+
+# algorithm, preprocessor, scope, and uuid are not used by Sunshine, but by libdisplaydevice, added here for convenience
+if(WIN32)
+    list(APPEND BOOST_COMPONENTS
+            algorithm
+            preprocessor
+            scope
+            uuid
+    )
+endif()
 
 if(BOOST_USE_STATIC)
     set(Boost_USE_STATIC_LIBS ON)  # cmake-lint: disable=C0103
@@ -18,9 +30,9 @@ endif()
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
     cmake_policy(SET CMP0167 NEW)  # Get BoostConfig.cmake from upstream
 endif()
-find_package(Boost CONFIG ${BOOST_VERSION} COMPONENTS ${BOOST_COMPONENTS})
+find_package(Boost CONFIG ${BOOST_VERSION} EXACT COMPONENTS ${BOOST_COMPONENTS})
 if(NOT Boost_FOUND)
-    message(STATUS "Boost v${BOOST_VERSION}.x package not found in the system. Falling back to FetchContent.")
+    message(STATUS "Boost v${BOOST_VERSION} package not found in the system. Falling back to FetchContent.")
     include(FetchContent)
 
     if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
@@ -41,12 +53,9 @@ if(NOT Boost_FOUND)
     set(BOOST_ENABLE_CMAKE ON)
 
     # Limit boost to the required libraries only
-    set(BOOST_INCLUDE_LIBRARIES
-            ${BOOST_COMPONENTS})
-    set(BOOST_URL
-            "https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.xz")
-    set(BOOST_HASH
-            "MD5=D02759931CEDC02ADED80402906C5EB6")
+    set(BOOST_INCLUDE_LIBRARIES ${BOOST_COMPONENTS})
+    set(BOOST_URL "https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.tar.xz")  # cmake-lint: disable=C0301
+    set(BOOST_HASH "SHA256=7da75f171837577a52bbf217e17f8ea576c7c246e4594d617bfde7fafd408be5")
 
     if(CMAKE_VERSION VERSION_LESS "3.24.0")
         FetchContent_Declare(
@@ -77,7 +86,7 @@ if(NOT Boost_FOUND)
 
     set(Boost_FOUND TRUE)  # cmake-lint: disable=C0103
     set(Boost_INCLUDE_DIRS  # cmake-lint: disable=C0103
-            "$<BUILD_INTERFACE:${Boost_SOURCE_DIR}/libs/headers/include>;$<INSTALL_INTERFACE:include/boost-1_85>")
+            "$<BUILD_INTERFACE:${Boost_SOURCE_DIR}/libs/headers/include>")
 
     if(WIN32)
         # Windows build is failing to create .h file in this directory

--- a/packaging/linux/flatpak/modules/boost.json
+++ b/packaging/linux/flatpak/modules/boost.json
@@ -9,8 +9,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.xz",
-      "sha256": "2c5ec5edcdff47ff55e27ed9560b0a0b94b07bd07ed9928b476150e16b0efc57"
+      "url": "https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.xz",
+      "sha256": "7da75f171837577a52bbf217e17f8ea576c7c246e4594d617bfde7fafd408be5"
     }
   ]
 }

--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -35,7 +35,6 @@ class @PROJECT_NAME@ < Formula
   depends_on "miniupnpc"
   depends_on "openssl"
   depends_on "opus"
-  depends_on "boost" => :recommended
   depends_on "icu4c" => :recommended
 
   on_linux do


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Boost 1.88 fails builds due to missing `boost::process::v1`. For now, pin to 1.87.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
