### PR TITLE
pair from standard input working again

### DIFF
--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -184,7 +184,7 @@ namespace platf {
   }
 
   std::string from_sockaddr(const sockaddr *const ip_addr) {
-    char data[INET6_ADDRSTRLEN] = {};
+    char data[INET6_ADDRSTRLEN];
 
     auto family = ip_addr->sa_family;
     if (family == AF_INET6) {
@@ -197,7 +197,7 @@ namespace platf {
   }
 
   std::pair<std::uint16_t, std::string> from_sockaddr_ex(const sockaddr *const ip_addr) {
-    char data[INET6_ADDRSTRLEN] = {};
+    char data[INET6_ADDRSTRLEN];
 
     auto family = ip_addr->sa_family;
     std::uint16_t port = 0;
@@ -333,7 +333,7 @@ namespace platf {
   }
 
   struct sockaddr_in to_sockaddr(boost::asio::ip::address_v4 address, uint16_t port) {
-    struct sockaddr_in saddr_v4 = {};
+    struct sockaddr_in saddr_v4;
 
     saddr_v4.sin_family = AF_INET;
     saddr_v4.sin_port = htons(port);
@@ -345,7 +345,7 @@ namespace platf {
   }
 
   struct sockaddr_in6 to_sockaddr(boost::asio::ip::address_v6 address, uint16_t port) {
-    struct sockaddr_in6 saddr_v6 = {};
+    struct sockaddr_in6 saddr_v6;
 
     saddr_v6.sin6_family = AF_INET6;
     saddr_v6.sin6_port = htons(port);
@@ -359,11 +359,11 @@ namespace platf {
 
   bool send_batch(batched_send_info_t &send_info) {
     auto sockfd = (int) send_info.native_socket;
-    struct msghdr msg = {};
+    struct msghdr msg;
 
     // Convert the target address into a sockaddr
-    struct sockaddr_in taddr_v4 = {};
-    struct sockaddr_in6 taddr_v6 = {};
+    struct sockaddr_in taddr_v4;
+    struct sockaddr_in6 taddr_v6;
     if (send_info.target_address.is_v6()) {
       taddr_v6 = to_sockaddr(send_info.target_address.to_v6(), send_info.target_port);
 
@@ -379,7 +379,7 @@ namespace platf {
     union {
       char buf[CMSG_SPACE(sizeof(uint16_t)) + std::max(CMSG_SPACE(sizeof(struct in_pktinfo)), CMSG_SPACE(sizeof(struct in6_pktinfo)))];
       struct cmsghdr alignment;
-    } cmbuf = {};  // Must be zeroed for CMSG_NXTHDR()
+    } cmbuf;  // Must be zeroed for CMSG_NXTHDR()
 
     socklen_t cmbuflen = 0;
 
@@ -424,7 +424,7 @@ namespace platf {
       // UDP GSO on Linux currently only supports sending 64K or 64 segments at a time
       size_t seg_index = 0;
       const size_t seg_max = 65536 / 1500;
-      struct iovec iovs[(send_info.headers ? std::min(seg_max, send_info.block_count) : 1) * max_iovs_per_msg] = {};
+      struct iovec iovs[(send_info.headers ? std::min(seg_max, send_info.block_count) : 1) * max_iovs_per_msg];
       auto msg_size = send_info.header_size + send_info.payload_size;
       while (seg_index < send_info.block_count) {
         int iovlen = 0;
@@ -507,8 +507,8 @@ namespace platf {
 
     {
       // If GSO is not supported, use sendmmsg() instead.
-      struct mmsghdr msgs[send_info.block_count] = {};
-      struct iovec iovs[send_info.block_count * (send_info.headers ? 2 : 1)] = {};
+      struct mmsghdr msgs[send_info.block_count];
+      struct iovec iovs[send_info.block_count * (send_info.headers ? 2 : 1)];
       int iov_idx = 0;
       for (size_t i = 0; i < send_info.block_count; i++) {
         msgs[i].msg_hdr.msg_iov = &iovs[iov_idx];
@@ -564,11 +564,11 @@ namespace platf {
 
   bool send(send_info_t &send_info) {
     auto sockfd = (int) send_info.native_socket;
-    struct msghdr msg = {};
+    struct msghdr msg;
 
     // Convert the target address into a sockaddr
-    struct sockaddr_in taddr_v4 = {};
-    struct sockaddr_in6 taddr_v6 = {};
+    struct sockaddr_in taddr_v4;
+    struct sockaddr_in6 taddr_v6;
     if (send_info.target_address.is_v6()) {
       taddr_v6 = to_sockaddr(send_info.target_address.to_v6(), send_info.target_port);
 
@@ -620,7 +620,7 @@ namespace platf {
       memcpy(CMSG_DATA(pktinfo_cm), &pktInfo, sizeof(pktInfo));
     }
 
-    struct iovec iovs[2] = {};
+    struct iovec iovs[2];
     int iovlen = 0;
     if (send_info.header) {
       iovs[iovlen].iov_base = (void *) send_info.header;


### PR DESCRIPTION
the text interface is broken for two years and nobody notices what else is new?I guess nobody use this it was broken. for two years apparently   I use a remote server with no
physical access and no web interface only text interface . when I used it two years ago it worked no big deal maybe a test would help but now I
can easier fix it the next time it breaks I know essentially how it
works took two days to find this learn how this works so I could fix it

I have to include an unrelated clang commit because otherwise I could
not test the build

i use android client all difference makes a difference. 99,99 percent is
a local rig with physical tele type and gleaming Trinitron and the whole
nine yards. shiny oak desk perhaps tasteful. this was not mentioned anywhere the logcat tag for the
android client . understand able since it is probably tested from a desk
not on the go~

~~~
logcat -d|ack LimeLog
~~~

 # remove the web interface from the build BUILD_WEBUI=OFF

this is an example of market pressure going too far. I understand the
enormous demand for computer operator assistance. when asked in 47 if
anyone could learn to use a computing machine von Neumann answered
absolutely. turns out no they Can not. so there is an enormous industry
for hand holding

if I could
exclude the web interface from the cmake build script it's just slightly provocative to have computers 101 force enabled   I would be the happiest man in the world

 # technical details

I hardly even remember but I think this is what happened. the client
stored the server state but not the server! so the next attempt the
client could never connect because the server was different. solved by
saving state even on failed pairing. and one time an error code was
returned together with paired=1 adding to the confusion. and something
more that I don't remember ready to sleep after 48 hours insomnia  and
migraine

oh right now I remember the return statement was missing probably
something changed for asynchronous pairing and a return statement was
never added leading to a successful pair and immediately a invalid
request message. strange that no one complained for two years I guess
they show each other how to do it and the web interface is vastly  preferred for struggling computer operators .
lonely text operator here it's lonely at the top. guess I have to post
this in Linux master race or something or text terminal master race

the original impetus was the never ending input problem on remote server
I tried to ask about it and absolutely zero people exactly a remote
machine with no physical access