### PR TITLE
feat(config): Added ability to listen source rather than sink

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -510,6 +510,7 @@ namespace config {
 
   audio_t audio {
     {},  // audio_sink
+    {},  // audio_source
     {},  // virtual_sink
     true,  // stream audio
     true,  // install_steam_drivers
@@ -1165,6 +1166,7 @@ namespace config {
     list_prep_cmd_f(vars, "global_prep_cmd", config::sunshine.prep_cmds);
 
     string_f(vars, "audio_sink", audio.sink);
+    string_f(vars, "audio_source", audio.source);
     string_f(vars, "virtual_sink", audio.virtual_sink);
     bool_f(vars, "stream_audio", audio.stream);
     bool_f(vars, "install_steam_audio_drivers", audio.install_steam_drivers);

--- a/src/config.h
+++ b/src/config.h
@@ -146,6 +146,7 @@ namespace config {
 
   struct audio_t {
     std::string sink;
+    std::string source;
     std::string virtual_sink;
     bool stream;
     bool install_steam_drivers;

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -456,7 +456,8 @@ namespace platf {
           sink_name = get_default_sink_name();
         }
 
-        return ::platf::microphone(mapping, channels, sample_rate, frame_size, get_monitor_name(sink_name));
+        auto monitor_name = config::audio.source.empty() ? get_monitor_name(sink_name) : config::audio.source;
+        return ::platf::microphone(mapping, channels, sample_rate, frame_size, monitor_name);
       }
 
       bool is_sink_available(const std::string &sink) override {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
Adding the `audio_source` option that allows to capture explicit `source` device (like `line-in` or `microphone`) rather than capturing an application's sound by making a virtual audio output device to trick the application. In my case I wanted to route the sound source from hardware, and with existing setup it's impossible to do without serious complicated tricks on the audio server by making loopbacks that connects sources and sinks.

By default, `audio_source` is empty, and behaviour is stay as before. But once `audio_source` is defined, then Sunshine will explicitly capture audio from the audio source rather than from the sink's monitor.

### Screenshot
I don't have any UI changes, only backend.

### Issues Fixed or Closed
Discussion:  https://github.com/orgs/LizardByte/discussions/830

#### Roadmap Issues
Nothing


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
