### PR TITLE
feature(security/windows): Add defense-in-depth measure for insecure system PATH configuration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,6 +95,10 @@ int main(int argc, char *argv[]) {
   task_pool_util::TaskPool::task_id_t force_shutdown = nullptr;
 
 #ifdef _WIN32
+  // Avoid searching the PATH in case a user has configured their system insecurely
+  // by placing a user-writable directory in the system-wide PATH variable.
+  SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
+
   setlocale(LC_ALL, "C");
 #endif
 


### PR DESCRIPTION
## Description
If an administrator has configured their system insecurely by adding a user-writeable path to the system-wide PATH variable, this can cause apps running as admin to load DLLs planted in this directory.

While the root cause is clearly the misconfigured system, we can reduce Sunshine's exposure to this by asking Windows not to search the PATH. For more information, see the blog post by Raymond Chen: https://devblogs.microsoft.com/oldnewthing/20200420-00/?p=103685

Thanks to @Pundhapat for reporting the libx265 DLLs being loaded from the `PATH` variable.

### Screenshot

### Issues Fixed or Closed


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
