### PR TITLE
fix(installer/windows): remember service start type

### DIFF
--- a/src_assets/windows/misc/service/install-service.bat
+++ b/src_assets/windows/misc/service/install-service.bat
@@ -1,10 +1,13 @@
 @echo off
+setlocal enabledelayedexpansion
 
 rem Get sunshine root directory
 for %%I in ("%~dp0\..") do set "ROOT_DIR=%%~fI"
 
 set SERVICE_NAME=SunshineService
-set SERVICE_BIN="%ROOT_DIR%\tools\sunshinesvc.exe"
+set "SERVICE_BIN=%ROOT_DIR%\tools\sunshinesvc.exe"
+set "SERVICE_CONFIG_DIR=%LOCALAPPDATA%\LizardByte\Sunshine"
+set "SERVICE_CONFIG_FILE=%SERVICE_CONFIG_DIR%\service_start_type.txt"
 
 rem Set service to demand start. It will be changed to auto later if the user selected that option.
 set SERVICE_START_TYPE=demand
@@ -25,6 +28,34 @@ if %ERRORLEVEL%==0 (
     rem Create a new service
     set SC_CMD=create
 )
+
+rem Check if we have a saved start type from previous installation
+if exist "%SERVICE_CONFIG_FILE%" (
+    rem Debug output file content
+    type "%SERVICE_CONFIG_FILE%"
+
+    rem Read the saved start type
+    for /f "usebackq delims=" %%a in ("%SERVICE_CONFIG_FILE%") do (
+        set "SAVED_START_TYPE=%%a"
+    )
+
+    echo Raw saved start type: [!SAVED_START_TYPE!]
+
+    rem Check start type
+    if "!SAVED_START_TYPE!"=="2-delayed" (
+        set SERVICE_START_TYPE=delayed-auto
+    ) else if "!SAVED_START_TYPE!"=="2" (
+        set SERVICE_START_TYPE=auto
+    ) else if "!SAVED_START_TYPE!"=="3" (
+        set SERVICE_START_TYPE=demand
+    ) else if "!SAVED_START_TYPE!"=="4" (
+        set SERVICE_START_TYPE=disabled
+    )
+
+    del "%SERVICE_CONFIG_FILE%"
+)
+
+echo Setting service start type set to: [!SERVICE_START_TYPE!]
 
 rem Run the sc command to create/reconfigure the service
 sc %SC_CMD% %SERVICE_NAME% binPath= %SERVICE_BIN% start= %SERVICE_START_TYPE% DisplayName= "Sunshine Service"

--- a/src_assets/windows/misc/service/uninstall-service.bat
+++ b/src_assets/windows/misc/service/uninstall-service.bat
@@ -1,4 +1,36 @@
 @echo off
+setlocal enabledelayedexpansion
+
+set "SERVICE_CONFIG_DIR=%LOCALAPPDATA%\LizardByte\Sunshine"
+set "SERVICE_CONFIG_FILE=%SERVICE_CONFIG_DIR%\service_start_type.txt"
+
+rem Save the current service start type to a file if the service exists
+sc qc SunshineService >nul 2>&1
+if %ERRORLEVEL%==0 (
+    if not exist "%SERVICE_CONFIG_DIR%\" mkdir "%SERVICE_CONFIG_DIR%\"
+
+    rem Get the start type
+    for /f "tokens=3" %%i in ('sc qc SunshineService ^| findstr /C:"START_TYPE"') do (
+        set "CURRENT_START_TYPE=%%i"
+    )
+
+    rem Set the content to write
+    if "!CURRENT_START_TYPE!"=="2" (
+        sc qc SunshineService | findstr /C:"(DELAYED)" >nul
+        if !ERRORLEVEL!==0 (
+            set "CONTENT=2-delayed"
+        ) else (
+            set "CONTENT=2"
+        )
+    ) else if "!CURRENT_START_TYPE!" NEQ "" (
+        set "CONTENT=!CURRENT_START_TYPE!"
+    ) else (
+        set "CONTENT=unknown"
+    )
+
+    rem Write content to file
+    echo !CONTENT!> "%SERVICE_CONFIG_FILE%"
+)
 
 rem Stop and delete the legacy SunshineSvc service
 net stop sunshinesvc


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR will make the installer "remember" the previous type of service start type on Windows. If the user selects to "auto start" during installation it will overwrite the previous service start type.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes https://github.com/LizardByte/Sunshine/issues/3469
- Closes https://github.com/LizardByte/Sunshine/pull/3867


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
