### PR TITLE
fix(linux): Split service unit into privileged and unprivileged variants

### DIFF
--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -18,6 +18,8 @@ if(${SUNSHINE_BUILD_APPIMAGE} OR ${SUNSHINE_BUILD_FLATPAK})
             DESTINATION "${SUNSHINE_ASSETS_DIR}/modules-load.d")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service"
             DESTINATION "${SUNSHINE_ASSETS_DIR}/systemd/user")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine-kms.service"
+            DESTINATION "${SUNSHINE_ASSETS_DIR}/systemd/user")
 else()
     find_package(Systemd)
     find_package(Udev)
@@ -28,6 +30,8 @@ else()
     endif()
     if(SYSTEMD_FOUND)
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine.service"
+                DESTINATION "${SYSTEMD_USER_UNIT_INSTALL_DIR}")
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sunshine-kms.service"
                 DESTINATION "${SYSTEMD_USER_UNIT_INSTALL_DIR}")
         install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/linux/misc/60-sunshine.conf"
                 DESTINATION "${SYSTEMD_MODULES_LOAD_DIR}")

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -62,6 +62,10 @@ if(FREEBSD)
     list(APPEND CPACK_POST_BUILD_SCRIPTS "${CMAKE_MODULE_PATH}/packaging/freebsd_custom_cpack.cmake")
 endif()
 
+# Apply setcap for RPM
+# https://github.com/coreos/rpm-ostree/discussions/5036#discussioncomment-10291071
+set(CPACK_RPM_USER_FILELIST "%caps(cap_sys_admin+p) ${SUNSHINE_EXECUTABLE_PATH}")
+
 # Dependencies
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "\

--- a/cmake/prep/special_package_configuration.cmake
+++ b/cmake/prep/special_package_configuration.cmake
@@ -26,6 +26,7 @@ elseif(UNIX)
 
     # configure service
     configure_file(packaging/linux/sunshine.service.in sunshine.service @ONLY)
+    configure_file(packaging/linux/sunshine-kms.service.in sunshine-kms.service @ONLY)
 
     # configure the arch linux pkgbuild
     if(${SUNSHINE_CONFIGURE_PKGBUILD})

--- a/docs/building.md
+++ b/docs/building.md
@@ -50,12 +50,12 @@ pkg install -y \
 #### Linux
 Dependencies vary depending on the distribution. You can reference our
 [linux_build.sh](https://github.com/LizardByte/Sunshine/blob/master/scripts/linux_build.sh) script for a list of
-dependencies we use in Debian-based, Fedora-based and Arch-based distributions. Please submit a PR if you would like to
-extend the script to support other distributions.
+dependencies we use in Debian-based, Fedora-based and Arch-based distributions. Please submit a PR if you would like to extend the
+script to support other distributions.
 
 ##### KMS Capture
-If you are using KMS, patching the Sunshine binary with `setcap` is required. Some post-install scripts handle this.
-If building from source and using the binary directly, this will also work:
+If you are using KMS, patching the Sunshine binary with `setcap` is required. Some post-install scripts handle this. If building
+from source and using the binary directly, this will also work:
 
 ```bash
 sudo cp build/sunshine /tmp

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -433,8 +433,8 @@ After adding yourself to the group, log out and log back in for the changes to t
 sudo setcap cap_sys_admin+p $(readlink -f $(which sunshine))
 ```
 
-#### X11/XDG Capture
-For X11 or XDG Portal capture to work, you may need to disable the capabilities that were set for KMS capture.
+#### X11 Capture
+For X11 capture to work, you may need to disable the capabilities that were set for KMS capture.
 
 ```bash
 sudo setcap -r $(readlink -f $(which sunshine))

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -419,28 +419,11 @@ After adding yourself to the group, log out and log back in for the changes to t
 
 ### Linux
 
-#### KMS Capture
-
-> [!WARNING]
-> Capture of most Wayland-based desktop environments will fail unless this step is performed.
+#### Services
 
 > [!NOTE]
-> `cap_sys_admin` may as well be root, except you don't need to be root to run the program. This is necessary to
-> allow Sunshine to use KMS capture.
-
-##### Enable
-```bash
-sudo setcap cap_sys_admin+p $(readlink -f $(which sunshine))
-```
-
-#### X11 Capture
-For X11 capture to work, you may need to disable the capabilities that were set for KMS capture.
-
-```bash
-sudo setcap -r $(readlink -f $(which sunshine))
-```
-
-#### Service
+> Two service unit files are available. Pick "sunshine" for unprivileged XDG Portal or X11 capture, otherwise
+> pick "sunshine-kms" for privileged KMS capture.
 
 **Start once**
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -160,10 +160,12 @@ sudo usermod -aG input $USER
 ```
 
 ### KMS Streaming fails
-If screencasting fails with KMS, you may need to run the following to force unprivileged screencasting.
+If screencasting fails with KMS, you may be using the unprivileged sunshine service unit. Switch to the privileged
+sunshine-kms service:
 
 ```bash
-sudo setcap -r $(readlink -f $(which sunshine))
+systemctl --user disable sunshine
+systemctl --user enable sunshine-kms --now
 ```
 
 > [!NOTE]

--- a/packaging/linux/AppImage/AppRun
+++ b/packaging/linux/AppImage/AppRun
@@ -58,6 +58,7 @@ function install() {
   cp -r "$SUNSHINE_SHARE_HERE/systemd/user/" ~/.config/systemd/
   # patch service executable path
   sed -i -e "s#$SUNSHINE_PATH#$(readlink -f $ARGV0)#g" ~/.config/systemd/user/sunshine.service
+  sed -i -e "s#$SUNSHINE_PATH#$(readlink -f $ARGV0)#g" ~/.config/systemd/user/sunshine-kms.service
 
   # setcap
   sudo setcap cap_sys_admin+p "$(readlink -f "$SUNSHINE_BIN_HERE")"
@@ -72,6 +73,7 @@ function remove() {
 
   # remove service
   sudo rm -f ~/.config/systemd/user/sunshine.service
+  sudo rm -f ~/.config/systemd/user/sunshine-kms.service
 }
 
 # process arguments

--- a/packaging/linux/AppImage/AppRun
+++ b/packaging/linux/AppImage/AppRun
@@ -58,6 +58,9 @@ function install() {
   cp -r "$SUNSHINE_SHARE_HERE/systemd/user/" ~/.config/systemd/
   # patch service executable path
   sed -i -e "s#$SUNSHINE_PATH#$(readlink -f $ARGV0)#g" ~/.config/systemd/user/sunshine.service
+
+  # setcap
+  sudo setcap cap_sys_admin+p "$(readlink -f "$SUNSHINE_BIN_HERE")"
 }
 
 function remove() {

--- a/packaging/linux/Arch/sunshine.install
+++ b/packaging/linux/Arch/sunshine.install
@@ -1,3 +1,7 @@
+do_setcap() {
+  setcap cap_sys_admin+p $(readlink -f usr/bin/sunshine)
+}
+
 do_udev_reload() {
   udevadm control --reload-rules
   udevadm trigger --property-match=DEVNAME=/dev/uinput
@@ -7,11 +11,13 @@ do_udev_reload() {
 }
 
 post_install() {
+  do_setcap
   do_udev_reload
   modprobe uhid
 }
 
 post_upgrade() {
+  do_setcap
   do_udev_reload
   modprobe uhid
 }

--- a/packaging/linux/copr/Sunshine.spec
+++ b/packaging/linux/copr/Sunshine.spec
@@ -282,10 +282,6 @@ xvfb-run ./tests/test_sunshine
 cd %{_builddir}/Sunshine/build
 %make_install
 
-# setcap will break XDG Desktop Portal's security policy, so create a copy that can have elevated capabilities
-# this is only necessary for immutable distributions with rpm-ostree
-install -Dm755 %{_builddir}/Sunshine/build/sunshine %{_bindir}/sunshine-kms
-
 %post
 # Note: this is copied from the postinst script
 
@@ -314,7 +310,8 @@ fi
 
 %files
 # Executables
-%caps(cap_sys_admin+p) %{_bindir}/sunshine-kms
+%caps(cap_sys_admin+p) %{_bindir}/sunshine
+%caps(cap_sys_admin+p) %{_bindir}/sunshine-*
 
 # Systemd unit file for user services
 %{_userunitdir}/sunshine.service

--- a/packaging/linux/copr/Sunshine.spec
+++ b/packaging/linux/copr/Sunshine.spec
@@ -284,7 +284,7 @@ cd %{_builddir}/Sunshine/build
 
 # setcap will break XDG Desktop Portal's security policy, so create a copy that can have elevated capabilities
 # this is only necessary for immutable distributions with rpm-ostree
-install -Dm755 %{_builddir}/Sunshine/build/sunshine %{buildroot}%{_bindir}/sunshine-kms
+install -Dm755 %{_builddir}/Sunshine/build/sunshine %{_bindir}/sunshine-kms
 
 %post
 # Note: this is copied from the postinst script
@@ -314,8 +314,6 @@ fi
 
 %files
 # Executables
-%{_bindir}/sunshine
-%{_bindir}/sunshine-%{build_version}
 %caps(cap_sys_admin+p) %{_bindir}/sunshine-kms
 
 # Systemd unit file for user services

--- a/packaging/linux/copr/Sunshine.spec
+++ b/packaging/linux/copr/Sunshine.spec
@@ -313,8 +313,9 @@ fi
 %caps(cap_sys_admin+p) %{_bindir}/sunshine
 %caps(cap_sys_admin+p) %{_bindir}/sunshine-*
 
-# Systemd unit file for user services
+# Systemd unit files for user services
 %{_userunitdir}/sunshine.service
+%{_userunitdir}/sunshine-kms.service
 
 # Udev rules
 %{_udevrulesdir}/*-sunshine.rules

--- a/packaging/linux/flatpak/scripts/additional-install.sh
+++ b/packaging/linux/flatpak/scripts/additional-install.sh
@@ -3,8 +3,9 @@
 # User Service
 mkdir -p ~/.config/systemd/user
 cp "/app/share/sunshine/systemd/user/sunshine.service" "$HOME/.config/systemd/user/sunshine.service"
-echo "Sunshine User Service has been installed."
-echo "Use [systemctl --user enable sunshine] once to autostart Sunshine on login."
+cp "/app/share/sunshine/systemd/user/sunshine-kms.service" "$HOME/.config/systemd/user/sunshine-kms.service"
+echo "Sunshine User Services have been installed."
+echo "Use [systemctl --user enable sunshine] or [systemctl --user enable sunshine-kms] once to autostart Sunshine on login."
 
 # Load uhid (DS5 emulation)
 UHID=$(cat /app/share/sunshine/modules-load.d/60-sunshine.conf)

--- a/packaging/linux/flatpak/scripts/remove-additional-install.sh
+++ b/packaging/linux/flatpak/scripts/remove-additional-install.sh
@@ -3,8 +3,9 @@
 # User Service
 systemctl --user stop sunshine
 rm "$HOME/.config/systemd/user/sunshine.service"
+rm "$HOME/.config/systemd/user/sunshine-kms.service"
 systemctl --user daemon-reload
-echo "Sunshine User Service has been removed."
+echo "Sunshine User Services have been removed."
 
 # Remove rules
 flatpak-spawn --host pkexec sh -c "rm /etc/modules-load.d/60-sunshine.conf"

--- a/packaging/linux/sunshine-kms.service.in
+++ b/packaging/linux/sunshine-kms.service.in
@@ -2,7 +2,7 @@
 Description=@PROJECT_DESCRIPTION@
 StartLimitIntervalSec=500
 StartLimitBurst=5
-Conflicts=sunshine-kms.service
+Conflicts=sunshine.service
 
 [Service]
 # Avoid starting Sunshine before the desktop is fully initialized.
@@ -11,7 +11,6 @@ ExecStartPre=/bin/sleep 5
 @SUNSHINE_SERVICE_STOP_COMMAND@
 Restart=on-failure
 RestartSec=5s
-NoNewPrivileges=true
 
 [Install]
 WantedBy=xdg-desktop-autostart.target

--- a/src_assets/linux/misc/postinst
+++ b/src_assets/linux/misc/postinst
@@ -8,6 +8,18 @@ modprobe uhid
 if [ ! -x "$(command -v rpm-ostree)" ]; then
   echo "Not in an rpm-ostree environment, proceeding with post install steps."
 
+  # Ensure Sunshine can grab images from KMS
+  path_to_setcap=$(which setcap)
+  path_to_sunshine=$(readlink -f "$(which sunshine)")
+  if [ -x "$path_to_setcap" ] ; then
+    echo "Setting CAP_SYS_ADMIN capability on Sunshine binary."
+    echo "$path_to_setcap cap_sys_admin+p $path_to_sunshine"
+    $path_to_setcap cap_sys_admin+p $path_to_sunshine
+    echo "CAP_SYS_ADMIN capability set on Sunshine binary."
+  else
+    echo "error: setcap not found or not executable."
+  fi
+
   # Trigger udev rule reload for /dev/uinput and /dev/uhid
   path_to_udevadm=$(which udevadm)
   if [ -x "$path_to_udevadm" ] ; then


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
Split service unit into privileged and unprivileged variants needed for XDG Portal. Technically a breaking change because the default "sunshine" service will now run unprivileged, so user action is needed to restore KMS capture functionality (switch to sunshine-kms service).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [x] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [x] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
