### PR TITLE
build(linux): add Ubuntu 25.04 support to linux_build.sh

### DIFF
--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -564,6 +564,15 @@ elif grep -q "Ubuntu 24.04" /etc/os-release; then
   cuda_build="520.61.05"
   gcc_version="11"
   nvm_node=0
+elif grep -q "Ubuntu 25.04" /etc/os-release; then
+  distro="ubuntu"
+  version="25.04"
+  package_update_command="${sudo_cmd} apt-get update"
+  package_install_command="${sudo_cmd} apt-get install -y"
+  cuda_version="12.9.0"
+  cuda_build="575.51.03"
+  gcc_version="12"
+  nvm_node=0
 else
   echo "Unsupported Distro or Version"
   exit 1

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -569,9 +569,9 @@ elif grep -q "Ubuntu 25.04" /etc/os-release; then
   version="25.04"
   package_update_command="${sudo_cmd} apt-get update"
   package_install_command="${sudo_cmd} apt-get install -y"
-  cuda_version="12.9.0"
-  cuda_build="575.51.03"
-  gcc_version="12"
+  cuda_version="11.8.0"
+  cuda_build="520.61.05"
+  gcc_version="11"
   nvm_node=0
 else
   echo "Unsupported Distro or Version"


### PR DESCRIPTION
## Description
Updated the linux_build.sh file to include Ubuntu 25.04.
Set the cuda and gcc versions.

Tested and working.

Added the config for Ubuntu 25.04

Tested on my machine, so ymmv.

Alienware Area-51 R5
Intel i9-9820X
NVIDIA GeForce RTX 2080
Ubuntu 25.04
Gnome 48
Wayland
Kernel - Linux 6.14.0-15-generic

Note that I had to patch the cuda math headers as per [nvidia forum](https://forums.developer.nvidia.com/t/error-exception-specification-is-incompatible-for-cospi-sinpi-cospif-sinpif-with-glibc-2-41/323591)

## Screenshot

## Issues Fixed or Closed
- Resolves https://github.com/LizardByte/Sunshine/issues/3892

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
