### PR TITLE
fix(windows): resolve disappearing cursor after KVM switch

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -610,6 +610,8 @@ namespace platf {
   };
   void adjust_thread_priority(thread_priority_e priority);
 
+  void enable_mouse_keys();
+
   // Allow OS-specific actions to be taken to prepare for streaming
   void streaming_will_start();
   void streaming_will_stop();

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -327,6 +327,10 @@ namespace platf {
     // Unimplemented
   }
 
+  void enable_mouse_keys() {
+    // Unimplemented
+  }
+
   void streaming_will_start() {
     // Nothing to do
   }

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -214,6 +214,10 @@ namespace platf {
     // Unimplemented
   }
 
+  void enable_mouse_keys() {
+    // Unimplemented
+  }
+
   void streaming_will_start() {
     // Nothing to do
   }

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1137,33 +1137,33 @@ namespace platf {
   }
 
   void enable_mouse_keys() {
-        // If there is no mouse connected, enable Mouse Keys to force the cursor to appear
-        if (!GetSystemMetrics(SM_MOUSEPRESENT)) {
-          BOOST_LOG(info) << "A mouse was not detected. Sunshine will enable Mouse Keys while streaming to force the mouse cursor to appear.";
-    
-          // Get the current state of Mouse Keys so we can restore it when streaming is over
-          previous_mouse_keys_state.cbSize = sizeof(previous_mouse_keys_state);
-          if (SystemParametersInfoW(SPI_GETMOUSEKEYS, 0, &previous_mouse_keys_state, 0)) {
-            MOUSEKEYS new_mouse_keys_state = {};
-    
-            // Enable Mouse Keys
-            new_mouse_keys_state.cbSize = sizeof(new_mouse_keys_state);
-            new_mouse_keys_state.dwFlags = MKF_MOUSEKEYSON | MKF_AVAILABLE;
-            new_mouse_keys_state.iMaxSpeed = 10;
-            new_mouse_keys_state.iTimeToMaxSpeed = 1000;
-            if (SystemParametersInfoW(SPI_SETMOUSEKEYS, 0, &new_mouse_keys_state, 0)) {
-              // Remember to restore the previous settings when we stop streaming
-              enabled_mouse_keys = true;
-            } else {
-              auto winerr = GetLastError();
-              BOOST_LOG(warning) << "Unable to enable Mouse Keys: "sv << winerr;
-            }
-          } else {
-            auto winerr = GetLastError();
-            BOOST_LOG(warning) << "Unable to get current state of Mouse Keys: "sv << winerr;
-          }
+    // If there is no mouse connected, enable Mouse Keys to force the cursor to appear
+    if (!GetSystemMetrics(SM_MOUSEPRESENT)) {
+      BOOST_LOG(info) << "A mouse was not detected. Sunshine will enable Mouse Keys while streaming to force the mouse cursor to appear.";
+
+      // Get the current state of Mouse Keys so we can restore it when streaming is over
+      previous_mouse_keys_state.cbSize = sizeof(previous_mouse_keys_state);
+      if (SystemParametersInfoW(SPI_GETMOUSEKEYS, 0, &previous_mouse_keys_state, 0)) {
+        MOUSEKEYS new_mouse_keys_state = {};
+
+        // Enable Mouse Keys
+        new_mouse_keys_state.cbSize = sizeof(new_mouse_keys_state);
+        new_mouse_keys_state.dwFlags = MKF_MOUSEKEYSON | MKF_AVAILABLE;
+        new_mouse_keys_state.iMaxSpeed = 10;
+        new_mouse_keys_state.iTimeToMaxSpeed = 1000;
+        if (SystemParametersInfoW(SPI_SETMOUSEKEYS, 0, &new_mouse_keys_state, 0)) {
+          // Remember to restore the previous settings when we stop streaming
+          enabled_mouse_keys = true;
+        } else {
+          auto winerr = GetLastError();
+          BOOST_LOG(warning) << "Unable to enable Mouse Keys: "sv << winerr;
         }
+      } else {
+        auto winerr = GetLastError();
+        BOOST_LOG(warning) << "Unable to get current state of Mouse Keys: "sv << winerr;
+      }
     }
+  }
 
   void streaming_will_stop() {
     // Demote ourselves back to normal priority class

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1133,34 +1133,37 @@ namespace platf {
         }
       }
     }
-
-    // If there is no mouse connected, enable Mouse Keys to force the cursor to appear
-    if (!GetSystemMetrics(SM_MOUSEPRESENT)) {
-      BOOST_LOG(info) << "A mouse was not detected. Sunshine will enable Mouse Keys while streaming to force the mouse cursor to appear.";
-
-      // Get the current state of Mouse Keys so we can restore it when streaming is over
-      previous_mouse_keys_state.cbSize = sizeof(previous_mouse_keys_state);
-      if (SystemParametersInfoW(SPI_GETMOUSEKEYS, 0, &previous_mouse_keys_state, 0)) {
-        MOUSEKEYS new_mouse_keys_state = {};
-
-        // Enable Mouse Keys
-        new_mouse_keys_state.cbSize = sizeof(new_mouse_keys_state);
-        new_mouse_keys_state.dwFlags = MKF_MOUSEKEYSON | MKF_AVAILABLE;
-        new_mouse_keys_state.iMaxSpeed = 10;
-        new_mouse_keys_state.iTimeToMaxSpeed = 1000;
-        if (SystemParametersInfoW(SPI_SETMOUSEKEYS, 0, &new_mouse_keys_state, 0)) {
-          // Remember to restore the previous settings when we stop streaming
-          enabled_mouse_keys = true;
-        } else {
-          auto winerr = GetLastError();
-          BOOST_LOG(warning) << "Unable to enable Mouse Keys: "sv << winerr;
-        }
-      } else {
-        auto winerr = GetLastError();
-        BOOST_LOG(warning) << "Unable to get current state of Mouse Keys: "sv << winerr;
-      }
-    }
+    enable_mouse_keys();
   }
+
+  void enable_mouse_keys() {
+        // If there is no mouse connected, enable Mouse Keys to force the cursor to appear
+        if (!GetSystemMetrics(SM_MOUSEPRESENT)) {
+          BOOST_LOG(info) << "A mouse was not detected. Sunshine will enable Mouse Keys while streaming to force the mouse cursor to appear.";
+    
+          // Get the current state of Mouse Keys so we can restore it when streaming is over
+          previous_mouse_keys_state.cbSize = sizeof(previous_mouse_keys_state);
+          if (SystemParametersInfoW(SPI_GETMOUSEKEYS, 0, &previous_mouse_keys_state, 0)) {
+            MOUSEKEYS new_mouse_keys_state = {};
+    
+            // Enable Mouse Keys
+            new_mouse_keys_state.cbSize = sizeof(new_mouse_keys_state);
+            new_mouse_keys_state.dwFlags = MKF_MOUSEKEYSON | MKF_AVAILABLE;
+            new_mouse_keys_state.iMaxSpeed = 10;
+            new_mouse_keys_state.iTimeToMaxSpeed = 1000;
+            if (SystemParametersInfoW(SPI_SETMOUSEKEYS, 0, &new_mouse_keys_state, 0)) {
+              // Remember to restore the previous settings when we stop streaming
+              enabled_mouse_keys = true;
+            } else {
+              auto winerr = GetLastError();
+              BOOST_LOG(warning) << "Unable to enable Mouse Keys: "sv << winerr;
+            }
+          } else {
+            auto winerr = GetLastError();
+            BOOST_LOG(warning) << "Unable to get current state of Mouse Keys: "sv << winerr;
+          }
+        }
+    }
 
   void streaming_will_stop() {
     // Demote ourselves back to normal priority class

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1977,6 +1977,10 @@ namespace video {
       }
 
       session->request_normal_frame();
+
+      // While streaming check to see if the mouse is present and enable Mouse Keys to force the cursor to appear
+      // This is useful for KVM switch scenarios where mouse may disappear during streaming
+      platf::enable_mouse_keys();
     }
   }
 


### PR DESCRIPTION
Added continuous checks for a physical mouse while streaming rather than just at the start of streaming. This fix is intended for particular situations on the windows platform when using a KVM switch that changes the cursor from a hardware cursor to a virtual cursor causing windows to not detect a physical cursor while streaming.

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Changed the previous physical mouse checking:

```// If there is no mouse connected, enable Mouse Keys to force the cursor to appear```
``` if (!GetSystemMetrics(SM_MOUSEPRESENT))... ``` 

to it's own function ```void enable_mouse_keys();```. The function is still called at the end of  ```streaming_will_start()``` and now in ```video.cpp``` to continuously check if a physical mouse is present.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
