### PR TITLE
fix(amf): attempt to use level 5.1/5.2 for hevc

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -765,6 +765,18 @@ namespace video {
         {"usage"s, &config::video.amd.amd_usage_hevc},
         {"vbaq"s, &config::video.amd.amd_vbaq},
         {"enforce_hrd"s, &config::video.amd.amd_enforce_hrd},
+        {"level"s, [](const config_t &cfg) {
+           auto size = cfg.width * cfg.height;
+           // For 4K and below, try to use level 5.1 or 5.2 if possible
+           if (size <= 8912896) {
+             if (size * cfg.framerate <= 534773760) {
+               return "5.1"s;
+             } else if (size * cfg.framerate <= 1069547520) {
+               return "5.2"s;
+             }
+           }
+           return "auto"s;
+         }},
       },
       {},  // SDR-specific options
       {},  // HDR-specific options
@@ -1639,7 +1651,7 @@ namespace video {
       ctx->thread_count = ctx->slices;
 
       AVDictionary *options {nullptr};
-      auto handle_option = [&options](const encoder_t::option_t &option) {
+      auto handle_option = [&options, &config](const encoder_t::option_t &option) {
         std::visit(
           util::overloaded {
             [&](int v) {
@@ -1653,7 +1665,7 @@ namespace video {
                 av_dict_set_int(&options, option.name.c_str(), **v, 0);
               }
             },
-            [&](std::function<int()> v) {
+            [&](const std::function<int()>& v) {
               av_dict_set_int(&options, option.name.c_str(), v(), 0);
             },
             [&](const std::string &v) {
@@ -1663,6 +1675,9 @@ namespace video {
               if (!v->empty()) {
                 av_dict_set(&options, option.name.c_str(), v->c_str(), 0);
               }
+            },
+            [&](const std::function<const std::string(const config_t &cfg)>& v) {
+              av_dict_set(&options, option.name.c_str(), v(config).c_str(), 0);
             }
           },
           option.value

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1665,7 +1665,7 @@ namespace video {
                 av_dict_set_int(&options, option.name.c_str(), **v, 0);
               }
             },
-            [&](const std::function<int()>& v) {
+            [&](const std::function<int()> &v) {
               av_dict_set_int(&options, option.name.c_str(), v(), 0);
             },
             [&](const std::string &v) {
@@ -1676,7 +1676,7 @@ namespace video {
                 av_dict_set(&options, option.name.c_str(), v->c_str(), 0);
               }
             },
-            [&](const std::function<const std::string(const config_t &cfg)>& v) {
+            [&](const std::function<const std::string(const config_t &cfg)> &v) {
               av_dict_set(&options, option.name.c_str(), v(config).c_str(), 0);
             }
           },

--- a/src/video.h
+++ b/src/video.h
@@ -150,7 +150,7 @@ namespace video {
       option_t(const option_t &) = default;
 
       std::string name;
-      std::variant<int, int *, std::optional<int> *, std::function<int()>, std::string, std::string *> value;
+      std::variant<int, int *, std::optional<int> *, std::function<int()>, std::string, std::string *, std::function<const std::string(const config_t&)>> value;
 
       option_t(std::string &&name, decltype(value) &&value):
           name {std::move(name)},

--- a/src/video.h
+++ b/src/video.h
@@ -150,7 +150,7 @@ namespace video {
       option_t(const option_t &) = default;
 
       std::string name;
-      std::variant<int, int *, std::optional<int> *, std::function<int()>, std::string, std::string *, std::function<const std::string(const config_t&)>> value;
+      std::variant<int, int *, std::optional<int> *, std::function<int()>, std::string, std::string *, std::function<const std::string(const config_t &)>> value;
 
       option_t(std::string &&name, decltype(value) &&value):
           name {std::move(name)},


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
AMF Encodes HEVC in L6.2 by default. Some clients can't properly handle level higher than 5.2 (e.g. webOS: https://github.com/mariotaku/moonlight-tv/issues/355)

This PR tries to use a lower level when possible, determined by resolution/frame rate automatically according to [specs](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding_tiers_and_levels#Levels), which improves compatibility.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
Not applicable.


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Resolve https://github.com/mariotaku/moonlight-tv/issues/355

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
