### PR TITLE
feat(docs): Suggest using displayconfig-mutter for Gnome Wayland resolution change

### DIFF
--- a/docs/app_examples.md
+++ b/docs/app_examples.md
@@ -229,8 +229,6 @@ xrandr --output ${display_output} --primary --mode ${mode_alias} --pos 0x0 --rot
 | Do        | @code{}sh -c "xrandr --output HDMI-1 --mode ${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT} --rate ${SUNSHINE_CLIENT_FPS}"@endcode |
 | Undo      | @code{}xrandr --output HDMI-1 --mode 3840x2160 --rate 120@endcode                                                                     |
 
-The commands above are valid for an X11 session but won't work for Wayland.
-
 ###### Gnome (Wayland)
 
 | Prep Step | Command                                                                                                                                                                                               |

--- a/docs/app_examples.md
+++ b/docs/app_examples.md
@@ -213,7 +213,7 @@ xrandr --output ${display_output} --primary --mode ${mode_alias} --pos 0x0 --rot
 ```
 }
 
-###### Wayland
+###### Wayland (wlroots, e.g. hyprland)
 
 | Prep Step | Command                                                                                                                                  |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -222,17 +222,32 @@ xrandr --output ${display_output} --primary --mode ${mode_alias} --pos 0x0 --rot
 
 @hint{`wlr-xrandr` only works with wlroots-based compositors.}
 
-###### Gnome (Wayland, X11)
+###### Gnome (X11)
 
 | Prep Step | Command                                                                                                                               |
 |-----------|---------------------------------------------------------------------------------------------------------------------------------------|
 | Do        | @code{}sh -c "xrandr --output HDMI-1 --mode ${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT} --rate ${SUNSHINE_CLIENT_FPS}"@endcode |
 | Undo      | @code{}xrandr --output HDMI-1 --mode 3840x2160 --rate 120@endcode                                                                     |
 
-The commands above are valid for an X11 session but won't work for
-Wayland. In that case `xrandr` must be replaced by [gnome-randr.py](https://gitlab.com/Oschowa/gnome-randr).
-This script is intended as a drop-in replacement with the same syntax. (It can be saved in
-`/usr/local/bin` and needs to be made executable.)
+The commands above are valid for an X11 session but won't work for Wayland.
+
+###### Gnome (Wayland)
+
+| Prep Step | Command                                                                                                                                                                                               |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Do        | @code{}sh -c "displayconfig-mutter set --connector HDMI-1 --resolution ${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT} --refresh-rate ${SUNSHINE_CLIENT_FPS} --hdr ${SUNSHINE_CLIENT_HDR}"@endcode |
+| Undo      | @code{}displayconfig-mutter set --connector HDMI-1 --resolution 3840x2160 --refresh-rate 120 --hdr false@endcode                                                                                      |
+
+Installation instructions for displayconfig-mutter can be [found here](https://github.com/eaglesemanation/displayconfig-mutter). Alternatives include
+[gnome-randr-rust](https://github.com/maxwellainatchi/gnome-randr-rust) and [gnome-randr.py](https://gitlab.com/Oschowa/gnome-randr), but both of those are
+unmaintained and do not support newer Mutter features such as HDR and VRR.
+
+@hint{HDR support has been added to Gnome 48, to check if your display supports it you can run this:
+```
+displayconfig-mutter list
+```
+If it doesn't, then remove ``--hdr`` flag from both ``Do`` and ``Undo`` steps.
+}
 
 ###### KDE Plasma (Wayland, X11)
 


### PR DESCRIPTION
## Description
Add usage example of `displayconfig-mutter` to Gnome section on resolution change


### Screenshot
N/A


### Issues Fixed or Closed
Don't think there is one


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
