### PR TITLE
fix(linux/input): improve input rules

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -494,6 +494,7 @@ All shortcuts start with `Ctrl+Alt+Shift`, just like Moonlight.
   instead it simply starts a stream. If you removed it and would like to get it back, just add a new application with
   the name "Desktop" and "desktop.png" as the image path.
 * For the Linux flatpak you must prepend commands with `flatpak-spawn --host`.
+* If inputs (mouse, keyboard, gamepads...) aren't working after connecting, add the user running sunshine to the `input` group
 
 ### HDR Support
 Streaming HDR content is officially supported on Windows hosts and experimentally supported for Linux hosts.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -494,7 +494,7 @@ All shortcuts start with `Ctrl+Alt+Shift`, just like Moonlight.
   instead it simply starts a stream. If you removed it and would like to get it back, just add a new application with
   the name "Desktop" and "desktop.png" as the image path.
 * For the Linux flatpak you must prepend commands with `flatpak-spawn --host`.
-* If inputs (mouse, keyboard, gamepads...) aren't working after connecting, add the user running sunshine to the `input` group
+* If inputs (mouse, keyboard, gamepads...) aren't working after connecting, add the user running sunshine to the `input` group.
 
 ### HDR Support
 Streaming HDR content is officially supported on Windows hosts and experimentally supported for Linux hosts.

--- a/src_assets/linux/misc/60-sunshine.rules
+++ b/src_assets/linux/misc/60-sunshine.rules
@@ -1,11 +1,11 @@
 # Allows Sunshine to acces /dev/uinput
-KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess", MODE="0660", GROUP="input"
+KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", GROUP="input", MODE="0660", TAG+="uaccess"
 
 # Allows Sunshine to access /dev/uhid
-KERNEL=="uhid", TAG+="uaccess", MODE="0660", GROUP="input"
+KERNEL=="uhid", GROUP="input", MODE="0660", TAG+="uaccess"
 
 # Joypads
-KERNEL=="hidraw*" ATTRS{name}=="Sunshine PS5 (virtual) pad" MODE="0660", TAG+="uaccess", GROUP="input"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad", MODE="0660", TAG+="uaccess", GROUP="input"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors", MODE="0660", TAG+="uaccess", GROUP="input"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad", MODE="0660", TAG+="uaccess", GROUP="input"
+KERNEL=="hidraw*" ATTRS{name}=="Sunshine PS5 (virtual) pad" GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"

--- a/src_assets/linux/misc/60-sunshine.rules
+++ b/src_assets/linux/misc/60-sunshine.rules
@@ -1,8 +1,8 @@
 # Allows Sunshine to acces /dev/uinput
-KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess"
+KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess", MODE="0660", GROUP="input"
 
 # Allows Sunshine to access /dev/uhid
-KERNEL=="uhid", TAG+="uaccess"
+KERNEL=="uhid", TAG+="uaccess", MODE="0660", GROUP="input"
 
 # Joypads
 KERNEL=="hidraw*" ATTRS{name}=="Sunshine PS5 (virtual) pad" MODE="0660", TAG+="uaccess"

--- a/src_assets/linux/misc/60-sunshine.rules
+++ b/src_assets/linux/misc/60-sunshine.rules
@@ -5,7 +5,7 @@ KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uacces
 KERNEL=="uhid", TAG+="uaccess", MODE="0660", GROUP="input"
 
 # Joypads
-KERNEL=="hidraw*" ATTRS{name}=="Sunshine PS5 (virtual) pad" MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*" ATTRS{name}=="Sunshine PS5 (virtual) pad" MODE="0660", TAG+="uaccess", GROUP="input"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad", MODE="0660", TAG+="uaccess", GROUP="input"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors", MODE="0660", TAG+="uaccess", GROUP="input"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad", MODE="0660", TAG+="uaccess", GROUP="input"


### PR DESCRIPTION
## Description
Adds `MODE="0660", GROUP="input"` to udev rules to improve input reliability on linux


### Issues Fixed or Closed
- Closes https://github.com/LizardByte/roadmap/issues/12


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
