### PR TITLE
Reducing severity of missing ViGEmBus from fatal to warning

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -203,8 +203,8 @@ namespace platf {
       client_t client {vigem_alloc()};
       VIGEM_ERROR status = vigem_connect(client.get());
       if (!VIGEM_SUCCESS(status)) {
-        // Log a special fatal message for this case to show the error in the web UI
-        BOOST_LOG(fatal) << "ViGEmBus is not installed or running. You must install ViGEmBus for gamepad support!"sv;
+        // Log a special info message for this case to show the error in the web UI
+        BOOST_LOG(info) << "ViGEmBus is not installed or running. You must install ViGEmBus for gamepad support!"sv;
       } else {
         vigem_disconnect(client.get());
       }


### PR DESCRIPTION
ViGEmBus has reached end-of-life and is no longer receiving any patches. We shouldn't require the user to install a discontinued software. In fact, it isn't a fatal error.

## Description

Sunshine\src\platform\windows\input.cpp

Replacing the severity level of the log from fatal to warning regarding missing ViGEmBus installation, as this error isn't fatal, nor should we require installing discontinued software.

### Screenshot
![image](https://github.com/user-attachments/assets/962967e1-ccd7-4af6-946a-2ab3a4735ae8)

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
