### PR TITLE
feat(confighttp): make the api/logs more elegant

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1111,7 +1111,7 @@ namespace confighttp {
     if (!in || !in.seekg(static_cast<std::streamoff>(prev_size))) {
       return nullptr;
     }
-    const auto tail_len = static_cast<std::size_t>(current_size - prev_size);
+    const auto tail_len = current_size - prev_size;
     std::string tail(tail_len, '\0');
     if (!in.read(tail.data(), static_cast<std::streamsize>(tail_len))) {
       return nullptr;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1114,7 +1114,7 @@ namespace confighttp {
     static std::atomic<std::uintmax_t> cached_log_size { 0 };
     static std::atomic<std::intmax_t> cached_log_mtime_ns { 0 };
 
-    const auto &log_path = config::sunshine.log_file;
+    const std::filesystem::path log_path(config::sunshine.log_file);
 
     // Check file status
     std::error_code ec;
@@ -1128,7 +1128,7 @@ namespace confighttp {
 
     // Read file again if it has changed
     if (current_size != cached_log_size.load() || current_mtime_ns != cached_log_mtime_ns.load()) {
-      auto new_content = std::make_shared<const std::string>(file_handler::read_file(log_path.c_str()));
+      auto new_content = std::make_shared<const std::string>(file_handler::read_file(log_path.string().c_str()));
       cached_log.store(new_content);
       cached_log_size.store(current_size);
       cached_log_mtime_ns.store(current_mtime_ns);
@@ -1148,7 +1148,7 @@ namespace confighttp {
       try {
         client_offset = std::stoull(it->second);
       }
-      catch (...) {
+      catch (const std::exception &) {
         client_offset = 0;
       }
     }

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -205,9 +205,14 @@
         console.error(e);
       }
       try {
-        this.logs = (await fetch("./api/logs").then(r => r.text()))
+        const response = await fetch("./api/logs");
+        if (!response.ok) {
+          console.error('Failed to fetch logs: HTTP', response.status);
+        } else {
+          this.logs = await response.text();
+        }
       } catch (e) {
-        console.error(e);
+        console.error('Failed to fetch logs:', e);
       }
       this.loading = false;
     },

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -206,10 +206,10 @@
       }
       try {
         const response = await fetch("./api/logs");
-        if (!response.ok) {
-          console.error('Failed to fetch logs: HTTP', response.status);
-        } else {
+        if (response.ok) {
           this.logs = await response.text();
+        } else {
+          console.error('Failed to fetch logs: HTTP', response.status);
         }
       } catch (e) {
         console.error('Failed to fetch logs:', e);

--- a/src_assets/common/assets/web/troubleshooting.html
+++ b/src_assets/common/assets/web/troubleshooting.html
@@ -237,6 +237,7 @@
           logs: 'Loading...',
           logFilter: null,
           logInterval: null,
+          logOffset: 0,
           restartPressed: false,
           showApplyMessage: false,
           platform: "",
@@ -386,22 +387,63 @@
             }
           });
 
-        this.logInterval = setInterval(() => {
-          this.refreshLogs();
-        }, 5000);
         this.refreshLogs();
+        this.startLogRefresh();
         this.refreshClients();
+
+        const handleVisibilityChange = () => {
+          if (document.hidden) {
+            this.stopLogRefresh();
+          } else {
+            this.refreshLogs();
+            this.startLogRefresh();
+          }
+        };
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        this._visibilityCleanup = () => document.removeEventListener('visibilitychange', handleVisibilityChange);
       },
       beforeDestroy() {
-        clearInterval(this.logInterval);
+        this.stopLogRefresh();
+        if (this._visibilityCleanup) this._visibilityCleanup();
       },
       methods: {
-        refreshLogs() {
-          fetch("./api/logs",)
-            .then((r) => r.text())
-            .then((r) => {
-              this.logs = r;
-            });
+        startLogRefresh() {
+          this.stopLogRefresh();
+          this.logInterval = setInterval(() => this.refreshLogs(), 5000);
+        },
+        stopLogRefresh() {
+          if (this.logInterval != null) {
+            clearInterval(this.logInterval);
+            this.logInterval = null;
+          }
+        },
+        async refreshLogs() {
+          try {
+            const headers = this.logOffset > 0 ? { 'X-Log-Offset': String(this.logOffset) } : {};
+            const response = await fetch('./api/logs', { headers });
+
+            if (response.status === 304) {
+              return;
+            }
+
+            if (!response.ok) {
+              console.error('Failed to refresh logs: HTTP', response.status);
+              return;
+            }
+
+            const newSize = parseInt(response.headers.get('X-Log-Size') || '0', 10);
+            const text = await response.text();
+
+            if (!this.logOffset || newSize < this.logOffset) {
+              this.logs = text;
+            } else if (text.length > 0) {
+              this.logs += text;
+            }
+
+            this.logOffset = newSize;
+          } catch (e) {
+            console.error('Failed to refresh logs:', e);
+          }
         },
         closeApp() {
           this.closeAppPressed = true;

--- a/src_assets/common/assets/web/troubleshooting.html
+++ b/src_assets/common/assets/web/troubleshooting.html
@@ -431,7 +431,7 @@
               return;
             }
 
-            const newSize = parseInt(response.headers.get('X-Log-Size') || '0', 10);
+            const newSize = Number.parseInt(response.headers.get('X-Log-Size') || '0', 10);
             const text = await response.text();
 
             if (!this.logOffset || newSize < this.logOffset) {

--- a/src_assets/common/assets/web/troubleshooting.html
+++ b/src_assets/common/assets/web/troubleshooting.html
@@ -419,10 +419,14 @@
         },
         async refreshLogs() {
           try {
-            const headers = this.logOffset > 0 ? { 'X-Log-Offset': String(this.logOffset) } : {};
+            const offset = Number(this.logOffset);
+            const headers = (!Number.isNaN(offset) && offset > 0) ? { 'X-Log-Offset': String(offset) } : {};
             const response = await fetch('./api/logs', { headers });
 
             if (response.status === 304) {
+              const sizeHeader = response.headers.get('X-Log-Size');
+              const size = Number.parseInt(sizeHeader || '0', 10);
+              this.logOffset = Number.isNaN(size) || size < 0 ? 0 : size;
               return;
             }
 
@@ -431,13 +435,15 @@
               return;
             }
 
-            const newSize = Number.parseInt(response.headers.get('X-Log-Size') || '0', 10);
+            const rawSize = Number.parseInt(response.headers.get('X-Log-Size') || '0', 10);
+            const newSize = Number.isNaN(rawSize) || rawSize < 0 ? 0 : rawSize;
+            const logRange = (response.headers.get('X-Log-Range') || '').trim().toLowerCase();
             const text = await response.text();
 
-            if (!this.logOffset || newSize < this.logOffset) {
-              this.logs = text;
-            } else if (text.length > 0) {
+            if (logRange === 'incremental' && text.length > 0) {
               this.logs += text;
+            } else {
+              this.logs = text;
             }
 
             this.logOffset = newSize;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
I think the log interface returns the full amount every time, which is an unreasonable mechanism.
Of course, I did consider using SSE, but it's not a good fit here. It would just introduce unnecessary complexity and over-engineering. So I tried to do these things.

Logs API improvements:

- Incremental fetch: client sends X-Log-Offset in request header, server returns only new bytes and X-Log-Size in response. Avoids re-sending the full file every 5s.
- HTTP 304 when offset already equals file size (no body).
- Backend cache: re-read log file only when size or mtime changes; use std::atomic<std::shared_ptr<const std::string>> for thread-safe access without locks.
- Pause polling when tab is hidden (Page Visibility API); resume and refresh when visible.
- Handle non-2xx and 304 so failed responses don’t overwrite existing log content.
- Sunshine uses `try_incremental_log_read` to avoid getting the full logs every time.

============
I know that modifying code related to file operations is an act that is prone to dangerous problems.
Therefore, I suggest that this PR should not be in a hurry to integrate, I will use it locally for a long time to see the stability.

BTW, I added log files to  `sunshinesvc.cpp` on PC, so I could know when Sunshine.exe had a safe and unsafe restart.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
<img width="1190" height="407" alt="image" src="https://github.com/user-attachments/assets/c0081abc-1b65-46a3-877f-12bf26a91480" />


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
