### PR TITLE
fix(linux/wlr): Fix dmabuf buffer params protocol violation/leak

### DIFF
--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -454,6 +454,7 @@ namespace wl {
     self->current_wl_buffer = buffer;
 
     // Start the actual copy
+    zwp_linux_buffer_params_v1_destroy(params);
     zwlr_screencopy_frame_v1_copy(frame, buffer);
   }
 
@@ -468,6 +469,7 @@ namespace wl {
     BOOST_LOG(error) << "Failed to create buffer from params"sv;
     self->cleanup_gbm();
 
+    zwp_linux_buffer_params_v1_destroy(params);
     zwlr_screencopy_frame_v1_destroy(frame);
     self->status = REINIT;
   }


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
Fixes a clear [wayland protocol](https://wayland.app/protocols/linux-dmabuf-v1#zwp_linux_buffer_params_v1:event:created) violation:

> Upon receiving this event, the client should destroy the zwp_linux_buffer_params_v1 object.

I don't know much about these protocols either, but using kms was starting to annoy me, so I thought I'd sit down and just read them, and seems like they were used wrong. This showed as a small memory leak and hyprland self destructing when the stream ended with several hundred thousand of these params resources collected apparently.

I've tested this with one 6 hour stream while I slept, memory leak was gone and the stream ended gracefully.

As a sidenote, the screencopy protocol is deprecated and marked for removal in wlroots 0.22, clients expected to migrate to extcopy, probably some time this year...

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #3854

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
