### PR TITLE
feat(web): Add session management UI for viewing and disconnecting active streams

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -33,6 +33,7 @@
 #include "nvhttp.h"
 #include "platform/common.h"
 #include "process.h"
+#include "stream.h"
 #include "utility.h"
 #include "uuid.h"
 
@@ -330,6 +331,26 @@ namespace confighttp {
     print_req(request);
 
     std::string content = file_handler::read_file(WEB_DIR "clients.html");
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "text/html; charset=utf-8");
+    headers.emplace("X-Frame-Options", "DENY");
+    headers.emplace("Content-Security-Policy", "frame-ancestors 'none';");
+    response->write(content, headers);
+  }
+
+  /**
+   * @brief Get the sessions page.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   */
+  void getSessionsPage(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    std::string content = file_handler::read_file(WEB_DIR "sessions.html");
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", "text/html; charset=utf-8");
     headers.emplace("X-Frame-Options", "DENY");
@@ -826,6 +847,88 @@ namespace confighttp {
   }
 
   /**
+   * @brief Get the list of active streaming sessions.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   *
+   * @api_examples{/api/sessions| GET| null}
+   */
+  void getSessions(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    auto sessions = stream::session::get_all_sessions();
+
+    nlohmann::json sessions_json = nlohmann::json::array();
+    auto now = std::chrono::steady_clock::now();
+
+    for (const auto &session : sessions) {
+      nlohmann::json session_json;
+      session_json["id"] = session.id;
+      session_json["client_name"] = session.client_name;
+      session_json["ip_address"] = session.ip_address;
+
+      // Calculate duration in seconds
+      auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - session.start_time);
+      session_json["duration_seconds"] = duration.count();
+
+      sessions_json.push_back(session_json);
+    }
+
+    nlohmann::json output_tree;
+    output_tree["sessions"] = sessions_json;
+    output_tree["status"] = true;
+    send_response(response, output_tree);
+  }
+
+  /**
+   * @brief Disconnect an active streaming session.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   * The body for the post request should be JSON serialized in the following format:
+   * @code{.json}
+   * {
+   *  "session_id": "<id>"
+   * }
+   * @endcode
+   *
+   * @api_examples{/api/sessions/disconnect| POST| {"session_id":"1234"}}
+   */
+  void disconnectSession(resp_https_t response, req_https_t request) {
+    if (!check_content_type(response, request, "application/json")) {
+      return;
+    }
+    if (!authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    std::stringstream ss;
+    ss << request->content.rdbuf();
+
+    try {
+      nlohmann::json output_tree;
+      const nlohmann::json input_tree = nlohmann::json::parse(ss);
+      const std::string session_id = input_tree.value("session_id", "");
+
+      if (session_id.empty()) {
+        bad_request(response, request, "Missing session_id");
+        return;
+      }
+
+      output_tree["status"] = stream::session::disconnect(session_id);
+      send_response(response, output_tree);
+    } catch (std::exception &e) {
+      BOOST_LOG(warning) << "DisconnectSession: "sv << e.what();
+      bad_request(response, request, e.what());
+    }
+  }
+
+  /**
    * @brief Get the configuration settings.
    * @param response The HTTP response object.
    * @param request The HTTP request object.
@@ -1195,6 +1298,7 @@ namespace confighttp {
     server.resource["^/pin/?$"]["GET"] = getPinPage;
     server.resource["^/apps/?$"]["GET"] = getAppsPage;
     server.resource["^/clients/?$"]["GET"] = getClientsPage;
+    server.resource["^/sessions/?$"]["GET"] = getSessionsPage;
     server.resource["^/config/?$"]["GET"] = getConfigPage;
     server.resource["^/password/?$"]["GET"] = getPasswordPage;
     server.resource["^/welcome/?$"]["GET"] = getWelcomePage;
@@ -1213,6 +1317,8 @@ namespace confighttp {
     server.resource["^/api/clients/unpair-all$"]["POST"] = unpairAll;
     server.resource["^/api/clients/list$"]["GET"] = getClients;
     server.resource["^/api/clients/unpair$"]["POST"] = unpair;
+    server.resource["^/api/sessions$"]["GET"] = getSessions;
+    server.resource["^/api/sessions/disconnect$"]["POST"] = disconnectSession;
     server.resource["^/api/apps/close$"]["POST"] = closeApp;
     server.resource["^/api/covers/upload$"]["POST"] = uploadCover;
     server.resource["^/images/sunshine.ico$"]["GET"] = getFaviconImage;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -266,12 +266,13 @@ namespace nvhttp {
     client_root = client;
   }
 
-  void add_authorized_client(const std::string &name, std::string &&cert) {
+  void add_authorized_client(const std::string &name, std::string &&cert, const std::string &client_unique_id) {
     client_t &client = client_root;
     named_cert_t named_cert;
     named_cert.name = name;
     named_cert.cert = std::move(cert);
-    named_cert.uuid = uuid_util::uuid_t::generate().string();
+    // Use the client's uniqueID so we can match it during session lookup
+    named_cert.uuid = client_unique_id;
     client.named_devices.emplace_back(named_cert);
 
     if (!config::sunshine.flags[config::flag::FRESH_STATE]) {
@@ -485,7 +486,7 @@ namespace nvhttp {
       add_cert->raise(crypto::x509(client.cert));
 
       // The client is now successfully paired and will be authorized to connect
-      add_authorized_client(client.name, std::move(client.cert));
+      add_authorized_client(client.name, std::move(client.cert), client.uniqueID);
     } else {
       tree.put("root.paired", 0);
     }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2073,6 +2073,16 @@ namespace stream {
       return session;
     }
 
+    /**
+     * @brief Get information about all active streaming sessions.
+     *
+     * This function retrieves a list of all currently running streaming sessions,
+     * including client name, IP address, and session start time. It looks up
+     * friendly client names from the paired clients database.
+     *
+     * @return A vector of session_info_t structures describing each active session.
+     *         Returns an empty vector if no sessions are active.
+     */
     std::vector<session_info_t> get_all_sessions() {
       std::vector<session_info_t> result;
 
@@ -2125,6 +2135,16 @@ namespace stream {
       return result;
     }
 
+    /**
+     * @brief Disconnect an active streaming session by its ID.
+     *
+     * This function allows administrators to forcefully terminate a streaming
+     * session from the web UI. It finds the session by its launch_session_id
+     * and calls stop() to cleanly shut it down.
+     *
+     * @param session_id The session ID (as a string) to disconnect.
+     * @return true if the session was found and disconnected, false otherwise.
+     */
     bool disconnect(const std::string &session_id) {
       // Check if any app is running before trying to access broadcast context
       if (proc::proc.running() == 0) {

--- a/src/stream.h
+++ b/src/stream.h
@@ -46,10 +46,33 @@ namespace stream {
       RUNNING,  ///< The session is running
     };
 
+    /**
+     * @brief Information about an active streaming session.
+     */
+    struct session_info_t {
+      std::string id;           ///< Unique session identifier
+      std::string client_name;  ///< Name of the connected client
+      std::string ip_address;   ///< Client's IP address
+      std::chrono::steady_clock::time_point start_time;  ///< When the session started
+    };
+
     std::shared_ptr<session_t> alloc(config_t &config, rtsp_stream::launch_session_t &launch_session);
     int start(session_t &session, const std::string &addr_string);
     void stop(session_t &session);
     void join(session_t &session);
     state_e state(session_t &session);
+
+    /**
+     * @brief Get a list of all active streaming sessions.
+     * @return Vector of session information.
+     */
+    std::vector<session_info_t> get_all_sessions();
+
+    /**
+     * @brief Disconnect a session by its ID.
+     * @param session_id The unique session identifier.
+     * @return true if the session was found and stopped, false otherwise.
+     */
+    bool disconnect(const std::string &session_id);
   }  // namespace session
 }  // namespace stream

--- a/src/stream.h
+++ b/src/stream.h
@@ -50,9 +50,9 @@ namespace stream {
      * @brief Information about an active streaming session.
      */
     struct session_info_t {
-      std::string id;           ///< Unique session identifier
+      std::string id;  ///< Unique session identifier
       std::string client_name;  ///< Name of the connected client
-      std::string ip_address;   ///< Client's IP address
+      std::string ip_address;  ///< Client's IP address
       std::chrono::steady_clock::time_point start_time;  ///< When the session started
     };
 

--- a/src_assets/common/assets/web/Navbar.vue
+++ b/src_assets/common/assets/web/Navbar.vue
@@ -20,6 +20,9 @@
             <a class="nav-link" href="./apps"><i class="fas fa-fw fa-stream"></i> {{ $t('navbar.applications') }}</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="./sessions"><i class="fas fa-fw fa-satellite-dish"></i> {{ $t('navbar.sessions') }}</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="./config"><i class="fas fa-fw fa-cog"></i> {{ $t('navbar.configuration') }}</a>
           </li>
           <li class="nav-item">

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -396,6 +396,7 @@
     "home": "Home",
     "password": "Change Password",
     "pin": "PIN",
+    "sessions": "Sessions",
     "theme_auto": "Auto",
     "theme_dark": "Dark",
     "theme_light": "Light",
@@ -427,6 +428,22 @@
     "resources": "Resources",
     "resources_desc": "Resources for Sunshine!",
     "third_party_notice": "Third Party Notice"
+  },
+  "sessions": {
+    "actions": "Actions",
+    "auto_refresh": "Auto-refresh",
+    "cancel": "Cancel",
+    "client": "Client",
+    "confirm_disconnect": "Are you sure you want to disconnect",
+    "confirm_disconnect_title": "Confirm Disconnect",
+    "disconnect": "Disconnect",
+    "disconnect_error": "Failed to disconnect session",
+    "disconnected": "Session disconnected successfully",
+    "duration": "Duration",
+    "ip_address": "IP Address",
+    "no_sessions": "No active streaming sessions",
+    "refresh": "Refresh",
+    "title": "Active Sessions"
   },
   "troubleshooting": {
     "dd_reset": "Reset Persistent Display Device Settings",

--- a/src_assets/common/assets/web/sessions.html
+++ b/src_assets/common/assets/web/sessions.html
@@ -109,6 +109,7 @@
   import { createApp } from 'vue'
   import { initApp } from './init'
   import Navbar from './Navbar.vue'
+  import { Modal } from 'bootstrap/dist/js/bootstrap'
 
   let app = createApp({
     components: {
@@ -136,7 +137,7 @@
     },
     mounted() {
       // Initialize Bootstrap modal
-      this.modal = new bootstrap.Modal(this.$refs.confirmModal);
+      this.modal = new Modal(this.$refs.confirmModal);
     },
     methods: {
       async fetchSessions() {

--- a/src_assets/common/assets/web/sessions.html
+++ b/src_assets/common/assets/web/sessions.html
@@ -147,6 +147,7 @@
           const data = await response.json();
           if (data.status) {
             this.sessions = data.sessions || [];
+            this.errorMessage = null;  // Clear any previous error on success
           } else {
             this.errorMessage = 'Failed to fetch sessions';
           }

--- a/src_assets/common/assets/web/sessions.html
+++ b/src_assets/common/assets/web/sessions.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="auto">
+
+<head>
+  <%- header %>
+</head>
+
+<body id="app" v-cloak>
+  <Navbar></Navbar>
+  <div id="content" class="container">
+    <div class="d-flex justify-content-between align-items-center my-4">
+      <h1 class="mb-0">{{ $t('sessions.title') }}</h1>
+      <div class="d-flex gap-2 align-items-center">
+        <div class="form-check form-switch">
+          <input class="form-check-input" type="checkbox" id="autoRefresh" v-model="autoRefresh" @change="toggleAutoRefresh">
+          <label class="form-check-label" for="autoRefresh">{{ $t('sessions.auto_refresh') }}</label>
+        </div>
+        <button class="btn btn-outline-primary" @click="fetchSessions" :disabled="loading">
+          <i class="fas fa-sync" :class="{ 'fa-spin': loading }"></i>
+          {{ $t('sessions.refresh') }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="loading && sessions.length === 0" class="text-center my-5">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+
+    <!-- No sessions -->
+    <div v-else-if="sessions.length === 0" class="alert alert-info my-4">
+      <i class="fas fa-info-circle me-2"></i>
+      {{ $t('sessions.no_sessions') }}
+    </div>
+
+    <!-- Sessions table -->
+    <div v-else class="card">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead>
+            <tr>
+              <th>{{ $t('sessions.client') }}</th>
+              <th>{{ $t('sessions.ip_address') }}</th>
+              <th>{{ $t('sessions.duration') }}</th>
+              <th>{{ $t('sessions.actions') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="session in sessions" :key="session.id">
+              <td>
+                <i class="fas fa-desktop me-2 text-primary"></i>
+                {{ session.client_name }}
+              </td>
+              <td>{{ session.ip_address }}</td>
+              <td>{{ formatDuration(session.duration_seconds) }}</td>
+              <td>
+                <button class="btn btn-danger btn-sm" @click="confirmDisconnect(session)">
+                  <i class="fas fa-plug-circle-xmark me-1"></i>
+                  {{ $t('sessions.disconnect') }}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Success alert -->
+    <div v-if="successMessage" class="alert alert-success alert-dismissible fade show mt-3" role="alert">
+      <i class="fas fa-check-circle me-2"></i>
+      {{ successMessage }}
+      <button type="button" class="btn-close" @click="successMessage = null"></button>
+    </div>
+
+    <!-- Error alert -->
+    <div v-if="errorMessage" class="alert alert-danger alert-dismissible fade show mt-3" role="alert">
+      <i class="fas fa-exclamation-triangle me-2"></i>
+      {{ errorMessage }}
+      <button type="button" class="btn-close" @click="errorMessage = null"></button>
+    </div>
+
+    <!-- Confirmation Modal -->
+    <div class="modal fade" id="confirmModal" tabindex="-1" ref="confirmModal">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">{{ $t('sessions.confirm_disconnect_title') }}</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <p>{{ $t('sessions.confirm_disconnect') }} <strong>{{ sessionToDisconnect?.client_name }}</strong>?</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ $t('sessions.cancel') }}</button>
+            <button type="button" class="btn btn-danger" @click="disconnectSession" :disabled="disconnecting">
+              <span v-if="disconnecting" class="spinner-border spinner-border-sm me-1"></span>
+              {{ $t('sessions.disconnect') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+<script type="module">
+  import { createApp } from 'vue'
+  import { initApp } from './init'
+  import Navbar from './Navbar.vue'
+
+  let app = createApp({
+    components: {
+      Navbar
+    },
+    data() {
+      return {
+        sessions: [],
+        loading: true,
+        autoRefresh: true,
+        refreshInterval: null,
+        sessionToDisconnect: null,
+        disconnecting: false,
+        successMessage: null,
+        errorMessage: null,
+        modal: null
+      }
+    },
+    async created() {
+      await this.fetchSessions();
+      this.startAutoRefresh();
+    },
+    beforeUnmount() {
+      this.stopAutoRefresh();
+    },
+    mounted() {
+      // Initialize Bootstrap modal
+      this.modal = new bootstrap.Modal(this.$refs.confirmModal);
+    },
+    methods: {
+      async fetchSessions() {
+        this.loading = true;
+        try {
+          const response = await fetch('./api/sessions');
+          const data = await response.json();
+          if (data.status) {
+            this.sessions = data.sessions || [];
+          } else {
+            this.errorMessage = 'Failed to fetch sessions';
+          }
+        } catch (e) {
+          console.error('Error fetching sessions:', e);
+          this.errorMessage = 'Error fetching sessions';
+        }
+        this.loading = false;
+      },
+      formatDuration(seconds) {
+        if (seconds < 60) {
+          return `${seconds}s`;
+        } else if (seconds < 3600) {
+          const mins = Math.floor(seconds / 60);
+          const secs = seconds % 60;
+          return `${mins}m ${secs}s`;
+        } else {
+          const hours = Math.floor(seconds / 3600);
+          const mins = Math.floor((seconds % 3600) / 60);
+          return `${hours}h ${mins}m`;
+        }
+      },
+      confirmDisconnect(session) {
+        this.sessionToDisconnect = session;
+        this.modal.show();
+      },
+      async disconnectSession() {
+        if (!this.sessionToDisconnect) return;
+
+        this.disconnecting = true;
+        try {
+          const response = await fetch('./api/sessions/disconnect', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ session_id: this.sessionToDisconnect.id })
+          });
+          const data = await response.json();
+
+          this.modal.hide();
+
+          if (data.status) {
+            this.successMessage = this.$t('sessions.disconnected');
+            await this.fetchSessions();
+          } else {
+            this.errorMessage = this.$t('sessions.disconnect_error');
+          }
+        } catch (e) {
+          console.error('Error disconnecting session:', e);
+          this.modal.hide();
+          this.errorMessage = this.$t('sessions.disconnect_error');
+        }
+        this.disconnecting = false;
+        this.sessionToDisconnect = null;
+
+        // Clear messages after 5 seconds
+        setTimeout(() => {
+          this.successMessage = null;
+          this.errorMessage = null;
+        }, 5000);
+      },
+      toggleAutoRefresh() {
+        if (this.autoRefresh) {
+          this.startAutoRefresh();
+        } else {
+          this.stopAutoRefresh();
+        }
+      },
+      startAutoRefresh() {
+        if (this.refreshInterval) {
+          clearInterval(this.refreshInterval);
+        }
+        this.refreshInterval = setInterval(() => {
+          this.fetchSessions();
+        }, 5000);
+      },
+      stopAutoRefresh() {
+        if (this.refreshInterval) {
+          clearInterval(this.refreshInterval);
+          this.refreshInterval = null;
+        }
+      }
+    }
+  });
+
+  initApp(app);
+</script>

--- a/vite.config.js
+++ b/vite.config.js
@@ -71,6 +71,7 @@ export default defineConfig({
                 index: resolve(assetsSrcPath, 'index.html'),
                 password: resolve(assetsSrcPath, 'password.html'),
                 pin: resolve(assetsSrcPath, 'pin.html'),
+                sessions: resolve(assetsSrcPath, 'sessions.html'),
                 troubleshooting: resolve(assetsSrcPath, 'troubleshooting.html'),
                 welcome: resolve(assetsSrcPath, 'welcome.html'),
             },


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

This PR adds a new **Sessions** page to the Sunshine web UI that allows administrators to view and manage active streaming sessions.

### Features:
- **View active streaming sessions** - See all currently connected Moonlight clients with their name, IP address, and session duration
- **Disconnect sessions** - Terminate streaming sessions directly from the web interface with a confirmation dialog
- **Auto-refresh** - Sessions list automatically updates every 5 seconds (with toggle to disable)
- **Manual refresh** - Button to manually refresh the session list

### Implementation Details:

**Backend (C++):**
- Added `session::get_all_sessions()` function in `stream.cpp` to enumerate active sessions thread-safely
- Added `session::disconnect()` function to terminate sessions by ID
- Added `GET /api/sessions` endpoint to retrieve session list as JSON
- Added `POST /api/sessions/disconnect` endpoint to terminate a session
- Fixed client name lookup by storing client's uniqueID during pairing (previously generated random UUID which couldn't be matched)

**Frontend (Vue.js):**
- New `sessions.html` page following existing UI patterns
- Bootstrap 5 modal for disconnect confirmation
- Auto-refresh toggle with 5-second interval
- Proper error handling and user feedback

**Files Changed:**
- `src/stream.h` - Added `session_info_t` struct and function declarations
- `src/stream.cpp` - Implemented session enumeration and disconnect functions
- `src/confighttp.cpp` - Added API endpoints and page route
- `src/nvhttp.cpp` - Fixed to store client's uniqueID during pairing
- `src_assets/common/assets/web/sessions.html` - New sessions page
- `src_assets/common/assets/web/Navbar.vue` - Added Sessions link to navigation
- `src_assets/common/assets/web/public/assets/locale/en.json` - Added translations
- `vite.config.js` - Added sessions.html to build inputs

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
![sessions_empty](https://github.com/user-attachments/assets/8487a325-d47e-422e-8bbc-a6eda4282662)
**Empty state (no active sessions):**
[Screenshot: Sessions page showing "No active streaming sessions" message]


**With active session:**
![sessions_one_pc](https://github.com/user-attachments/assets/ff1173a6-72c3-4358-bf30-c283786753c1)
[Screenshot: Sessions page showing client "yoga" connected from 10.0.0.2 with Disconnect button]

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Closes https://github.com/LizardByte/Sunshine/pull/5137


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes

---

**Notes:**
- Existing paired clients will display their UUID until re-paired (due to the uniqueID storage fix)
- Thread-safe access to session list using existing `sync_util::sync_t` patterns
- Tested on Windows with NVIDIA GPU