### PR TITLE
fix(apps): exit steam big picture mode on session end

### DIFF
--- a/docs/app_examples.md
+++ b/docs/app_examples.md
@@ -31,12 +31,12 @@ process is killed.}
     \| Image                        \| @code{}steam.png@endcode                             \|
   }
   @tab{macOS | <!-- -->
-    \| Field                        \| Value                                                \|
-    \|------------------------------\|------------------------------------------------------\|
-    \| Application Name             \| @code{}Steam Big Picture@endcode                     \|
-    \| Command Preporations -> Undo \| @code{}open steam steam://close/bigpicture@endcode   \|
-    \| Detached Commands            \| @code{}open steam steam://open/bigpicture@endcode    \|
-    \| Image                        \| @code{}steam.png@endcode                             \|
+    \| Field                        \| Value                                          \|
+    \|------------------------------\|------------------------------------------------\|
+    \| Application Name             \| @code{}Steam Big Picture@endcode               \|
+    \| Command Preporations -> Undo \| @code{}open steam://close/bigpicture@endcode   \|
+    \| Detached Commands            \| @code{}open steam://open/bigpicture@endcode    \|
+    \| Image                        \| @code{}steam.png@endcode                       \|
   }
   @tab{Windows | <!-- -->
     \| Field                        \| Value                                     \|

--- a/docs/app_examples.md
+++ b/docs/app_examples.md
@@ -23,25 +23,28 @@ process is killed.}
 
 @tabs{
   @tab{Linux | <!-- -->
-    \| Field             \| Value                                               \|
-    \|-------------------\|-----------------------------------------------------\|
-    \| Application Name  \| @code{}Steam Big Picture@endcode                    \|
-    \| Detached Commands \| @code{}setsid steam steam://open/bigpicture@endcode \|
-    \| Image             \| @code{}steam.png@endcode                            \|
+    \| Field                        \| Value                                                \|
+    \|------------------------------\|------------------------------------------------------\|
+    \| Application Name             \| @code{}Steam Big Picture@endcode                     \|
+    \| Command Preporations -> Undo \| @code{}setsid steam steam://close/bigpicture@endcode \|
+    \| Detached Commands            \| @code{}setsid steam steam://open/bigpicture@endcode  \|
+    \| Image                        \| @code{}steam.png@endcode                             \|
   }
   @tab{macOS | <!-- -->
-    \| Field             \| Value                                             \|
-    \|-------------------\|---------------------------------------------------\|
-    \| Application Name  \| @code{}Steam Big Picture@endcode                  \|
-    \| Detached Commands \| @code{}open steam steam://open/bigpicture@endcode \|
-    \| Image             \| @code{}steam.png@endcode                          \|
+    \| Field                        \| Value                                                \|
+    \|------------------------------\|------------------------------------------------------\|
+    \| Application Name             \| @code{}Steam Big Picture@endcode                     \|
+    \| Command Preporations -> Undo \| @code{}open steam steam://close/bigpicture@endcode   \|
+    \| Detached Commands            \| @code{}open steam steam://open/bigpicture@endcode    \|
+    \| Image                        \| @code{}steam.png@endcode                             \|
   }
   @tab{Windows | <!-- -->
-    \| Field             \| Value                                  \|
-    \|-------------------\|----------------------------------------\|
-    \| Application Name  \| @code{}Steam Big Picture@endcode       \|
-    \| Detached Commands \| @code{}steam://open/bigpicture@endcode \|
-    \| Image             \| @code{}steam.png@endcode               \|
+    \| Field                        \| Value                                     \|
+    \|------------------------------\|-------------------------------------------\|
+    \| Application Name             \| @code{}Steam Big Picture@endcode          \|
+    \| Command Preporations -> Undo \| @code{}steam://close/bigpicture@endcode   \|
+    \| Detached Commands            \| @code{}steam://open/bigpicture@endcode    \|
+    \| Image                        \| @code{}steam.png@endcode                  \|
   }
 }
 

--- a/src_assets/linux/assets/apps.json
+++ b/src_assets/linux/assets/apps.json
@@ -22,6 +22,12 @@
       "detached": [
         "setsid steam steam://open/bigpicture"
       ],
+      "prep-cmd": [
+        {
+          "do": "",
+          "undo": "setsid steam steam://close/bigpicture"
+        }
+      ],
       "image-path": "steam.png"
     }
   ]

--- a/src_assets/macos/assets/apps.json
+++ b/src_assets/macos/assets/apps.json
@@ -12,6 +12,12 @@
       "detached": [
         "open steam://open/bigpicture"
       ],
+      "prep-cmd": [
+        {
+          "do": "",
+          "undo": "open steam://close/bigpicture"
+        }
+      ],
       "image-path": "steam.png"
     }
   ]

--- a/src_assets/windows/assets/apps.json
+++ b/src_assets/windows/assets/apps.json
@@ -8,6 +8,12 @@
     {
       "name": "Steam Big Picture",
       "cmd": "steam://open/bigpicture",
+      "prep-cmd": [
+        {
+          "do": "",
+          "undo": "steam://close/bigpicture"
+        }
+      ],
       "auto-detach": true,
       "wait-all": true,
       "image-path": "steam.png"


### PR DESCRIPTION
## Description
This will make example Steam Big Picture app automatically exit big picture mode on disconnect.

Note: only validated on Linux. Don't think that's really an issue, considering it's just a url change


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Adds command from ["Command to quit steam big picture"](https://github.com/orgs/LizardByte/discussions/206) discussion


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
