### PR TITLE
build(homebrew): use miniupnpc head package instead of resource

### DIFF
--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -33,6 +33,7 @@ class @PROJECT_NAME@ < Formula
   depends_on "node" => :build
   depends_on "pkg-config" => :build
   depends_on "curl"
+  depends_on "miniupnpc" => :head
   depends_on "openssl"
   depends_on "opus"
   depends_on "icu4c" => :recommended
@@ -198,11 +199,6 @@ index 5b3638d..aca9481 100644
     end
   end
 
-  resource "miniupnpc" do
-    url "https://github.com/miniupnp/miniupnp.git",
-      revision: "e263ab6f56c382e10fed31347ec68095d691a0e8"
-  end
-
   def install
     ENV["BRANCH"] = "@GITHUB_BRANCH@"
     ENV["BUILD_VERSION"] = "@BUILD_VERSION@"
@@ -303,23 +299,6 @@ index 5b3638d..aca9481 100644
         system "ninja", "-C", "build"
         system "ninja", "-C", "build", "install"
       end
-    end
-
-    # Build miniupnpc
-    resource("miniupnpc").stage do
-      # Change to the miniupnpc directory within the repo
-      cd "miniupnpc" do
-        system "make", "INSTALLPREFIX=#{prefix}/miniupnpc", "install"
-      end
-
-      # Copy the shared libraries to the main lib directory
-      # This ensures they're in the library search path at runtime
-      cp Dir["#{prefix}/miniupnpc/lib/libminiupnpc.so*"], "#{lib}/" if OS.linux?
-
-      # Set include and library paths for the custom miniupnpc
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{prefix}/miniupnpc/lib/pkgconfig"
-      ENV.prepend "CPPFLAGS", "-I#{prefix}/miniupnpc/include"
-      ENV.prepend "LDFLAGS", "-L#{prefix}/miniupnpc/lib"
     end
 
     system "cmake", "-S", ".", "-B", "build", "-G", "Unix Makefiles",


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
We can now use the head option for miniupnpc in homebrew after https://github.com/Homebrew/homebrew-core/pull/226124


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
