### PR TITLE
build(deps): add doxygen and graphviz to arch deps

### DIFF
--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -96,9 +96,11 @@ function add_arch_deps() {
     'base-devel'
     'cmake'
     'curl'
+    'doxygen'
     "gcc${gcc_version}"
     "gcc${gcc_version}-libs"
     'git'
+    'graphviz'
     'libayatana-appindicator'
     'libcap'
     'libdrm'


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

This adds two missing build dependencies for Arch to linux_build.sh: doxygen and graphviz.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
