### PR TITLE
fix(linux/kms): resolve connector names in output_name config

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1157,6 +1157,7 @@ namespace config {
 
     string_f(vars, "external_ip", nvhttp.external_ip);
     list_prep_cmd_f(vars, "global_prep_cmd", config::sunshine.prep_cmds);
+    list_prep_cmd_f(vars, "pre_probe_cmd", config::sunshine.pre_probe_cmds);
 
     string_f(vars, "audio_sink", audio.sink);
     string_f(vars, "virtual_sink", audio.virtual_sink);

--- a/src/config.h
+++ b/src/config.h
@@ -259,6 +259,7 @@ namespace config {
     bool notify_pre_releases;
     bool system_tray;
     std::vector<prep_cmd_t> prep_cmds;
+    std::vector<prep_cmd_t> pre_probe_cmds;
   };
 
   extern video_t video;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -810,6 +810,39 @@ namespace nvhttp {
     }
   }
 
+  /**
+   * @brief Execute pre-probe commands before encoder probing.
+   * @param launch_session The session to extract client parameters from (may be null for undo-only).
+   * @param execute_do If true, run "do" commands; if false, run "undo" commands.
+   */
+  static void run_pre_probe_cmds(
+      const std::shared_ptr<rtsp_stream::launch_session_t> &launch_session,
+      bool execute_do) {
+    for (auto &cmd : config::sunshine.pre_probe_cmds) {
+      auto &cmd_str = execute_do ? cmd.do_cmd : cmd.undo_cmd;
+      if (cmd_str.empty()) continue;
+
+      boost::process::v1::environment env = boost::this_process::environment();
+      if (launch_session) {
+        env["SUNSHINE_CLIENT_WIDTH"] = std::to_string(launch_session->width);
+        env["SUNSHINE_CLIENT_HEIGHT"] = std::to_string(launch_session->height);
+        env["SUNSHINE_CLIENT_FPS"] = std::to_string(launch_session->fps);
+        env["SUNSHINE_CLIENT_HDR"] = launch_session->enable_hdr ? "true" : "false";
+      }
+
+      std::error_code ec;
+      boost::filesystem::path working_dir(".");
+      BOOST_LOG(info) << "Executing pre-probe cmd: ["sv << cmd_str << ']';
+      auto child = platf::run_command(cmd.elevated, true, cmd_str, working_dir, env, nullptr, ec, nullptr);
+      if (ec) {
+        BOOST_LOG(warning) << "Pre-probe cmd failed: "sv << ec.message();
+      }
+      else {
+        child.wait();
+      }
+    }
+  }
+
   void launch(bool &host_audio, resp_https_t response, req_https_t request) {
     print_req<SunshineHTTPS>(request);
 
@@ -863,6 +896,10 @@ namespace nvhttp {
       // The display should be restored in case something fails as there are no other sessions.
       revert_display_configuration = true;
 
+      // Run pre-probe commands (e.g. enable virtual display) before anything
+      // that depends on a connected monitor.
+      run_pre_probe_cmds(launch_session, true);
+
       // We want to prepare display only if there are no active sessions at
       // the moment. This should be done before probing encoders as it could
       // change the active displays.
@@ -877,6 +914,7 @@ namespace nvhttp {
         tree.put("root.<xmlattr>.status_message", "Failed to initialize video capture/encoding. Is a display connected and turned on?");
         tree.put("root.gamesession", 0);
 
+        run_pre_probe_cmds(launch_session, false);
         return;
       }
     }
@@ -968,6 +1006,10 @@ namespace nvhttp {
     const auto launch_session = make_launch_session(host_audio, args);
 
     if (no_active_sessions) {
+      // Run pre-probe commands (e.g. enable virtual display) before anything
+      // that depends on a connected monitor.
+      run_pre_probe_cmds(launch_session, true);
+
       // We want to prepare display only if there are no active sessions at
       // the moment. This should be done before probing encoders as it could
       // change the active displays.
@@ -982,6 +1024,7 @@ namespace nvhttp {
         tree.put("root.<xmlattr>.status_code", 503);
         tree.put("root.<xmlattr>.status_message", "Failed to initialize video capture/encoding. Is a display connected and turned on?");
 
+        run_pre_probe_cmds(launch_session, false);
         return;
       }
     }
@@ -1033,8 +1076,15 @@ namespace nvhttp {
       proc::proc.terminate();
     }
 
+    // Undo pre-probe commands (e.g. disable virtual display).
+    run_pre_probe_cmds(nullptr, false);
+
     // The config needs to be reverted regardless of whether "proc::proc.terminate()" was called or not.
     display_device::revert_configuration();
+  }
+
+  void undo_pre_probe_cmds() {
+    run_pre_probe_cmds(nullptr, false);
   }
 
   void appasset(resp_https_t response, req_https_t request) {

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -53,6 +53,11 @@ namespace nvhttp {
   void start();
 
   /**
+   * @brief Run the undo commands of all pre_probe_cmds.
+   */
+  void undo_pre_probe_cmds();
+
+  /**
    * @brief Setup the nvhttp server.
    * @param pkey
    * @param cert

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -594,6 +594,68 @@ namespace platf {
       BOOST_LOG(debug) << ss.str();
     }
 
+    /**
+     * @brief Resolve a display name to a numeric monitor index.
+     *
+     * Accepts either a plain numeric index ("0", "1", ...) or a DRM connector
+     * name in the form "{type}-{index}" (e.g. "DP-2", "HDMI-A-1").
+     * Connector names are matched against the card_descriptors populated by
+     * kms_display_names(), reusing the same parsing logic as correlate_to_wayland().
+     *
+     * @param display_name The user-provided output_name value.
+     * @return The resolved monitor index, or -1 on failure.
+     */
+    static int resolve_display_name(const std::string &display_name) {
+      // If the name is purely numeric, use it directly as a monitor index
+      bool all_digits = !display_name.empty();
+      for (auto c : display_name) {
+        if (!std::isdigit(static_cast<unsigned char>(c))) {
+          all_digits = false;
+          break;
+        }
+      }
+
+      if (all_digits) {
+        return util::from_view(display_name);
+      }
+
+      // Try to parse as connector name: "{type}-{index}" (e.g. "DP-2", "HDMI-A-1")
+      auto dash_pos = display_name.find_last_of('-');
+      if (dash_pos == std::string::npos || dash_pos == 0 || dash_pos == display_name.size() - 1) {
+        return -1;
+      }
+
+      auto type_str = std::string_view(display_name).substr(0, dash_pos);
+      auto index_str = std::string_view(display_name).substr(dash_pos + 1);
+
+      // Verify the suffix is numeric before calling util::from_view()
+      for (auto c : index_str) {
+        if (!std::isdigit(static_cast<unsigned char>(c))) {
+          return -1;
+        }
+      }
+
+      auto type = kms::from_view(type_str);
+      auto index = std::max<std::int64_t>(1, util::from_view(index_str));
+
+      if (type == DRM_MODE_CONNECTOR_Unknown) {
+        return -1;
+      }
+
+      // Search card_descriptors (populated by kms_display_names() before init() runs)
+      for (auto &cd : card_descriptors) {
+        for (auto &[crtc_id, mon] : cd.crtc_to_monitor) {
+          if (mon.type == type && mon.index == index) {
+            BOOST_LOG(info) << "Resolved connector name '"sv << display_name
+                            << "' to monitor index "sv << mon.monitor_index;
+            return mon.monitor_index;
+          }
+        }
+      }
+
+      return -1;
+    }
+
     class display_t: public platf::display_t {
     public:
       display_t(mem_type_e mem_type):
@@ -604,7 +666,12 @@ namespace platf {
       int init(const std::string &display_name, const ::video::config_t &config) {
         delay = std::chrono::nanoseconds {1s} / config.framerate;
 
-        int monitor_index = util::from_view(display_name);
+        int monitor_index = resolve_display_name(display_name);
+        if (monitor_index < 0) {
+          BOOST_LOG(error) << "Could not resolve output name '"sv << display_name
+                           << "'. Use a numeric index (0, 1, 2, ...) or a connector name (DP-1, HDMI-A-1, ...)"sv;
+          return -1;
+        }
         int monitor = 0;
 
         fs::path card_dir {"/dev/dri"sv};

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -34,6 +34,9 @@ namespace fs = std::filesystem;
 
 namespace platf {
 
+  // Forward declaration: refresh card_descriptors for connector name resolution
+  std::vector<std::string> kms_display_names(mem_type_e hwdevice_type);
+
   namespace kms {
 
     class cap_sys_admin {
@@ -642,14 +645,24 @@ namespace platf {
         return -1;
       }
 
-      // Search card_descriptors (populated by kms_display_names() before init() runs)
-      for (auto &cd : card_descriptors) {
-        for (auto &[crtc_id, mon] : cd.crtc_to_monitor) {
-          if (mon.type == type && mon.index == index) {
-            BOOST_LOG(info) << "Resolved connector name '"sv << display_name
-                            << "' to monitor index "sv << mon.monitor_index;
-            return mon.monitor_index;
+      // Search card_descriptors, refreshing once if the connector is not found.
+      // This handles the case where pre_probe_cmd just enabled a virtual display
+      // that wasn't present when card_descriptors was initially populated.
+      for (int attempt = 0; attempt < 2; ++attempt) {
+        for (auto &cd : card_descriptors) {
+          for (auto &[crtc_id, mon] : cd.crtc_to_monitor) {
+            if (mon.type == type && mon.index == index) {
+              BOOST_LOG(info) << "Resolved connector name '"sv << display_name
+                              << "' to monitor index "sv << mon.monitor_index;
+              return mon.monitor_index;
+            }
           }
+        }
+
+        if (attempt == 0) {
+          BOOST_LOG(info) << "Connector '"sv << display_name
+                          << "' not found in cached descriptors, refreshing display list..."sv;
+          kms_display_names(mem_type_e::unknown);
         }
       }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include "input.h"
 #include "logging.h"
 #include "network.h"
+#include "nvhttp.h"
 #include "platform/common.h"
 #include "process.h"
 #include "stream.h"
@@ -1950,6 +1951,9 @@ namespace stream {
           // We have no app running and also no clients anymore.
           revert_display_config = true;
         }
+
+        // Undo pre-probe commands (e.g. disable virtual display).
+        nvhttp::undo_pre_probe_cmds();
 
         if (revert_display_config) {
           display_device::revert_configuration();

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1171,6 +1171,14 @@ namespace video {
           return;
         }
       }
+
+      // If output_name is a connector name (e.g. "DP-2") rather than a numeric
+      // index, it won't match the numeric display_names list. Add it directly
+      // so display_t::init() can resolve the connector name.
+      if (!output_name.empty()) {
+        display_names.emplace_back(output_name);
+        current_display_index = display_names.size() - 1;
+      }
     }
   }
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

This PR adds support for DRM connector names in `output_name` and introduces `pre_probe_cmd` for virtual display lifecycle management on Linux/KMS.

**Commit 1 - fix(linux/kms): resolve connector names in output_name config**
When `output_name` is set to a DRM connector name like `DP-2`, `util::from_view()` silently converts it to a garbage integer. Added `resolve_display_name()` that accepts both numeric indices (backward compatible) and connector names.

**Commit 2 - feat: add pre_probe_cmd config option**
New config option (same JSON syntax as `global_prep_cmd`) that runs commands before encoder probing. Enables virtual display on-demand lifecycle: enable on stream connect, disable on disconnect. Client parameters exposed as env vars (`SUNSHINE_CLIENT_WIDTH`, `HEIGHT`, `FPS`, `HDR`).

**Commit 3 - fix(linux/kms): refresh card_descriptors when connector not found**
When `pre_probe_cmd` enables a virtual display, the connector is not yet in `card_descriptors` (populated at startup). `resolve_display_name()` now retries once after refreshing the display list.

**Commit 4 - fix(video): add connector name fallback in refresh_displays**
When `output_name` is a connector name, it won't match the numeric `display_names` list, causing the wrong monitor to be streamed. Added fallback that appends the connector name directly.

**Use case:** Virtual monitor driven by custom EDID firmware, kept disabled when not streaming. On stream connect, `pre_probe_cmd` enables the display via `kscreen-doctor`, on disconnect the undo command disables it.

Example `sunshine.conf`:
```
output_name = DP-2
pre_probe_cmd = [{"do":"sunshine-display-manager on","undo":"sunshine-display-manager off"}]
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
N/A (no UI changes)

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes

AI tool used: Claude Code (Opus 4.6). The concept, architecture, and testing were done by the author; Claude Code assisted with implementation, debugging, and commit messages.