### PR TITLE
fix(windows): Memory leak when EnumAdapters1 uses dxgi::adapter_t address as parameter

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1059,8 +1059,9 @@ namespace platf {
       return {};
     }
 
-    dxgi::adapter_t adapter;
-    for (int x = 0; factory->EnumAdapters1(x, &adapter) != DXGI_ERROR_NOT_FOUND; ++x) {
+    dxgi::adapter_t::pointer adapter_p;
+    for (int x = 0; factory->EnumAdapters1(x, &adapter_p) != DXGI_ERROR_NOT_FOUND; ++x) {
+      dxgi::adapter_t adapter {adapter_p};
       DXGI_ADAPTER_DESC1 adapter_desc;
       adapter->GetDesc1(&adapter_desc);
 


### PR DESCRIPTION
This PR fixes a memory leak issue in the Windows DXGI adapter enumeration code. Previously, dxgi::adapter_t instances were passed directly to EnumAdapters1(), which expects a raw IDXGIAdapter1**. This could cause the internal pointer of dxgi::adapter_t (a uniq_ptr wrapper) to be overwritten, leading to potential memory leaks or invalid pointer access.