### PR TITLE
chores: drop unused nvenc(ffmpeg) encoder

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -517,24 +517,14 @@ namespace video {
   encoder_t nvenc {
     "nvenc"sv,
     std::make_unique<encoder_platform_formats_avcodec>(
-  #ifdef _WIN32
-      AV_HWDEVICE_TYPE_D3D11VA,
-      AV_HWDEVICE_TYPE_NONE,
-      AV_PIX_FMT_D3D11,
-  #else
       AV_HWDEVICE_TYPE_CUDA,
       AV_HWDEVICE_TYPE_NONE,
       AV_PIX_FMT_CUDA,
-  #endif
       AV_PIX_FMT_NV12,
       AV_PIX_FMT_P010,
       AV_PIX_FMT_NONE,
       AV_PIX_FMT_NONE,
-  #ifdef _WIN32
-      dxgi_init_avcodec_hardware_input_buffer
-  #else
       cuda_init_avcodec_hardware_input_buffer
-  #endif
     ),
     {
       // Common options


### PR DESCRIPTION
## Description

drop unused nvenc(ffmpeg) encoder

It never be used on Windows, drop it.

## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [x] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
