### PR TITLE
build(rpm): add OpenSUSE support

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -65,10 +65,10 @@ CUDA is used for NVFBC capture.
         <td>sunshine_{arch}.flatpak</td>
     </tr>
     <tr>
-        <td>Sunshine (copr - Fedora 41)</td>
+        <td>Sunshine (copr - Fedora)</td>
     </tr>
     <tr>
-        <td>Sunshine (copr - Fedora 42)</td>
+        <td>Sunshine (copr - OpenSUSE)</td>
     </tr>
     <tr>
         <td>sunshine.pkg.tar.zst</td>
@@ -150,6 +150,7 @@ pacman -R sunshine
 ```
 
 #### Debian/Ubuntu
+
 ##### Install
 Download `sunshine-{distro}-{distro-version}-{arch}.deb` and run the following command.
 ```bash
@@ -168,12 +169,30 @@ sudo dpkg -i ./sunshine-{distro}-{distro-version}-{arch}.deb
 sudo apt remove sunshine
 ```
 
-#### Fedora
+#### Fedora/OpenSUSE
 
 > [!TIP]
 > The package name is case-sensitive.
 
-##### Install
+##### Install (GitHub releases)
+Download `Sunshine-{version}.{distro+version}.{arch}.rpm` and run the following command.
+```bash
+sudo dnf install ./Sunshine-{version}.{distro}.{arch}.rpm
+```
+
+> [!NOTE]
+> The `{distro+version}` is the distro and distro version of the distro we built the package on. The `{arch}` is the
+> architecture of your operating system.
+
+> [!TIP]
+> You can double-click the rpm file to see details about the package and begin installation.
+
+##### Uninstall
+```bash
+sudo dnf remove sunshine
+```
+
+##### Install (Copr)
 1. Enable copr repository.
    ```bash
    sudo dnf copr enable lizardbyte/stable

--- a/packaging/linux/copr/Sunshine.spec
+++ b/packaging/linux/copr/Sunshine.spec
@@ -7,6 +7,13 @@
 
 %undefine _hardened_build
 
+# Define _metainfodir for OpenSUSE if not already defined
+%if 0%{?suse_version}
+%if !0%{?_metainfodir:1}
+%global _metainfodir %{_datadir}/metainfo
+%endif
+%endif
+
 Name: Sunshine
 Version: %{build_version}
 Release: 1%{?dist}
@@ -15,17 +22,14 @@ License: GPLv3-only
 URL: https://github.com/LizardByte/Sunshine
 Source0: tarball.tar.gz
 
-BuildRequires: appstream
-# BuildRequires: boost-devel >= 1.86.0
+# Common BuildRequires
 BuildRequires: cmake >= 3.25.0
 BuildRequires: desktop-file-utils
-BuildRequires: libappstream-glib
-BuildRequires: libayatana-appindicator3-devel
+BuildRequires: git
 BuildRequires: libcap-devel
 BuildRequires: libcurl-devel
 BuildRequires: libdrm-devel
 BuildRequires: libevdev-devel
-BuildRequires: libgudev
 BuildRequires: libnotify-devel
 BuildRequires: libva-devel
 BuildRequires: libX11-devel
@@ -36,26 +40,51 @@ BuildRequires: libXi-devel
 BuildRequires: libXinerama-devel
 BuildRequires: libXrandr-devel
 BuildRequires: libXtst-devel
-BuildRequires: git
-BuildRequires: mesa-libGL-devel
-BuildRequires: mesa-libgbm-devel
-BuildRequires: miniupnpc-devel
 BuildRequires: npm
-BuildRequires: numactl-devel
 BuildRequires: openssl-devel
-BuildRequires: opus-devel
-BuildRequires: pulseaudio-libs-devel
 BuildRequires: rpm-build
-BuildRequires: systemd-udev
 BuildRequires: systemd-rpm-macros
-%{?sysusers_requires_compat}
 BuildRequires: wget
 BuildRequires: which
 
+%if 0%{?fedora}
+# Fedora-specific BuildRequires
+BuildRequires: appstream
+# BuildRequires: boost-devel >= 1.86.0
+BuildRequires: libappstream-glib
+BuildRequires: libayatana-appindicator3-devel
+BuildRequires: libgudev
+BuildRequires: mesa-libGL-devel
+BuildRequires: mesa-libgbm-devel
+BuildRequires: miniupnpc-devel
+BuildRequires: numactl-devel
+BuildRequires: opus-devel
+BuildRequires: pulseaudio-libs-devel
+BuildRequires: systemd-udev
+%{?sysusers_requires_compat}
 # for unit tests
 BuildRequires: xorg-x11-server-Xvfb
+%endif
 
-# Conditional BuildRequires for cuda-gcc based on Fedora version
+%if 0%{?suse_version}
+# OpenSUSE-specific BuildRequires
+BuildRequires: AppStream
+BuildRequires: appstream-glib
+BuildRequires: libappindicator3-devel
+BuildRequires: libgudev-1_0-devel
+BuildRequires: Mesa-libGL-devel
+BuildRequires: libgbm-devel
+BuildRequires: libminiupnpc-devel
+BuildRequires: libnuma-devel
+BuildRequires: libopus-devel
+BuildRequires: libpulse-devel
+BuildRequires: udev
+# for unit tests
+BuildRequires: xvfb-run
+%endif
+
+# Conditional BuildRequires for cuda-gcc based on distribution version
+%if 0%{?fedora}
 %if 0%{?fedora} <= 41
 BuildRequires: gcc13
 BuildRequires: gcc13-c++
@@ -69,9 +98,34 @@ BuildRequires: gcc14-c++
 %global cuda_version 12.9.1
 %global cuda_build 575.57.08
 %endif
+%endif
+
+%if 0%{?suse_version}
+%if 0%{?suse_version} <= 1699
+# OpenSUSE Leap 15.x
+BuildRequires: gcc13
+BuildRequires: gcc13-c++
+%global gcc_version 13
+%global cuda_version 12.9.1
+%global cuda_build 575.57.08
+%else
+# OpenSUSE Tumbleweed
+BuildRequires: gcc14
+BuildRequires: gcc14-c++
+%global gcc_version 14
+%global cuda_version 12.9.1
+%global cuda_build 575.57.08
+%endif
+%endif
 
 %global cuda_dir %{_builddir}/cuda
 
+# Common runtime requirements
+Requires: miniupnpc >= 2.2.4
+Requires: which >= 2.21
+
+%if 0%{?fedora}
+# Fedora runtime requirements
 Requires: libayatana-appindicator3 >= 0.5.3
 Requires: libcap >= 2.22
 Requires: libcurl >= 7.0
@@ -81,11 +135,26 @@ Requires: libopusenc >= 0.2.1
 Requires: libva >= 2.14.0
 Requires: libwayland-client >= 1.20.0
 Requires: libX11 >= 1.7.3.1
-Requires: miniupnpc >= 2.2.4
 Requires: numactl-libs >= 2.0.14
 Requires: openssl >= 3.0.2
 Requires: pulseaudio-libs >= 10.0
-Requires: which >= 2.21
+%endif
+
+%if 0%{?suse_version}
+# OpenSUSE runtime requirements
+Requires: libappindicator3-1
+Requires: libcap2
+Requires: libcurl4
+Requires: libdrm2
+Requires: libevdev2
+Requires: libopusenc0
+Requires: libva2
+Requires: libwayland-client0
+Requires: libX11-6
+Requires: libnuma1
+Requires: libopenssl3
+Requires: libpulse0
+%endif
 
 %description
 Self-hosted game stream host for Moonlight.


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Add OpenSUSE support to Sunshine.spec. Builds will take place in our copr repos. Tumbleweed is disabled due to the following error. Seems that `libxml2.so.2` is not available in Tumbleweed.

```
+ install_cuda
+ '[' -f /builddir/build/BUILD/Sunshine-0.0.4359-build/cuda/bin/nvcc ']'
+ local cuda_prefix=https://developer.download.nvidia.com/compute/cuda/
+ local cuda_suffix=
+ '[' x86_64 == aarch64 ']'
+ local url=https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_575.57.08_linux.run
+ echo 'cuda url: https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_575.57.08_linux.run'
+ wget https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_575.57.08_linux.run --progress=bar:force:noscroll --retry-connrefused --tries=3 -q -O /builddir/build/BUILD/Sunshine-0.0.4359-build/cuda.run
+ chmod a+x /builddir/build/BUILD/Sunshine-0.0.4359-build/cuda.run
+ /builddir/build/BUILD/Sunshine-0.0.4359-build/cuda.run --no-drm --no-man-page --no-opengl-libs --override --silent --toolkit --toolkitpath=/builddir/build/BUILD/Sunshine-0.0.4359-build/cuda
./cuda-installer: error while loading shared libraries: libxml2.so.2: cannot open shared object file: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.sMrynf (%build)
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
