### PR TITLE
fix(video): base min frame time strictly on client framerate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1363,35 +1363,6 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
-### min_fps_factor
-
-<table>
-    <tr>
-        <td>Description</td>
-        <td colspan="2">
-            Sunshine will use this factor to calculate the minimum time between frames. Increasing this value may help
-            when streaming mostly static content.
-            @warning{Higher values will consume more bandwidth.}
-        </td>
-    </tr>
-    <tr>
-        <td>Default</td>
-        <td colspan="2">@code{}
-            1
-            @endcode</td>
-    </tr>
-    <tr>
-        <td>Range</td>
-        <td colspan="2">1-3</td>
-    </tr>
-    <tr>
-        <td>Example</td>
-        <td colspan="2">@code{}
-            min_fps_factor = 1
-            @endcode</td>
-    </tr>
-</table>
-
 ## Network
 
 ### upnp

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -504,7 +504,6 @@ namespace config {
       {}  // wa
     },  // display_device
 
-    1,  // min_fps_factor
     0  // max_bitrate
   };
 
@@ -1143,7 +1142,6 @@ namespace config {
       video.dd.wa.hdr_toggle_delay = std::chrono::milliseconds {value};
     }
 
-    int_between_f(vars, "min_fps_factor", video.min_fps_factor, {1, 3});
     int_f(vars, "max_bitrate", video.max_bitrate);
 
     path_f(vars, "pkey", nvhttp.pkey);

--- a/src/config.h
+++ b/src/config.h
@@ -140,7 +140,6 @@ namespace config {
       workarounds_t wa;
     } dd;
 
-    int min_fps_factor;  // Minimum fps target, determines minimum frame time
     int max_bitrate;  // Maximum bitrate, sets ceiling in kbps for bitrate requested from client
   };
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1875,9 +1875,9 @@ namespace video {
       }
     });
 
-    // set minimum frame time, avoiding violation of client-requested target framerate
-    auto minimum_frame_time = std::chrono::milliseconds(1000 / std::min(config.framerate, (config::video.min_fps_factor * 10)));
-    BOOST_LOG(debug) << "Minimum frame time set to "sv << minimum_frame_time.count() << "ms, based on min fps factor of "sv << config::video.min_fps_factor << "."sv;
+    // set minimum frame time based on client-requested target framerate
+    std::chrono::duration<double, std::milli> minimum_frame_time {1000.0 / config.framerate};
+    BOOST_LOG(info) << "Minimum frame time set to "sv << minimum_frame_time.count() << "ms, based on client-requested target framerate "sv << config.framerate << "."sv;
 
     auto shutdown_event = mail->event<bool>(mail::shutdown);
     auto packets = mail::man->queue<packet_t>(mail::video_packets);

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -178,7 +178,6 @@
               "dd_config_revert_on_disconnect": "disabled",
               "dd_mode_remapping": {"mixed": [], "resolution_only": [], "refresh_rate_only": []},
               "dd_wa_hdr_toggle_delay": 0,
-              "min_fps_factor": 1,
               "max_bitrate": 0,
             },
           },

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayModesSettings.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayModesSettings.vue
@@ -11,13 +11,6 @@ const config = ref(props.config)
 </script>
 
 <template>
-  <!--min_fps_factor-->
-  <div class="mb-3">
-    <label for="qp" class="form-label">{{ $t('config.min_fps_factor') }}</label>
-    <input type="number" min="1" max="3" class="form-control" id="min_fps_factor" placeholder="1" v-model="config.min_fps_factor" />
-    <div class="form-text">{{ $t('config.min_fps_factor_desc') }}</div>
-  </div>
-
   <!--max_bitrate-->
   <div class="mb-3">
     <label for="max_bitrate" class="form-label">{{ $t("config.max_bitrate") }}</label>

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -256,8 +256,6 @@
     "log_path_desc": "The file where the current logs of Sunshine are stored.",
     "max_bitrate": "Maximum Bitrate",
     "max_bitrate_desc": "The maximum bitrate (in Kbps) that Sunshine will encode the stream at. If set to 0, it will always use the bitrate requested by Moonlight.",
-    "min_fps_factor": "Minimum FPS Factor",
-    "min_fps_factor_desc": "Sunshine will use this factor to calculate the minimum time between frames. Increasing this value slightly may help when streaming mostly static content. Higher values will consume more bandwidth.",
     "min_threads": "Minimum CPU Thread Count",
     "min_threads_desc": "Increasing the value slightly reduces encoding efficiency, but the tradeoff is usually worth it to gain the use of more CPU cores for encoding. The ideal value is the lowest value that can reliably encode at your desired streaming settings on your hardware.",
     "misc": "Miscellaneous options",


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR makes the minimum_frame_time calculation based strictly on the client requested framerate.

| Client Framerate | `minimum_frame_time` | static FPS |
| --- | --- | --- |
| 30 | 33ms | 23 |
| 60 | 16ms | 33 |
| 90 | 11ms | 55 |
| 120 | 8ms | 64 |

TODO:
- [x] remove/update `min_fps_factor` from UI and config

Optionally:
- [ ] allow multiplying the client requested framerate by up to 2


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Closes https://github.com/LizardByte/Sunshine/pull/3715
- Resolves https://github.com/LizardByte/Sunshine/issues/3419


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
