### PR TITLE
feat(audio): add an option to disable sound streaming

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -770,25 +770,25 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
-### disable_audio
+### stream_audio
 
 <table>
     <tr>
         <td>Description</td>
         <td colspan="2">
-            This option allows to disable streaming audio completely, useful for streaming of headless displays as second monitors
+            Weather to Stream Audio or Not, Disabling this can be useful for streaming headless displays as second monitors.
         </td>
     </tr>
     <tr>
         <td>Default</td>
         <td colspan="2">@code{}
-            disabled
+            enabled
             @endcode</td>
     </tr>
     <tr>
         <td>Example</td>
         <td colspan="2">@code{}
-            disable_audio = enabled
+            stream_audio = disabled
             @endcode</td>
     </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -776,7 +776,7 @@ editing the `conf` file in a text editor. Use the examples as reference.
     <tr>
         <td>Description</td>
         <td colspan="2">
-            Weather to Stream Audio or Not, Disabling this can be useful for streaming headless displays as second monitors.
+            Whether to stream audio or not. Disabling this can be useful for streaming headless displays as second monitors.
         </td>
     </tr>
     <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -770,6 +770,29 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### disable_audio
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            This option allows to disable streaming audio completely, useful for streaming of headless displays as second monitors
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}
+            disabled
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            disable_audio = enabled
+            @endcode</td>
+    </tr>
+</table>
+
 ### install_steam_audio_drivers
 
 <table>

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -129,7 +129,7 @@ namespace audio {
 
   void capture(safe::mail_t mail, config_t config, void *channel_data) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
-    if (config::audio.disable){
+    if (!config::audio.stream){
       shutdown_event->view();
       return;
   }

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -129,10 +129,10 @@ namespace audio {
 
   void capture(safe::mail_t mail, config_t config, void *channel_data) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
-    if (!config::audio.stream){
+    if (!config::audio.stream) {
       shutdown_event->view();
       return;
-  }
+    }
     auto stream = stream_configs[map_stream(config.channels, config.flags[config_t::HIGH_QUALITY])];
     if (config.flags[config_t::CUSTOM_SURROUND_PARAMS]) {
       apply_surround_params(stream, config.customStreamParams);

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -129,6 +129,10 @@ namespace audio {
 
   void capture(safe::mail_t mail, config_t config, void *channel_data) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
+    if (config::audio.disable){
+      shutdown_event->view();
+      return;
+  }
     auto stream = stream_configs[map_stream(config.channels, config.flags[config_t::HIGH_QUALITY])];
     if (config.flags[config_t::CUSTOM_SURROUND_PARAMS]) {
       apply_surround_params(stream, config.customStreamParams);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -511,6 +511,7 @@ namespace config {
   audio_t audio {
     {},  // audio_sink
     {},  // virtual_sink
+    false,  // disable audio
     true,  // install_steam_drivers
   };
 
@@ -1160,6 +1161,7 @@ namespace config {
 
     string_f(vars, "audio_sink", audio.sink);
     string_f(vars, "virtual_sink", audio.virtual_sink);
+    bool_f(vars, "disable_audio", audio.disable);
     bool_f(vars, "install_steam_audio_drivers", audio.install_steam_drivers);
 
     string_restricted_f(vars, "origin_web_ui_allowed", nvhttp.origin_web_ui_allowed, {"pc"sv, "lan"sv, "wan"sv});

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -511,7 +511,7 @@ namespace config {
   audio_t audio {
     {},  // audio_sink
     {},  // virtual_sink
-    false,  // disable audio
+    true,  // stream audio
     true,  // install_steam_drivers
   };
 
@@ -1161,7 +1161,7 @@ namespace config {
 
     string_f(vars, "audio_sink", audio.sink);
     string_f(vars, "virtual_sink", audio.virtual_sink);
-    bool_f(vars, "disable_audio", audio.disable);
+    bool_f(vars, "stream_audio", audio.stream);
     bool_f(vars, "install_steam_audio_drivers", audio.install_steam_drivers);
 
     string_restricted_f(vars, "origin_web_ui_allowed", nvhttp.origin_web_ui_allowed, {"pc"sv, "lan"sv, "wan"sv});

--- a/src/config.h
+++ b/src/config.h
@@ -147,6 +147,7 @@ namespace config {
   struct audio_t {
     std::string sink;
     std::string virtual_sink;
+    bool disable;
     bool install_steam_drivers;
   };
 

--- a/src/config.h
+++ b/src/config.h
@@ -147,7 +147,7 @@ namespace config {
   struct audio_t {
     std::string sink;
     std::string virtual_sink;
-    bool disable;
+    bool stream;
     bool install_steam_drivers;
   };
 

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -65,10 +65,10 @@ const config = ref(props.config)
 
     <!-- Disable Audio -->
     <Checkbox class="mb-3"
-              id="disable_audio"
+              id="stream_audio"
               locale-prefix="config"
-              v-model="config.disable_audio"
-              default="false"
+              v-model="config.stream_audio"
+              default="true"
     ></Checkbox>
 
     <AdapterNameSelector

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -63,6 +63,14 @@ const config = ref(props.config)
       </template>
     </PlatformLayout>
 
+    <!-- Disable Audio -->
+    <Checkbox class="mb-3"
+              id="disable_audio"
+              locale-prefix="config"
+              v-model="config.disable_audio"
+              default="false"
+    ></Checkbox>
+
     <AdapterNameSelector
         :platform="platform"
         :config="config"

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -227,8 +227,6 @@
     "hevc_mode_desc": "Allows the client to request HEVC Main or HEVC Main10 video streams. HEVC is more CPU-intensive to encode, so enabling this may reduce performance when using software encoding.",
     "high_resolution_scrolling": "High Resolution Scrolling Support",
     "high_resolution_scrolling_desc": "When enabled, Sunshine will pass through high resolution scroll events from Moonlight clients. This can be useful to disable for older applications that scroll too fast with high resolution scroll events.",
-    "stream_audio" : "Stream Audio""
-    "stream_audio_desc" : "Weather to Stream Audio or Not, Disabling this can be useful for streaming headless displays as second monitors.",
     "install_steam_audio_drivers": "Install Steam Audio Drivers",
     "install_steam_audio_drivers_desc": "If Steam is installed, this will automatically install the Steam Streaming Speakers driver to support 5.1/7.1 surround sound and muting host audio.",
     "key_repeat_delay": "Key Repeat Delay",
@@ -331,6 +329,8 @@
     "qsv_slow_hevc": "Allow Slow HEVC Encoding",
     "qsv_slow_hevc_desc": "This can enable HEVC encoding on older Intel GPUs, at the cost of higher GPU usage and worse performance.",
     "restart_note": "Sunshine is restarting to apply changes.",
+    "stream_audio": "Stream Audio",
+    "stream_audio_desc": "Whether to stream audio or not. Disabling this can be useful for streaming headless displays as second monitors.",
     "sunshine_name": "Sunshine Name",
     "sunshine_name_desc": "The name displayed by Moonlight. If not specified, the PC's hostname is used",
     "sw_preset": "SW Presets",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -227,6 +227,8 @@
     "hevc_mode_desc": "Allows the client to request HEVC Main or HEVC Main10 video streams. HEVC is more CPU-intensive to encode, so enabling this may reduce performance when using software encoding.",
     "high_resolution_scrolling": "High Resolution Scrolling Support",
     "high_resolution_scrolling_desc": "When enabled, Sunshine will pass through high resolution scroll events from Moonlight clients. This can be useful to disable for older applications that scroll too fast with high resolution scroll events.",
+    "disable_audio" : "Disable Audio Streaming",
+    "disable_audio_desc" : "Disable Streaming Audio Completely, useful for streaming headless monitors",
     "install_steam_audio_drivers": "Install Steam Audio Drivers",
     "install_steam_audio_drivers_desc": "If Steam is installed, this will automatically install the Steam Streaming Speakers driver to support 5.1/7.1 surround sound and muting host audio.",
     "key_repeat_delay": "Key Repeat Delay",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -227,8 +227,8 @@
     "hevc_mode_desc": "Allows the client to request HEVC Main or HEVC Main10 video streams. HEVC is more CPU-intensive to encode, so enabling this may reduce performance when using software encoding.",
     "high_resolution_scrolling": "High Resolution Scrolling Support",
     "high_resolution_scrolling_desc": "When enabled, Sunshine will pass through high resolution scroll events from Moonlight clients. This can be useful to disable for older applications that scroll too fast with high resolution scroll events.",
-    "disable_audio" : "Disable Audio Streaming",
-    "disable_audio_desc" : "Disable Streaming Audio Completely, useful for streaming headless monitors",
+    "stream_audio" : "Stream Audio""
+    "stream_audio_desc" : "Weather to Stream Audio or Not, Disabling this can be useful for streaming headless displays as second monitors.",
     "install_steam_audio_drivers": "Install Steam Audio Drivers",
     "install_steam_audio_drivers_desc": "If Steam is installed, this will automatically install the Steam Streaming Speakers driver to support 5.1/7.1 surround sound and muting host audio.",
     "key_repeat_delay": "Key Repeat Delay",


### PR DESCRIPTION
## Description
So I use sunshine to stream my headless monitor to my laptop and use it as a second display, when doing so sunshine automatically changes the default audio sink to one created by sunshine, This is undesirable for my usecase, this pr adds an option disable_audio to the config which allows stopping streaming audio completely

### Issues Fixed or Closed
None

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
