### PR TITLE
build(linux): explicitely set CC and CXX compilers

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -186,7 +186,7 @@ jobs:
         working-directory: build
         run: |
           ${{ steps.python.outputs.python-path }} -m pip install gcovr
-          ${{ steps.python.outputs.python-path }} -m gcovr . -r ../src \
+          ${{ steps.python.outputs.python-path }} -m gcovr --gcov-executable "gcov-${GCC_VERSION}" . -r ../src \
             --exclude-noncode-lines \
             --exclude-throw-branches \
             --exclude-unreachable-branches \

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -749,6 +749,15 @@ if [ "$architecture" != "x86_64" ] && [ "$architecture" != "aarch64" ]; then
   exit 1
 fi
 
+# export variables for github actions ci
+if [ -f "$GITHUB_ENV" ]; then
+  {
+    echo "CC=gcc-${gcc_version}"
+    echo "CXX=g++-${gcc_version}"
+    echo "GCC_VERSION=${gcc_version}"
+  } >> "$GITHUB_ENV"
+fi
+
 # get directory of this script
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 build_dir=$(readlink -f "$script_dir/../build")


### PR DESCRIPTION
## Description
This is hopefully the last PR. This fixes the fedora package build via cmake. When I build sunshine locally I could never get cuda to work so I always build it without it since I don't need it.

However I looked into the rpm spec file and transferred those changes to the `linux_build.sh` script and it now all seems to work.

**Issues & solutions**
- `wget` Complained about the relative link in the -O argument when downloading cuda so I made it resolve to an an absolute path before it gets used (2beecac11587c791e457e300560c69a612c59ec4).
- `cmake` Complained it could not find compilers so these are now explicitly set. This was already done in the `copr` build (0279b20f506034357428b5df977cc31fc18436f8). 
- `cuda` Could not build so I copied some config over from the rpm spec (16918a8d67267ead2565668c10c7971b6fe30c1f):
   - added the `--override` flag conditionally
   - added `CMAKE_CUDA_HOST_COMPILER` flag to cmake

Every docker (including my own Fedora) is now building and packaging correctly. I don't know anything about building cuda so please look carefully.

I also want to note that it should also be possible to use the `linux_build.sh` script in the `copr` build so you don't have to maintain two separate builds. Things like cuda, the build and install could be run from the script.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [x] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
