### PR TITLE
ci(release): add virustotal reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         run: ls -l artifacts
 
       - name: Create/Update GitHub Release
-        uses: LizardByte/actions/actions/release_create@v2025.627.30023
+        uses: LizardByte/actions/actions/release_create@v2025.702.213340
         with:
           allowUpdates: false
           body: ${{ needs.release-setup.outputs.release_body }}
@@ -200,3 +200,4 @@ jobs:
           prerelease: true
           tag: ${{ needs.release-setup.outputs.release_tag }}
           token: ${{ secrets.GH_BOT_TOKEN }}
+          virustotal_api_key: ${{ secrets.VIRUSTOTAL_API_KEY }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds VirusTotal scanning results to the end of the release notes in the releases.

See:
- https://github.com/LizardByte/roadmap/issues/86
- https://github.com/LizardByte/actions/pull/13
- https://github.com/LizardByte/Sunshine/issues/3962


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
