### PR TITLE
build(linux): fix compilation with Clang

### DIFF
--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -424,7 +424,8 @@ namespace platf {
       // UDP GSO on Linux currently only supports sending 64K or 64 segments at a time
       size_t seg_index = 0;
       const size_t seg_max = 65536 / 1500;
-      struct iovec iovs[(send_info.headers ? std::min(seg_max, send_info.block_count) : 1) * max_iovs_per_msg] = {};
+      struct iovec iovs[(send_info.headers ? std::min(seg_max, send_info.block_count) : 1) * max_iovs_per_msg];
+      memset(iovs, 0, sizeof(iovs));
       auto msg_size = send_info.header_size + send_info.payload_size;
       while (seg_index < send_info.block_count) {
         int iovlen = 0;
@@ -507,8 +508,10 @@ namespace platf {
 
     {
       // If GSO is not supported, use sendmmsg() instead.
-      struct mmsghdr msgs[send_info.block_count] = {};
-      struct iovec iovs[send_info.block_count * (send_info.headers ? 2 : 1)] = {};
+      struct mmsghdr msgs[send_info.block_count];
+      memset(msgs, 0, sizeof(msgs));
+      struct iovec iovs[send_info.block_count * (send_info.headers ? 2 : 1)];
+      memset(iovs, 0, sizeof(iovs));
       int iov_idx = 0;
       for (size_t i = 0; i < send_info.block_count; i++) {
         msgs[i].msg_hdr.msg_iov = &iovs[iov_idx];


### PR DESCRIPTION
## Description
Clang 20.1.7 fails with the following error:
```
/var/tmp/portage/net-misc/sunshine-2025.122.141614/work/Sunshine-2025.122.141614/src/platform/linux/misc.cpp:427:25: error: variable-sized object may not be initialized
  427 |       struct iovec iovs[(send_info.headers ? std::min(seg_max, send_info.block_count) : 1) * max_iovs_per_msg] = {};
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

As VLAs are not part of the C++ standard, Clang barely supports their features. However, simple memset fixes the issue.

### Issues Fixed or Closed
- N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
