### PR TITLE
build(windows): fix gcc15 compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -864,48 +864,61 @@ jobs:
 
       - name: Update Windows dependencies
         env:
-          gcc_version: "14.2.0-3"
+          MSYSTEM: "ucrt64"
+          TOOLCHAIN: "ucrt-x86_64"
         shell: msys2 {0}
         run: |
-          broken_deps=(
-            "mingw-w64-ucrt-x86_64-gcc"
-            "mingw-w64-ucrt-x86_64-gcc-libs"
+          # variables
+          declare -A pinned_deps
+
+          # dependencies
+          dependencies=(
+            "git"
+            "mingw-w64-${TOOLCHAIN}-cmake"
+            "mingw-w64-${TOOLCHAIN}-cppwinrt"
+            "mingw-w64-${TOOLCHAIN}-curl-winssl"
+            "mingw-w64-${TOOLCHAIN}-gcc"
+            "mingw-w64-${TOOLCHAIN}-graphviz"
+            "mingw-w64-${TOOLCHAIN}-MinHook"
+            "mingw-w64-${TOOLCHAIN}-miniupnpc"
+            "mingw-w64-${TOOLCHAIN}-nlohmann-json"
+            "mingw-w64-${TOOLCHAIN}-nodejs"
+            "mingw-w64-${TOOLCHAIN}-nsis"
+            "mingw-w64-${TOOLCHAIN}-onevpl"
+            "mingw-w64-${TOOLCHAIN}-openssl"
+            "mingw-w64-${TOOLCHAIN}-opus"
+            "mingw-w64-${TOOLCHAIN}-toolchain"
           )
 
-          tarballs=""
-          for dep in "${broken_deps[@]}"; do
-            tarball="${dep}-${gcc_version}-any.pkg.tar.zst"
+          # do not modify below this line
 
-            # download and install working version
-            wget https://repo.msys2.org/mingw/ucrt64/${tarball}
+          ignore_packages=()
+          tarballs=""
+          for pkg in "${!pinned_deps[@]}"; do
+            ignore_packages+=("${pkg}")
+            version="${pinned_deps[$pkg]}"
+            tarball="${pkg}-${version}-any.pkg.tar.zst"
+
+            # download working version
+            wget "https://repo.msys2.org/mingw/${MSYSTEM}/${tarball}"
 
             tarballs="${tarballs} ${tarball}"
           done
 
-          # install broken dependencies
+          # Create the ignore string for pacman
+          ignore_list=$(IFS=,; echo "${ignore_packages[*]}")
+
+          # install pinned dependencies
           if [ -n "$tarballs" ]; then
             pacman -U --noconfirm ${tarballs}
           fi
 
-          # install dependencies
-          dependencies=(
-            "git"
-            "mingw-w64-ucrt-x86_64-cmake"
-            "mingw-w64-ucrt-x86_64-cppwinrt"
-            "mingw-w64-ucrt-x86_64-curl-winssl"
-            "mingw-w64-ucrt-x86_64-graphviz"
-            "mingw-w64-ucrt-x86_64-MinHook"
-            "mingw-w64-ucrt-x86_64-miniupnpc"
-            "mingw-w64-ucrt-x86_64-nlohmann-json"
-            "mingw-w64-ucrt-x86_64-nodejs"
-            "mingw-w64-ucrt-x86_64-nsis"
-            "mingw-w64-ucrt-x86_64-onevpl"
-            "mingw-w64-ucrt-x86_64-openssl"
-            "mingw-w64-ucrt-x86_64-opus"
-            "mingw-w64-ucrt-x86_64-toolchain"
-          )
-
-          pacman -Syu --noconfirm --ignore="$(IFS=,; echo "${broken_deps[*]}")" "${dependencies[@]}"
+          # Only add --ignore if we have packages to ignore
+          if [ -n "$ignore_list" ]; then
+            pacman -Syu --noconfirm --ignore="${ignore_list}" "${dependencies[@]}"
+          else
+            pacman -Syu --noconfirm "${dependencies[@]}"
+          fi
 
       - name: Install Doxygen
         # GCC compiled doxygen has issues when running graphviz

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -9,6 +9,10 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
 # gcc complains about misleading indentation in some mingw includes
 list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-misleading-indentation)
 
+# gcc15 complains about non-template type 'coroutine_handle' used as a template in Windows.Foundation.h
+# can remove after https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120495 is available in mingw-w64
+list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-template-body)
+
 # see gcc bug 98723
 add_definitions(-DUSE_BOOST_REGEX)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,6 +15,7 @@ target_compile_options(dxgi-info PRIVATE ${SUNSHINE_COMPILE_OPTIONS})
 add_executable(audio-info audio.cpp)
 set_target_properties(audio-info PROPERTIES CXX_STANDARD 20)
 target_link_libraries(audio-info
+        ${Boost_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
         ksuser
         ${PLATFORM_LIBRARIES})

--- a/tools/audio.cpp
+++ b/tools/audio.cpp
@@ -3,8 +3,8 @@
  * @brief Handles collecting audio device information from Windows.
  */
 #define INITGUID
-#include "src/utility.h"
 
+// platform includes
 #include <audioclient.h>
 #include <codecvt>
 #include <iostream>
@@ -12,6 +12,12 @@
 #include <mmdeviceapi.h>
 #include <roapi.h>
 #include <synchapi.h>
+
+// lib includes
+#include <boost/locale.hpp>
+
+// local includes
+#include "src/utility.h"
 
 DEFINE_PROPERTYKEY(PKEY_Device_DeviceDesc, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 2);  // DEVPROP_TYPE_STRING
 DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 14);  // DEVPROP_TYPE_STRING
@@ -43,8 +49,6 @@ namespace audio {
   using wstring_t = util::safe_ptr<WCHAR, co_task_free<WCHAR>>;
 
   using handle_t = util::safe_ptr_v2<void, BOOL, CloseHandle>;
-
-  static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
 
   class prop_var_t {
   public:
@@ -204,7 +208,7 @@ namespace audio {
       // so we can take the first match as the current format to display.
       auto audio_client = make_audio_client(device, format);
       if (audio_client) {
-        current_format = converter.from_bytes(format.name.data());
+        current_format = boost::locale::conv::utf_to_utf<wchar_t>(format.name.data());
         break;
       }
     }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix Windows build, same logic used as in `build-deps` repo.

See:
- https://github.com/msys2/MINGW-packages/issues/24209
- https://github.com/microsoft/cppwinrt/issues/1490
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120495


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
