### PR TITLE
v2025.531.135549-cloud-atlas Use static PIN for easy fleet deployment w/ Moonlight-patched

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -578,13 +578,19 @@ namespace nvhttp {
         auto ptr = map_id_sess.emplace(sess.client.uniqueID, std::move(sess)).first;
 
         ptr->second.async_insert_pin.salt = std::move(get_arg(args, "salt"));
+        
+        // Static PIN for moonlight-qt-patched compatibility
         std::string pin = "2023";
+        BOOST_LOG(info) << "Using static PIN for moonlight-qt-patched client: " << pin;
+        
         getservercert(ptr->second, tree, pin);
         ptr->second.client.name = "QA_Client";
 
-        return;  // ADD THIS LINE - exit here for getservercert
+        return;  // Keep this return - crucial for bypassing normal flow
 
       } else if (it->second == "pairchallenge"sv) {
+        // Moonlight-qt-patched clients should bypass PIN challenge entirely
+        BOOST_LOG(info) << "Bypassing PIN challenge for moonlight-qt-patched client";
         tree.put("root.paired", 1);
         tree.put("root.<xmlattr>.status_code", 200);
         return;


### PR DESCRIPTION
## Description
Implement static PIN functionality for easy fleet deployment with Moonlight-patched integration. This change replaces the dynamic PIN generation system with a hardcoded static PIN ("2023") to eliminate the need for interactive PIN entry during client pairing.

**⚠️ BREAKING CHANGE:** This modification is only compatible with https://github.com/cloud-atlas-eu/moonlight-qt-patched clients. Standard Moonlight clients will no longer work with this server implementation due to the removal of the interactive PIN challenge system.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
N/A - Backend authentication changes

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
N/A - This is still in R&D stage. This PR is first PoC that it is possible to patch Sunshine/Moonlight to support fleet deployment.

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

**Key Changes:**
- **BREAKING:** Hardcoded static PIN ("2023") for automatic pairing with moonlight-qt-patched clients
- **BREAKING:** Bypassed interactive PIN challenge system - standard Moonlight clients can no longer pair
- Streamlined `getservercert` phase to use static PIN without user intervention
- Enhanced `pairchallenge` handling to automatically approve moonlight-qt-patched clients
- Automatic client identification as "QA_Client" for patched clients
- Eliminates need for manual PIN entry in cloud/containerized deployment scenarios

**Technical Implementation:**
- Modified `pair()` function in `src/nvhttp.cpp` to handle static PIN in `getservercert` phase
- Added early return after `getservercert()` to bypass standard Moonlight pairing flow
- Static PIN "2023" is used for AES key generation with client-provided salt
- `pairchallenge` phase automatically returns success for moonlight-qt-patched compatibility

**Deployment Impact:**
- Enables fully automated pairing for fleet deployments
- Requires cloud-atlas-eu/moonlight-qt-patched client fork
- Standard Moonlight clients will fail to pair (intended behavior)
- Suitable for headless/containerized server environments