### PR TITLE
Let users opt-out of auto-opening the browser

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -581,7 +581,8 @@ namespace config {
     "ipv4",  // Address family
     platf::appdata().string() + "/sunshine.log",  // log file
     false,  // notify_pre_releases
-    {},  // prep commands
+    {},     // prep commands
+    true,   // open_webui
   };
 
   bool endline(char ch) {
@@ -1227,6 +1228,7 @@ namespace config {
     bool_f(vars, "native_pen_touch", input.native_pen_touch);
 
     bool_f(vars, "notify_pre_releases", sunshine.notify_pre_releases);
+    bool_f(vars, "open_webui", sunshine.open_webui);
 
     int port = sunshine.port;
     int_between_f(vars, "port"s, port, {1024 + nvhttp::PORT_HTTPS, 65535 - rtsp_stream::RTSP_SETUP_PORT});
@@ -1442,8 +1444,10 @@ namespace config {
         service_ctrl::wait_for_ui_ready();
       }
 
-      // Launch the web UI
-      launch_ui();
+      if (config::sunshine.open_webui) {
+        // Launch the web UI
+        launch_ui();
+      }
 
       // Always return 1 to ensure Sunshine doesn't start normally
       return 1;

--- a/src/config.h
+++ b/src/config.h
@@ -255,6 +255,7 @@ namespace config {
     std::string log_file;
     bool notify_pre_releases;
     std::vector<prep_cmd_t> prep_cmds;
+    bool open_webui;
   };
 
   extern video_t video;

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -136,6 +136,7 @@
               "min_log_level": 2,
               "global_prep_cmd": [],
               "notify_pre_releases": "disabled",
+              "open_webui": "enabled",
             },
           },
           {

--- a/src_assets/common/assets/web/configs/tabs/General.vue
+++ b/src_assets/common/assets/web/configs/tabs/General.vue
@@ -129,6 +129,14 @@ function removeCmd(index) {
               v-model="config.notify_pre_releases"
               default="false"
     ></Checkbox>
+
+    <!-- open_webui -->
+    <Checkbox class="mb-3"
+              id="open_webui"
+              locale-prefix="config"
+              v-model="config.open_webui"
+              default="false"
+    ></Checkbox>
   </div>
 </template>
 

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -290,6 +290,8 @@
     "nvenc_twopass_quarter_res": "Quarter resolution (faster, default)",
     "nvenc_vbv_increase": "Single-frame VBV/HRD percentage increase",
     "nvenc_vbv_increase_desc": "By default sunshine uses single-frame VBV/HRD, which means any encoded video frame size is not expected to exceed requested bitrate divided by requested frame rate. Relaxing this restriction can be beneficial and act as low-latency variable bitrate, but may also lead to packet loss if the network doesn't have buffer headroom to handle bitrate spikes. Maximum accepted value is 400, which corresponds to 5x increased encoded video frame upper size limit.",
+    "open_webui": "Open web UI on launch",
+    "open_webui_desc": "Whether the web UI is automatically opened in your browser when Sunshine is started from the shortcut",
     "origin_web_ui_allowed": "Origin Web UI Allowed",
     "origin_web_ui_allowed_desc": "The origin of the remote endpoint address that is not denied access to Web UI",
     "origin_web_ui_allowed_lan": "Only those in LAN may access Web UI",


### PR DESCRIPTION
## Description

Let users opt-out of auto-opening the browser when Sunshine is started from a shortcut on windows.

### Screenshot

The commit should add a checkbox on the general page. This is untested.

### Issues Fixed or Closed

Fixes https://github.com/orgs/LizardByte/discussions/358


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
  - It looks fine, but I don't have a windows CPP build env handy to test.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
  - Doesn't seem relevant?
