### PR TITLE
fix(linux/xdgportal): don't pass `external_only` argument to `eglQueryDmaBufModifiersEXT`

### DIFF
--- a/src/platform/linux/portalgrab.cpp
+++ b/src/platform/linux/portalgrab.cpp
@@ -1371,8 +1371,7 @@ namespace portal {
 
         EGLint num_modifiers = 0;
         std::array<EGLuint64KHR, MAX_DMABUF_MODIFIERS> mods = {0};
-        EGLBoolean external_only;
-        eglQueryDmaBufModifiersEXT(egl_display, dmabuf_formats[i], MAX_DMABUF_MODIFIERS, mods.data(), &external_only, &num_modifiers);
+        eglQueryDmaBufModifiersEXT(egl_display, dmabuf_formats[i], MAX_DMABUF_MODIFIERS, mods.data(), nullptr, &num_modifiers);
 
         if (num_modifiers > MAX_DMABUF_MODIFIERS) {
           BOOST_LOG(warning) << "Some DMA-BUF modifiers are being ignored"sv;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
`eglQueryDmaBufModifiersEXT` function accepts an array of booleans in an `external_only` argument, not a single boolean, as documented [here](https://github.com/KhronosGroup/EGL-Registry/blob/3ae2b7c48690d2ce13cc6db3db02dfc0572be65e/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt#L198).

Passing a single boolean may lead to buffer overflow and some local variables of being overridden - e.g. an `i` variable:
```gdb
(gdb) watch i
Hardware watchpoint 2: i
(gdb) c
Continuing.
Thread 1 "test_sunshine" hit Hardware watchpoint 2: i

Old value = 21
New value = 0
0x00007ffff049eb06 in ?? () from /usr/lib/libEGL_nvidia.so.0
(gdb) bt
#0  0x00007ffff049eb06 in ??? () at /usr/lib/libEGL_nvidia.so.0
#1  0x00007ffff047dd3d in ??? () at /usr/lib/libEGL_nvidia.so.0
#2  0x00005555565ae1e5 in portal::portal_t::query_dmabuf_formats (this=0x555558e8e040, egl_display=0x555558bd96b0) at /data/cache-yay/leenr/sunshine-git/src/sunshine/src/platform/linux/portalgrab.cpp:1217
#3  0x00005555565af49e in portal::portal_t::get_dmabuf_modifiers (this=0x555558e8e040) at /data/cache-yay/leenr/sunshine-git/src/sunshine/src/platform/linux/portalgrab.cpp:1273
```
This, in turn, leads to `for` loop not stopping as it eventually should, and after some time - to an assertion while trying to write to `dmabuf_infos[n_dmabuf_infos]`:
```
/usr/include/c++/15.2.1/array:210: constexpr std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) [with _Tp = portal::dmabuf_format_info_t; long unsigned int _Nm = 200; reference = portal::dmabuf_format_info_t&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```
due to `n_dmabuf_infos` reaching `MAX_DMABUF_FORMATS`.

Because `external_only` value is actually not used, it should be safe to just not pass the address at all.
Alternatively, this patch works too:
```diff
-        EGLBoolean external_only;
-        eglQueryDmaBufModifiersEXT(egl_display, dmabuf_formats[i], MAX_DMABUF_MODIFIERS, mods.data(), &external_only, &num_modifiers);
+        std::array<EGLBoolean, MAX_DMABUF_MODIFIERS> external_only;
+        eglQueryDmaBufModifiersEXT(egl_display, dmabuf_formats[i], MAX_DMABUF_MODIFIERS, mods.data(), external_only.data(), &num_modifiers);
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes