### PR TITLE
fix(linux): fix touch misalignment for wlgrab on scaled outputs

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -903,9 +903,10 @@ namespace input {
   }
 
   /**
-   * @brief Called to pass a touch message to the platform backend.
-   * @param input The input context pointer.
-   * @param packet The touch packet.
+   * @brief Normalizes coordinates to monitor-local logical touch dimensions.
+   * @param touch_port The current touch port metadata.
+   * @param coords The in/out coordinate pair to normalize.
+   * @return The monitor-local touch port, or std::nullopt if dimensions are invalid.
    */
   std::optional<platf::touch_port_t> monitor_touch_port(const input::touch_port_t &touch_port, std::pair<float, float> &coords) {
     const float monitor_logical_w = (touch_port.width * touch_port.scalar_inv) / touch_port.scalar_tpcoords;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -919,16 +919,25 @@ namespace input {
     }
 
     auto &touch_port = input->touch_port;
+
+    // Compute the monitor's logical dimensions from touch port fields
+    float monitor_logical_w = (touch_port.width * touch_port.scalar_inv) / touch_port.scalar_tpcoords;
+    float monitor_logical_h = (touch_port.height * touch_port.scalar_inv) / touch_port.scalar_tpcoords;
+
     platf::touch_port_t abs_port {
       touch_port.offset_x,
       touch_port.offset_y,
-      touch_port.env_width,
-      touch_port.env_height
+      (int) monitor_logical_w,
+      (int) monitor_logical_h
     };
 
-    // Renormalize the coordinates
-    coords->first /= abs_port.width;
-    coords->second /= abs_port.height;
+    // Convert from desktop-absolute to monitor-relative
+    coords->first -= touch_port.offset_x;
+    coords->second -= touch_port.offset_y;
+
+    // Normalize to [0, 1] within the monitor
+    coords->first /= monitor_logical_w;
+    coords->second /= monitor_logical_h;
 
     // Normalize rotation value to 0-359 degree range
     auto rotation = util::endian::little(packet->rotation);
@@ -975,16 +984,25 @@ namespace input {
     }
 
     auto &touch_port = input->touch_port;
+
+    // Compute the monitor's logical dimensions from touch port fields
+    float monitor_logical_w = (touch_port.width * touch_port.scalar_inv) / touch_port.scalar_tpcoords;
+    float monitor_logical_h = (touch_port.height * touch_port.scalar_inv) / touch_port.scalar_tpcoords;
+
     platf::touch_port_t abs_port {
       touch_port.offset_x,
       touch_port.offset_y,
-      touch_port.env_width,
-      touch_port.env_height
+      (int) monitor_logical_w,
+      (int) monitor_logical_h
     };
 
-    // Renormalize the coordinates
-    coords->first /= abs_port.width;
-    coords->second /= abs_port.height;
+    // Convert from desktop-absolute to monitor-relative
+    coords->first -= touch_port.offset_x;
+    coords->second -= touch_port.offset_y;
+
+    // Normalize to [0, 1] within the monitor
+    coords->first /= monitor_logical_w;
+    coords->second /= monitor_logical_h;
 
     // Normalize rotation value to 0-359 degree range
     auto rotation = util::endian::little(packet->rotation);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -927,6 +927,11 @@ namespace input {
     };
   }
 
+  /**
+   * @brief Called to pass a touch message to the platform backend.
+   * @param input The input context pointer.
+   * @param packet The touch packet.
+   */
   void passthrough(std::shared_ptr<input_t> &input, PSS_TOUCH_PACKET packet) {
     if (!config::input.mouse) {
       return;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -77,16 +77,16 @@ namespace wl {
       this->logical_width = monitor->viewport.logical_width;
       this->logical_height = monitor->viewport.logical_height;
 
-      int env_logical_width = 0;
-      int env_logical_height = 0;
-      for (auto &output : interface.monitors) {
-        auto output_monitor = output.get();
-        env_logical_width = std::max(env_logical_width, output_monitor->viewport.offset_x + output_monitor->viewport.logical_width);
-        env_logical_height = std::max(env_logical_height, output_monitor->viewport.offset_y + output_monitor->viewport.logical_height);
+      int desktop_logical_width = 0;
+      int desktop_logical_height = 0;
+      for (auto &monitor_entry : interface.monitors) {
+        auto output_monitor = monitor_entry.get();
+        desktop_logical_width = std::max(desktop_logical_width, output_monitor->viewport.offset_x + output_monitor->viewport.logical_width);
+        desktop_logical_height = std::max(desktop_logical_height, output_monitor->viewport.offset_y + output_monitor->viewport.logical_height);
       }
 
-      this->env_logical_width = env_logical_width;
-      this->env_logical_height = env_logical_height;
+      this->env_logical_width = desktop_logical_width;
+      this->env_logical_height = desktop_logical_height;
 
       BOOST_LOG(info) << "Selected monitor ["sv << monitor->description << "] for streaming"sv;
       BOOST_LOG(debug) << "Offset: "sv << offset_x << 'x' << offset_y;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -18,6 +18,8 @@ using namespace std::literals;
 namespace wl {
   static int env_width;
   static int env_height;
+  static int env_logical_width;
+  static int env_logical_height;
 
   struct img_t: public platf::img_t {
     ~img_t() override {
@@ -74,10 +76,17 @@ namespace wl {
       this->env_width = ::wl::env_width;
       this->env_height = ::wl::env_height;
 
+      this->logical_width = monitor->viewport.logical_width;
+      this->logical_height = monitor->viewport.logical_height;
+      this->env_logical_width = ::wl::env_logical_width;
+      this->env_logical_height = ::wl::env_logical_height;
+
       BOOST_LOG(info) << "Selected monitor ["sv << monitor->description << "] for streaming"sv;
       BOOST_LOG(debug) << "Offset: "sv << offset_x << 'x' << offset_y;
       BOOST_LOG(debug) << "Resolution: "sv << width << 'x' << height;
+      BOOST_LOG(debug) << "Logical Resolution: "sv << logical_width << 'x' << logical_height;
       BOOST_LOG(debug) << "Desktop Resolution: "sv << env_width << 'x' << env_height;
+      BOOST_LOG(debug) << "Logical Desktop Resolution: "sv << env_logical_width << 'x' << env_logical_height;
 
       return 0;
     }
@@ -414,6 +423,8 @@ namespace platf {
 
     wl::env_width = 0;
     wl::env_height = 0;
+    wl::env_logical_width = 0;
+    wl::env_logical_height = 0;
 
     for (auto &monitor : interface.monitors) {
       monitor->listen(interface.output_manager);
@@ -428,6 +439,8 @@ namespace platf {
 
       wl::env_width = std::max(wl::env_width, (int) (monitor->viewport.offset_x + monitor->viewport.width));
       wl::env_height = std::max(wl::env_height, (int) (monitor->viewport.offset_y + monitor->viewport.height));
+      wl::env_logical_width = std::max(wl::env_logical_width, (int) (monitor->viewport.offset_x + monitor->viewport.logical_width));
+      wl::env_logical_height = std::max(wl::env_logical_height, (int) (monitor->viewport.offset_y + monitor->viewport.logical_height));
 
       BOOST_LOG(info) << "Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
PR #4607 added logical dimension tracking and `scalar_tpcoords` scaling support for the `kmsgrab` (KMS/DRM) capture backend, but my configuration (niri, multimonitor, scaled hidpi output) was still mapping input to the wrong portion of the desktop.  

This PR tries to mirror the pattern used in `kmsgrab.cpp` to `wlgrab.cpp`:
- Adds `env_logical_width` / `env_logical_height` statics to the `wl` namespace
- Sets `logical_width`, `logical_height`, `env_logical_width`, `env_logical_height` on the display object during `wlr_t::init()`

Additionally, the touch and pen passthrough functions in `input.cpp` are updated to normalize coordinates relative to the streamed monitor rather than the full desktop. 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Partially fixes #2166 for wlgrab



#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
