### PR TITLE
fix(macOS): nil displayName on macOS 26 beta

### DIFF
--- a/src/platform/macos/av_video.m
+++ b/src/platform/macos/av_video.m
@@ -34,7 +34,7 @@
 
 + (NSString *)getDisplayName:(CGDirectDisplayID)displayID {
   for (NSScreen *screen in [NSScreen screens]) {
-    if (screen.deviceDescription[@"NSScreenNumber"] == [NSNumber numberWithUnsignedInt:displayID]) {
+    if ([screen.deviceDescription[@"NSScreenNumber"] isEqualToNumber:[NSNumber numberWithUnsignedInt:displayID]]) {
       return screen.localizedName;
     }
   }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
One liner change from identity comparison to value comparison for display ID. It fixes the issue for me on macOS 26 beta. I only have one computer, so I’m unable to verify whether this change affects compatibility with earlier versions of macOS.

Before change:
```
[2025-06-19 20:25:34.684802] [0x00000001fb026340] [info]    config: 'stream_audio' = true
[2025-06-19 20:25:34.685028] [0x00000001fb026340] [info]    config: 'ping_timeout' = 10000
[2025-06-19 20:25:34.685]: Info: Sunshine version: 0.0.0.dirty
[2025-06-19 20:25:34.685]: Info: Package Publisher: Third Party Publisher
[2025-06-19 20:25:34.685]: Info: Publisher Website:
[2025-06-19 20:25:34.685]: Info: Get support: https://app.lizardbyte.dev/support
[2025-06-19 20:25:34.685]: Info: config: 'ping_timeout' = 10000
[2025-06-19 20:25:34.685]: Info: config: 'stream_audio' = true
[2025-06-19 20:25:34.733]: Warning: No gamepad input is available
[2025-06-19 20:25:34.733]: Info: // Testing for available encoders, this may generate errors. You can safely ignore those errors. //
[2025-06-19 20:25:34.733]: Info: Trying encoder [videotoolbox]
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[2]'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000018e582690 __exceptionPreprocess + 176
	1   libobjc.A.dylib                     0x000000018e06a430 objc_exception_throw + 88
	2   CoreFoundation                      0x000000018e6abe64 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 724
	3   CoreFoundation                      0x000000018e64dbd0 +[NSDictionary dictionaryWithObjects:forKeys:count:] + 52
	4   sunshine-v2025.615.34501            0x000000010044aee8 +[AVVideo displayNames] + 252
	5   sunshine-v2025.615.34501            0x000000010044b810 _ZN5platf7displayENS_10mem_type_eERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEERKN5video8config_tE + 320
	6   sunshine-v2025.615.34501            0x0000000100423a94 _ZN5video13reset_displayERNSt3__110shared_ptrIN5platf9display_tEEERKNS2_10mem_type_eERKNS0_12basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEERKNS_8config_tE + 92
	7   sunshine-v2025.615.34501            0x000000010042a724 _ZN5video16validate_encoderERNS_9encoder_tEb + 472
	8   sunshine-v2025.615.34501            0x000000010042c11c _ZN5video14probe_encodersEv + 2768
	9   sunshine-v2025.615.34501            0x000000010037469c main + 2488
	10  dyld                                0x000000018e0dd854 start + 6256
)
libc++abi: terminating due to uncaught exception of type NSException
[1]    4664 abort      sunshine
```
After change:
```
[2025-06-19 20:26:22.628986] [0x00000001fb026340] [info]    config: 'stream_audio' = true
[2025-06-19 20:26:22.629197] [0x00000001fb026340] [info]    config: 'ping_timeout' = 10000
[2025-06-19 20:26:22.629]: Info: Sunshine version: 0.0.0.dirty
[2025-06-19 20:26:22.629]: Info: Package Publisher: Third Party Publisher
[2025-06-19 20:26:22.629]: Info: Publisher Website:
[2025-06-19 20:26:22.629]: Info: Get support: https://app.lizardbyte.dev/support
[2025-06-19 20:26:22.629]: Info: config: 'ping_timeout' = 10000
[2025-06-19 20:26:22.629]: Info: config: 'stream_audio' = true
[2025-06-19 20:26:22.662]: Warning: No gamepad input is available
[2025-06-19 20:26:22.662]: Info: // Testing for available encoders, this may generate errors. You can safely ignore those errors. //
[2025-06-19 20:26:22.662]: Info: Trying encoder [videotoolbox]
[2025-06-19 20:26:22.677]: Info: Detecting displays
[2025-06-19 20:26:22.677]: Info: Detected display: <display 1 model redacted> (id: 5) connected: true
[2025-06-19 20:26:22.677]: Info: Detected display: <display 2 model redacted> (id: 3) connected: true
[2025-06-19 20:26:22.677]: Info: Configuring selected display (5) to stream
[2025-06-19 20:26:22.682]: Info: Creating encoder [h264_videotoolbox]
[2025-06-19 20:26:22.682]: Info: Color coding: SDR (Rec. 601)
[2025-06-19 20:26:22.682]: Info: Color depth: 8-bit
[2025-06-19 20:26:22.682]: Info: Color range: JPEG
[2025-06-19 20:26:22.687]: Info: Streaming bitrate is 1000000
[2025-06-19 20:26:22.825]: Warning: [h264_videotoolbox @ 0x8e5268000] PrioritizeEncodingSpeedOverQuality property is not supported on this device. Ignoring.
[2025-06-19 20:26:22.826]: Info: [h264_videotoolbox @ 0x8e5268000] This device does not support the AllowOpenGop option. Value ignored.
[2025-06-19 20:26:22.996]: Info: Creating encoder [hevc_videotoolbox]
[2025-06-19 20:26:22.996]: Info: Color coding: SDR (Rec. 601)
[2025-06-19 20:26:22.996]: Info: Color depth: 8-bit
[2025-06-19 20:26:22.996]: Info: Color range: JPEG
[2025-06-19 20:26:22.996]: Info: Streaming bitrate is 1000000
[2025-06-19 20:26:23.005]: Info: [hevc_videotoolbox @ 0x8e5268000] This device does not support the max_ref_frames option. Value ignored.
[2025-06-19 20:26:23.116]: Info: Creating encoder [av1_videotoolbox]
[2025-06-19 20:26:23.116]: Info: Color coding: SDR (Rec. 601)
[2025-06-19 20:26:23.116]: Info: Color depth: 8-bit
[2025-06-19 20:26:23.116]: Info: Color range: JPEG
[2025-06-19 20:26:23.116]: Error: Couldn't open [av1_videotoolbox]
[2025-06-19 20:26:23.116]: Info: Detecting displays
[2025-06-19 20:26:23.116]: Info: Detected display: <display 1 model redacted> (id: 5) connected: true
[2025-06-19 20:26:23.116]: Info: Detected display: <display 2 model redacted> (id: 3) connected: true
[2025-06-19 20:26:23.116]: Info: Configuring selected display (5) to stream
[2025-06-19 20:26:23.116]: Info: Creating encoder [hevc_videotoolbox]
[2025-06-19 20:26:23.117]: Info: Color coding: SDR (Rec. 709)
[2025-06-19 20:26:23.117]: Info: Color depth: 10-bit
[2025-06-19 20:26:23.117]: Info: Color range: JPEG
[2025-06-19 20:26:23.117]: Info: Streaming bitrate is 1000000
[2025-06-19 20:26:23.123]: Info: [hevc_videotoolbox @ 0x8e5268000] This device does not support the max_ref_frames option. Value ignored.
[2025-06-19 20:26:23.233]: Info:
[2025-06-19 20:26:23.233]: Info: // Ignore any errors mentioned above, they are not relevant. //
[2025-06-19 20:26:23.233]: Info:
[2025-06-19 20:26:23.233]: Info: Found H.264 encoder: h264_videotoolbox [videotoolbox]
[2025-06-19 20:26:23.233]: Info: Found HEVC encoder: hevc_videotoolbox [videotoolbox]
[2025-06-19 20:26:23.236]: Info: Configuration UI available at [https://localhost:47990]
[2025-06-19 20:26:23.869]: Info: Successfully registered DNS service.
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes the runtime error reported in #3961. However this fix alone is not sufficient for full macOS 26 support, as other issues still exist.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
