### PR TITLE
build(linux): enable deb package auto dependency list

### DIFF
--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -91,6 +91,22 @@ if(NOT BOOST_USE_STATIC)
                 boost-locale >= ${Boost_VERSION}, \
                 boost-log >= ${Boost_VERSION}, \
                 boost-program-options >= ${Boost_VERSION}")
+else()
+    # Even when boost (locale) is static linked, it still requires ICU.
+    # Distros might not have ICU in their base image so when packaging
+    # add ICU as a dependency.
+    # The ICU library is released with the version in their name... :(.
+    find_package(ICU COMPONENTS uc data i18n REQUIRED)
+    # ICU does not provide a minor / major version variable.
+    string(REGEX MATCH "^[0-9]+" ICU_VERSION_MAJOR ${ICU_VERSION})
+    # Debian-based distros have libicu versioned in the name.
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
+                ${CPACK_DEBIAN_PACKAGE_DEPENDS}, \
+                libicu${ICU_VERSION_MAJOR}")
+    # Fedora based distros provide a general package
+    set(CPACK_RPM_PACKAGE_REQUIRES "\
+                ${CPACK_RPM_PACKAGE_REQUIRES}, \
+                libicu")
 endif()
 
 # This should automatically figure out dependencies, doesn't work with the current config

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -91,26 +91,10 @@ if(NOT BOOST_USE_STATIC)
                 boost-locale >= ${Boost_VERSION}, \
                 boost-log >= ${Boost_VERSION}, \
                 boost-program-options >= ${Boost_VERSION}")
-else()
-    # Even when boost (locale) is static linked, it still requires ICU.
-    # Distros might not have ICU in their base image so when packaging
-    # add ICU as a dependency.
-    # The ICU library is released with the version in their name... :(.
-    find_package(ICU COMPONENTS uc data i18n REQUIRED)
-    # ICU does not provide a minor / major version variable.
-    string(REGEX MATCH "^[0-9]+" ICU_VERSION_MAJOR ${ICU_VERSION})
-    # Debian-based distros have libicu versioned in the name.
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
-                ${CPACK_DEBIAN_PACKAGE_DEPENDS}, \
-                libicu${ICU_VERSION_MAJOR}")
-    # Fedora based distros provide a general package
-    set(CPACK_RPM_PACKAGE_REQUIRES "\
-                ${CPACK_RPM_PACKAGE_REQUIRES}, \
-                libicu")
 endif()
 
-# This should automatically figure out dependencies, doesn't work with the current config
-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
+# This should automatically figure out dependencies on deb packages
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
 # application icon
 if(NOT ${SUNSHINE_BUILD_FLATPAK})

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -221,6 +221,7 @@ function add_debian_based_deps() {
     "cmake"
     "desktop-file-utils"
     "doxygen"
+    "file"
     "flex"  # required if we need to compile doxygen
     "gcc-${gcc_version}"
     "g++-${gcc_version}"


### PR DESCRIPTION
## Description
As mentioned in PR #4304 this PR is meant to fix the `libicu` issue on debian. After some further investigation I noticed that https://github.com/LizardByte/Sunshine/blob/f52891d6fc7063efd96849134ca60837878085b0/cmake/packaging/linux.cmake#L96-L97 is turned off because of config issue.

The only issue I could find right now is that it needs the `file` package on Debian-based distros. So adding the file to the build dependencies and running all the builds again fixes this issue (+ maybe some future issues).

If this is not acceptable I also have a fix specifically for `libicu` in b7b9e44024e7eb638631329b88aaa25c2c2b3524 using the [FindICU](https://cmake.org/cmake/help/latest/module/FindICU.html) module.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
