### PR TITLE
fix(display): Restore Checkbox import for display device opts

### DIFF
--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref } from 'vue'
 import PlatformLayout from '../../../PlatformLayout.vue'
+import Checkbox from "../../../Checkbox.vue";
 
 const props = defineProps({
   platform: String,


### PR DESCRIPTION
## Description
As discussed in #3613, the import for the Checkbox element was removed as a part of #3579 which stopped the 'Config revert on disconnect', option in the display options, from rendering.

This simply adds the import back which restores the functionality.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

Before (v2025.628.4510):
<img width="638" height="157" alt="sunshine_before" src="https://github.com/user-attachments/assets/78dc804a-661a-4ead-adec-3c18dacf5a19" />
After:
<img width="638" height="249" alt="sunshine_after" src="https://github.com/user-attachments/assets/c22f4d4a-a9cb-4a26-9c1d-dbb821471b19" />


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
None

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
