### PR TITLE
fix(linux/xdgportal): basic frame pacing support

### DIFF
--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -295,6 +295,8 @@ namespace egl {
 
     // Increment sequence when new rgb_t needs to be created
     std::uint64_t sequence;
+    // pts metadata from pipewire
+    std::optional<std::uint64_t> pts;
   };
 
   class sws_t {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
* Fetch pts and seq pipewire metadata to use as duplicate detection and
  for accurate frame_timestamp calculation (to 100ms limit).
* Duplicate frames are interpreted as timeouts, even though snapshot()
  usually returns duplicate frames immediately.
* Don't send fake frames on timeouts. Rationale: timeouts are recoverable.
* Change capture flow to better accommodate pipewire behaviour:
  - Old behaviour: sleep until next_frame deadline, grab frame, send.
  - New behaviour: grab, send. On timeout, sleep 1ms and retry grab
    until deadline is exceeded, then resync deadline. After 100x1ms retries,
    enter regular deadline waiting mode. On success, sleep until deadline.
  - This flow greatly reduces missed frames due to pipewire sending frames
    at unpredictable intervals, especially when vsync is disabled.
  - This flow (particularly sleeping after send) may also improve latency.
  - New flow seems to have reasonable CPU usage. ~5% CPU in top for 60fps,
    3% for 30fps in-game or static desktop on 60fps stream.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
