### PR TITLE
build(linux): fix gcc version and disable docs for build on arch

### DIFF
--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -96,6 +96,8 @@ function add_arch_deps() {
     'base-devel'
     'cmake'
     'curl'
+    "gcc-${gcc_version}"
+    "gcc${gcc_version}-libs"
     'git'
     'libayatana-appindicator'
     'libcap'
@@ -358,6 +360,8 @@ function run_install() {
 
   if [ "$distro" == "arch" ]; then
     add_arch_deps
+    #docs currently broken for arch
+    cmake_args+=("-DBUILD_DOCS=OFF")
   elif [ "$distro" == "debian" ]; then
     add_debian_deps
   elif [ "$distro" == "ubuntu" ]; then
@@ -382,8 +386,11 @@ function run_install() {
     "gcc-ranlib"
   )
 
-  # update alternatives for gcc and g++ if a debian based distro
-  if [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
+  #set gcc version based on distros 
+  if [ "$distro" == "arch" ]; then
+    export CC=gcc-14
+    export CXX=g++-14
+  elif [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
     for file in "${gcc_alternative_files[@]}"; do
       file_path="/etc/alternatives/$file"
       if [ -e "$file_path" ]; then
@@ -498,6 +505,7 @@ if grep -q "Arch Linux" /etc/os-release; then
   package_update_command="${sudo_cmd} pacman -Syu --noconfirm"
   package_install_command="${sudo_cmd} pacman -Sy --needed"
   nvm_node=0
+  gcc_version="14"
 elif grep -q "Debian GNU/Linux 12 (bookworm)" /etc/os-release; then
   distro="debian"
   version="12"

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -295,6 +295,7 @@ function install_cuda() {
 function check_version() {
   local package_name=$1
   local min_version=$2
+  local max_version=$3
   local installed_version
 
   echo "Checking if $package_name is installed and at least version $min_version"
@@ -315,11 +316,12 @@ function check_version() {
     return 1
   fi
 
-  if [ "$(printf '%s\n' "$installed_version" "$min_version" | sort -V | head -n1)" = "$min_version" ]; then
-    echo "$package_name version $installed_version is at least $min_version"
+if [[ "$(printf '%s\n' "$installed_version" "$min_version" | sort -V | head -n1)" = "$min_version" ]] && \
+   [[ "$(printf '%s\n' "$installed_version" "$max_version" | sort -V | head -n1)" = "$installed_version" ]]; then
+    echo "Installed version is within range"
     return 0
   else
-    echo "$package_name version $installed_version is less than $min_version"
+    echo "$package_name version $installed_version is out of range"
     return 1
   fi
 }
@@ -360,8 +362,6 @@ function run_install() {
 
   if [ "$distro" == "arch" ]; then
     add_arch_deps
-    #docs currently broken for arch
-    cmake_args+=("-DBUILD_DOCS=OFF")
   elif [ "$distro" == "debian" ]; then
     add_debian_deps
   elif [ "$distro" == "ubuntu" ]; then
@@ -409,7 +409,7 @@ function run_install() {
   # compile cmake if the version is too low
   cmake_min="3.25.0"
   target_cmake_version="3.30.1"
-  if ! check_version "cmake" "$cmake_min"; then
+  if ! check_version "cmake" "$cmake_min" "inf"; then
     cmake_prefix="https://github.com/Kitware/CMake/releases/download/v"
     if [ "$architecture" == "x86_64" ]; then
       cmake_arch="x86_64"
@@ -427,7 +427,8 @@ function run_install() {
   # compile doxygen if version is too low
   doxygen_min="1.10.0"
   _doxygen_min="1_10_0"
-  if ! check_version "doxygen" "$doxygen_min"; then
+  doxygen_max="1.12.0"
+  if ! check_version "doxygen" "$doxygen_min" "$doxygen_max"; then
     if [ "${SUNSHINE_COMPILE_DOXYGEN}" == "true" ]; then
       echo "Compiling doxygen"
       doxygen_url="https://github.com/doxygen/doxygen/releases/download/Release_${_doxygen_min}/doxygen-${doxygen_min}.src.tar.gz"
@@ -439,7 +440,7 @@ function run_install() {
       ninja -C "build" -j"${num_processors}"
       ninja -C "build" install
     else
-      echo "Doxygen version too low, skipping docs"
+      echo "Doxygen version not in range, skipping docs"
       cmake_args+=("-DBUILD_DOCS=OFF")
     fi
   fi

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -96,7 +96,7 @@ function add_arch_deps() {
     'base-devel'
     'cmake'
     'curl'
-    "gcc-${gcc_version}"
+    "gcc${gcc_version}"
     "gcc${gcc_version}-libs"
     'git'
     'libayatana-appindicator'


### PR DESCRIPTION
## Description
This commit locks the gcc version to 14 instead of 15.x.x currently default on arch and also disables docs as they are currently broken on arch. This fixes arch builds

### Issues Fixed or Closed
- Fix bug #3840 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
