### PR TITLE
ci(flatpak): disable maximize build space for arm64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,6 +71,7 @@ jobs:
             runner: ubuntu-22.04-arm
     steps:
       - name: Maximize build space
+        if: matrix.arch == 'x86_64'
         uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 10240


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
arm64 builds for flatpak and constantly failing, likely due to the maximize build space action.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
