### PR TITLE
fix(installer): preserve start type during installs

### DIFF
--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -24,10 +24,6 @@ install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/path/"
         DESTINATION "scripts"
         COMPONENT assets)
 
-# Configurable options for the service
-install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/autostart/"
-        DESTINATION "scripts"
-        COMPONENT autostart)
 
 # scripts
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/firewall/"
@@ -72,7 +68,6 @@ SET(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\add-firewall-rule.bat\\\"'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\install-gamepad.bat\\\"'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\install-service.bat\\\"'
-        nsExec::ExecToLog '\\\"$INSTDIR\\\\scripts\\\\autostart-service.bat\\\"'
         NoController:
         ")
 

--- a/src_assets/windows/misc/autostart/autostart-service.bat
+++ b/src_assets/windows/misc/autostart/autostart-service.bat
@@ -1,4 +1,0 @@
-@echo off
-
-rem Set the service to auto-start
-sc config SunshineService start= auto

--- a/src_assets/windows/misc/service/uninstall-service.bat
+++ b/src_assets/windows/misc/service/uninstall-service.bat
@@ -1,9 +1,40 @@
 @echo off
+setlocal EnableDelayedExpansion
 
-rem Stop and delete the legacy SunshineSvc service
-net stop sunshinesvc
-sc delete sunshinesvc
+set "SERVICE_NAME=SunshineService"
+set "LEGACY_NAME=sunshinesvc"
+set "MARKER=%TEMP%\sunshine_start_mode.txt"
 
-rem Stop and delete the new SunshineService service
-net stop SunshineService
-sc delete SunshineService
+rem -----------------  default in case the query fails
+set "SERVICE_START_TYPE=auto"
+
+rem -----------------  grab existing start-type if the service is present
+sc qc "%SERVICE_NAME%" >nul 2>&1
+if %ERRORLEVEL%==0 (
+    for /f "tokens=3,*" %%S in ('sc qc "%SERVICE_NAME%" ^| find /i "START_TYPE"') do (
+        set "NUM=%%S"
+        set "EXTRA=%%T"
+    )
+    if "!NUM!"=="2" (
+        echo !EXTRA! | find /i "DELAYED" >nul && (
+            set "SERVICE_START_TYPE=delayed-auto"
+        ) || (
+            set "SERVICE_START_TYPE=auto"
+        )
+    ) else if "!NUM!"=="3" (
+        set "SERVICE_START_TYPE=demand"
+    ) else if "!NUM!"=="4" (
+        set "SERVICE_START_TYPE=disabled"
+    )
+)
+
+echo !SERVICE_START_TYPE! > "%MARKER%"
+
+rem -----------------  stop & delete both service names
+net stop "%LEGACY_NAME%"     >nul 2>&1
+sc  delete "%LEGACY_NAME%"   >nul 2>&1
+
+net stop "%SERVICE_NAME%"    >nul 2>&1
+sc  delete "%SERVICE_NAME%"  >nul 2>&1
+
+endlocal


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Preserve whatever **start-type** (auto, delayed-auto, demand, or disabled) the Windows
**SunshineService** already uses when the program is upgraded or re-installed.  
Previously every update reset the service to **Automatic**.

### Key Points
* **Vibe Coding** – Most of the code changes and this PR text were AI-generated and then peer-reviewed/tweaked by humans for accuracy and style.  
* **install-service.bat**
  * Reads a marker file written by the uninstaller and re-creates the service with that start-type; defaults to `auto` on fresh installs.
  * Starts the service only if the preserved mode isn’t **disabled**.
* **uninstall-service.bat**
  * Detects the current start-type (or the legacy `sunshinesvc`) and writes it to `%TEMP%\sunshine_start_mode.txt` before deletion.
* **windows.cmake**
  * Removes installation of the obsolete `autostart` folder and call to `autostart-service.bat`.
* **autostart-service.bat** – Deleted (logic folded into the installer scripts).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
_Not applicable – no UI changes._

### Issues Fixed or Closed
- Closes #3469 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Dependency update
- [ ] Documentation update
- [ ] Repository update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in-code documentation blocks for new or existing scripts
