### PR TITLE
fix(linux): steamdeck pointer orientation

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -561,6 +561,7 @@ namespace config {
     true,  // always send scancodes
     true,  // high resolution scrolling
     true,  // native pen/touch support
+    0,  // input rotation
   };
 
   sunshine_t sunshine {
@@ -1222,6 +1223,7 @@ namespace config {
 
     bool_f(vars, "high_resolution_scrolling", input.high_resolution_scrolling);
     bool_f(vars, "native_pen_touch", input.native_pen_touch);
+    int_f(vars, "output_rotation", input.output_rotation);
 
     bool_f(vars, "notify_pre_releases", sunshine.notify_pre_releases);
 

--- a/src/config.h
+++ b/src/config.h
@@ -202,6 +202,7 @@ namespace config {
 
     bool high_resolution_scrolling;
     bool native_pen_touch;
+    int output_rotation;
   };
 
   namespace flag {

--- a/src/platform/linux/input/inputtino.cpp
+++ b/src/platform/linux/input/inputtino.cpp
@@ -34,9 +34,26 @@ namespace platf {
     delete input;
   }
 
+  std::pair<int, int> rotate_delta(int delta_x, int delta_y, int rotation) {
+    switch (rotation) {
+      case 0:
+        return {delta_x, delta_y};
+      case 90:
+        return {delta_y, -delta_x};
+      case 180:
+        return {-delta_x, -delta_y};
+      case 270:
+        return {-delta_y, delta_x};
+      default:
+        return {delta_x, delta_y};
+    }
+  }
+
   void move_mouse(input_t &input, int deltaX, int deltaY) {
     auto raw = (input_raw_t *) input.get();
-    platf::mouse::move(raw, deltaX, deltaY);
+
+    auto rotated = rotate_delta(deltaX, deltaY, config::input.output_rotation);
+    platf::mouse::move(raw, rotated.first, rotated.second);
   }
 
   void abs_mouse(input_t &input, const touch_port_t &touch_port, float x, float y) {

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -695,13 +695,13 @@ namespace platf {
 
               switch (card.get_panel_orientation(plane->plane_id)) {
                 case DRM_MODE_ROTATE_270:
-                  BOOST_LOG(debug) << "Detected panel orientation at 90, swapping width and height.";
+                  BOOST_LOG(warning) << "Detected panel orientation at 90 (DRM_MODE_ROTATE_270), swapping width and height.";
                   width = viewport.height;
                   height = viewport.width;
                   break;
                 case DRM_MODE_ROTATE_90:
                 case DRM_MODE_ROTATE_180:
-                  BOOST_LOG(warning) << "Panel orientation is unsupported, screen capture may not work correctly.";
+                  BOOST_LOG(warning) << "Panel orientation is unsupported (DRM_MODE_ROTATE_{90|180}), screen capture may not work correctly.";
                   break;
               }
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -412,7 +412,9 @@ namespace platf {
         auto props = plane_props(plane_id);
         auto value = prop_value_by_name(props, "rotation"sv);
         if (value) {
-          return *value;
+          BOOST_LOG(info) << "Found panel orientation ["sv << *value << "]";
+          return DRM_MODE_ROTATE_0;
+          //return *value;
         }
 
         BOOST_LOG(error) << "Failed to determine panel orientation, defaulting to landscape.";


### PR DESCRIPTION
## Description
I am experiencing an issue when using Moonlight Android that also affects its fork Artemis: When serving Sunshine from a SteamDeck, the pointer orientation does not match the screen orientation. I mean, when moving the finger horizontally, the mouse pointer on the streamed screen moves vertically.

My current suspicion is that the rotation sourced from DRM_MODE_ROTATE_270 changes the _image_ orientation but does not change the _input_ orientation.

So, instead of advocating for applying the same solution to input handling in Sunshine, I am experimenting with removing the _image_ rotation on Sunshine and handling both the _image and input_ rotation on client side. 

That would be cleaner IMHO because Sunshine would be responsible to provide accurate image and input handling, and the decision on how to _present_ these would be kept in full on the client side. Would still be useful if Sunshine provides the rotation info it discovered, _as metadata_ to the client.

### Why a Draft PR?
This PR is opened as Draft because I could compile a working binary from current `master` Sunshine on Ubuntu 24.04 but I failed to make it build any package with `cpak`, and the bare binary does not run on Steamdeck because some library missing.

So I am pushing a barebones PR just to make CI build the needed packages on my behalf, instead of preparing Steamdeck to build the stuff directly.

### Issues Fixed or Closed
- Relates to #3203
- Relates to #2439 
- Practically reverts #711 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
