### PR TITLE
fix(installer/windows): ensure service_bin is properly quoted

### DIFF
--- a/src_assets/windows/misc/service/install-service.bat
+++ b/src_assets/windows/misc/service/install-service.bat
@@ -58,7 +58,7 @@ if exist "%SERVICE_CONFIG_FILE%" (
 echo Setting service start type set to: [!SERVICE_START_TYPE!]
 
 rem Run the sc command to create/reconfigure the service
-sc %SC_CMD% %SERVICE_NAME% binPath= %SERVICE_BIN% start= %SERVICE_START_TYPE% DisplayName= "Sunshine Service"
+sc %SC_CMD% %SERVICE_NAME% binPath= "%SERVICE_BIN%" start= %SERVICE_START_TYPE% DisplayName= "Sunshine Service"
 
 rem Set the description of the service
 sc description %SERVICE_NAME% "Sunshine is a self-hosted game stream host for Moonlight."


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Changing quoting style in https://github.com/LizardByte/Sunshine/pull/3902 broke later usages of the variable that were not quoted.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes https://github.com/LizardByte/Sunshine/issues/3903


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
