### PR TITLE
Add new form of preparation commands that runs before checking for displays

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -851,6 +851,17 @@ namespace nvhttp {
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     auto launch_session = make_launch_session(host_audio, args);
 
+    if (appid > 0) {
+      auto err = proc::proc.prepare(appid, launch_session);
+      if (err) {
+        tree.put("root.<xmlattr>.status_code", err);
+        tree.put("root.<xmlattr>.status_message", "Failed to prepare for the specified application");
+        tree.put("root.gamesession", 0);
+
+        return;
+      }
+    }
+
     if (rtsp_stream::session_count() == 0) {
       // The display should be restored in case something fails as there are no other sessions.
       revert_display_configuration = true;
@@ -885,7 +896,7 @@ namespace nvhttp {
     }
 
     if (appid > 0) {
-      auto err = proc::proc.execute(appid, launch_session);
+      auto err = proc::proc.execute();
       if (err) {
         tree.put("root.<xmlattr>.status_code", err);
         tree.put("root.<xmlattr>.status_message", "Failed to start the specified application");

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -130,21 +130,21 @@ namespace proc {
     return cmd_path.parent_path();
   }
 
-  int proc_t::execute(int app_id, std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
+  int proc_t::prepare(int app_id, std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
     // Ensure starting from a clean slate
     terminate();
 
-    auto iter = std::find_if(_apps.begin(), _apps.end(), [&app_id](const auto app) {
+    auto app_iter = std::find_if(_apps.begin(), _apps.end(), [&app_id](const auto app) {
       return app.id == std::to_string(app_id);
     });
 
-    if (iter == _apps.end()) {
+    if (app_iter == _apps.end()) {
       BOOST_LOG(error) << "Couldn't find app with ID ["sv << app_id << ']';
       return 404;
     }
 
     _app_id = app_id;
-    _app = *iter;
+    _app = *app_iter;
     _app_prep_begin = std::begin(_app.prep_cmds);
     _app_prep_it = _app_prep_begin;
 
@@ -187,6 +187,10 @@ namespace proc {
 #endif
     }
 
+    return 0;
+  }
+
+  int proc_t::execute() {
     std::error_code ec;
     // Executed when returning from function
     auto fg = util::fail_guard([&]() {

--- a/src/process.h
+++ b/src/process.h
@@ -67,6 +67,27 @@ namespace proc {
     std::chrono::seconds exit_timeout;
   };
 
+  /**
+   * @brief A list of preparation commands
+   */
+  class prep_cmds_t {
+  public:
+    prep_cmds_t(const std::vector<cmd_t> &cmds) :
+      _cmds(cmds),
+      _cmds_it(_cmds.begin()) {}
+    
+    prep_cmds_t() : prep_cmds_t(std::vector<cmd_t>{}) {}
+    
+    int run_do(const std::string &working_dir, const boost::process::v1::environment &env, FILE *output, unsigned int flags = 0);
+    int run_undo(const std::string &working_dir, const boost::process::v1::environment &env, FILE *output);
+
+    static const unsigned int FLAG_IGNORE_PERMISSION_DENIED = 1;
+
+  private:
+    std::vector<cmd_t> _cmds;
+    std::vector<cmd_t>::const_iterator _cmds_it;
+  };
+
   class proc_t {
   public:
     KITTY_DEFAULT_CONSTR_MOVE_THROW(proc_t)
@@ -118,8 +139,7 @@ namespace proc {
     boost::process::v1::group _process_group;
 
     file_t _pipe;
-    std::vector<cmd_t>::const_iterator _app_prep_it;
-    std::vector<cmd_t>::const_iterator _app_prep_begin;
+    prep_cmds_t _app_prep;
   };
 
   /**

--- a/src/process.h
+++ b/src/process.h
@@ -80,7 +80,15 @@ namespace proc {
         _apps(std::move(apps)) {
     }
 
-    int execute(int app_id, std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
+    /**
+     * @brief Check the app's existence and set up environment, but does not actually launch it
+     */
+    int prepare(int app_id, std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
+
+    /**
+     * @brief Launch the app after calling `prepare()`
+     */
+    int execute();
 
     /**
      * @return `_app_id` if a process is running, otherwise returns `0`


### PR DESCRIPTION
## Description
This PR attempts to a new form of preparation commands that runs before checking for displays, to solve feature request https://github.com/orgs/LizardByte/discussions/283 . This will include a minor refactor as suggested in [this comment](https://github.com/orgs/LizardByte/discussions/283#discussioncomment-6757616).

Hopefully this can open up doors for adding "on stream pause/resume" commands in the future.


### Issues Fixed or Closed
https://github.com/orgs/LizardByte/discussions/283


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
