### PR TITLE
build/flatpak/change salsa git dependencies

### DIFF
--- a/packaging/linux/flatpak/modules/avahi.json
+++ b/packaging/linux/flatpak/modules/avahi.json
@@ -32,15 +32,12 @@
   "sources": [
     {
       "type": "git",
-      "url": "https://salsa.debian.org/utopia-team/avahi.git",
-      "commit": "1412c015d348166d58ea9c192239b00769eae24e",
-      "tag": "debian/0.8-13",
+      "url": "https://github.com/avahi/avahi.git",
+      "commit": "f060abee2807c943821d88839c013ce15db17b58",
+      "tag": "v0.8",
       "x-checker-data": {
         "type": "git",
-        "tag-pattern": "^debian\\/(\\d.+)$",
-        "versions": {
-          "<": "0.9"
-        }
+        "tag-pattern": "^v([\\d.]+)$"
       }
     },
     {

--- a/packaging/linux/flatpak/modules/libevdev.json
+++ b/packaging/linux/flatpak/modules/libevdev.json
@@ -5,22 +5,24 @@
     "-Ddocumentation=disabled",
     "-Dtests=disabled"
   ],
-  "cleanup": [
-    "/bin"
-  ],
   "sources": [
     {
       "type": "git",
-      "url": "https://salsa.debian.org/debian/libevdev.git",
-      "commit": "1aa7baa233d6df4cee6a66fbc61bb5ffc8b6e88d",
-      "tag": "debian/1.13.0+dfsg-1",
+      "url": "https://github.com/LizardByte-infrastructure/libevdev.git",
+      "commit": "ac0056961c3332a260db063ab4fccc7747638a1d",
+      "tag": "libevdev-1.13.4",
       "x-checker-data": {
-        "type": "git",
-        "tag-pattern": "^debian\\/(\\d.\\d+\\.\\d+)",
-        "versions": {
-          "<": "1.13.1"
-        }
+        "type": "anitya",
+        "project-id": 20540,
+        "stable-only": true,
+        "tag-template": "libevdev-$version"
       }
     }
+  ],
+  "cleanup": [
+    "/bin",
+    "/include",
+    "/lib/pkgconfig",
+    "/share"
   ]
 }

--- a/packaging/linux/flatpak/modules/libnotify.json
+++ b/packaging/linux/flatpak/modules/libnotify.json
@@ -11,15 +11,12 @@
   "sources": [
     {
       "type": "git",
-      "url": "https://salsa.debian.org/gnome-team/libnotify.git",
-      "commit": "ccf2f62ef0a4b264dd4eff32cab70a3e213ceb1a",
-      "tag": "debian/0.8.1-1",
+      "url": "https://github.com/LizardByte-infrastructure/libnotify.git",
+      "commit": "131aad01ff5f563b4863becbb6ed84dac6e75d5a",
+      "tag": "0.8.6",
       "x-checker-data": {
         "type": "git",
-        "tag-pattern": "^debian\\/(\\d.+)$",
-        "versions": {
-          "<": "0.8.2"
-        }
+        "tag-pattern": "^([\\d.]+)$"
       }
     }
   ]

--- a/packaging/linux/flatpak/modules/miniupnpc.json
+++ b/packaging/linux/flatpak/modules/miniupnpc.json
@@ -1,25 +1,33 @@
 {
   "name": "miniupnpc",
   "buildsystem": "cmake-ninja",
+  "builddir": true,
   "config-opts": [
-    "-DCMAKE_BUILD_TYPE=Release",
-    "-DUPNPC_BUILD_SAMPLE=OFF",
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+    "-DUPNPC_BUILD_STATIC=OFF",
     "-DUPNPC_BUILD_SHARED=ON",
-    "-DUPNPC_BUILD_TESTS=OFF"
+    "-DUPNPC_BUILD_TESTS=OFF",
+    "-DUPNPC_BUILD_SAMPLE=OFF"
   ],
   "sources": [
     {
-      "type": "git",
-      "url": "https://salsa.debian.org/miniupnp-team/miniupnpc.git",
-      "commit": "c5fe3aa794e92a503cecec6a4071eb6d310b4e42",
-      "tag": "debian/2.2.4-1",
+      "url": "https://miniupnp.tuxfamily.org/files/miniupnpc-2.3.3.tar.gz",
+      "sha256": "d52a0afa614ad6c088cc9ddff1ae7d29c8c595ac5fdd321170a05f41e634bd1a",
       "x-checker-data": {
-        "type": "git",
-        "tag-pattern": "^debian\\/(\\d.+)$",
-        "versions": {
-          "<": "2.2.5"
-        }
-      }
+        "type": "anitya",
+        "project-id": 1986,
+        "stable-only": true,
+        "url-template": "https://miniupnp.tuxfamily.org/files/miniupnpc-$version.tar.gz"
+      },
+      "type": "archive"
     }
+  ],
+  "cleanup": [
+    "/share/man",
+    "/lib/pkgconfig",
+    "/lib/libminiupnpc.so",
+    "/lib/cmake",
+    "/include",
+    "/bin/external-ip.sh"
   ]
 }

--- a/packaging/linux/flatpak/modules/numactl.json
+++ b/packaging/linux/flatpak/modules/numactl.json
@@ -1,22 +1,24 @@
 {
   "name": "numactl",
-  "buildsystem": "autotools",
-  "cleanup": [
-    "/bin"
-  ],
   "sources": [
     {
       "type": "git",
-      "url": "https://salsa.debian.org/debian/numactl.git",
-      "commit": "640bb34497702f9aaeb8af1b491f32b91d03ec80",
-      "tag": "debian/2.0.16-1",
+      "url": "https://github.com/numactl/numactl.git",
+      "tag": "v2.0.19",
+      "commit": "3bc85e37d5a30da6790cb7e8bb488bb8f679170f",
       "x-checker-data": {
         "type": "git",
-        "tag-pattern": "^debian\\/(\\d.+)$",
-        "versions": {
-          "<": "2.0.17"
-        }
+        "tag-pattern": "^v([\\d.]+)$"
       }
     }
+  ],
+  "rm-configure": true,
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/lib/*.a",
+    "/lib/*.la",
+    "/lib/*.so",
+    "/share/man"
   ]
 }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR stops using all gitlab hosted dependencies for the Flatpak build. Two of the 5 repos were mirrored to @LizardByte-infrastructure, while two others are already hosted on GitHub. `miniupnpc` is not using a git source at this time.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
