### PR TITLE
feat(linux/xdgportal): implement event-driven capture

### DIFF
--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -301,6 +301,8 @@ namespace egl {
     // PipeWire metadata
     std::optional<uint64_t> pts;
     std::optional<uint64_t> seq;
+    std::optional<bool> pw_damage;
+    std::optional<uint32_t> pw_flags;
   };
 
   class sws_t {

--- a/src/platform/linux/portalgrab.cpp
+++ b/src/platform/linux/portalgrab.cpp
@@ -723,6 +723,24 @@ namespace portal {
 
     ~pipewire_t() {
       cleanup_stream();
+
+      pw_thread_loop_lock(loop);
+
+      if (core) {
+        pw_core_disconnect(core);
+        core = nullptr;
+      }
+      if (context) {
+        pw_context_destroy(context);
+        context = nullptr;
+      }
+
+      pw_thread_loop_unlock(loop);
+
+      pw_thread_loop_stop(loop);
+      if (fd >= 0) {
+        close(fd);
+      }
       pw_thread_loop_destroy(loop);
     }
 
@@ -775,21 +793,8 @@ namespace portal {
           pw_stream_destroy(stream_data.stream);
           stream_data.stream = nullptr;
         }
-        if (core) {
-          pw_core_disconnect(core);
-          core = nullptr;
-        }
-        if (context) {
-          pw_context_destroy(context);
-          context = nullptr;
-        }
 
         pw_thread_loop_unlock(loop);
-
-        pw_thread_loop_stop(loop);
-        if (fd >= 0) {
-          close(fd);
-        }
       }
       session_cache_t::instance().invalidate();
     }
@@ -1299,6 +1304,8 @@ namespace portal {
             stream_stopped.store(false);
             previous_height.store(0);
             previous_width.store(0);
+            // Delay interrupt signal to give Portal time to detect change
+            std::this_thread::sleep_for(std::chrono::milliseconds(1500));
             return platf::capture_e::interrupted;
           } else {
             BOOST_LOG(warning) << "PipeWire stream disconnected. Forcing session reset."sv;

--- a/src/platform/linux/portalgrab.cpp
+++ b/src/platform/linux/portalgrab.cpp
@@ -734,6 +734,14 @@ namespace portal {
       return stream_data.frame_cv;
     }
 
+    bool is_frame_ready() const {
+      return stream_data.frame_ready;
+    }
+
+    void set_frame_ready(bool ready) {
+      stream_data.frame_ready = ready;
+    }
+
     void init(int stream_fd, int stream_node, std::shared_ptr<shared_state_t> shared_state) {
       fd = stream_fd;
       node = stream_node;
@@ -843,20 +851,37 @@ namespace portal {
       }
 
       // 2. Validate we have a buffer and a signal that it's "new"
-      if (stream_data.current_buffer && stream_data.frame_ready) {
+      if (stream_data.current_buffer) {
         struct spa_buffer *buf = stream_data.current_buffer->buffer;
 
         if (buf->datas[0].chunk->size != 0) {
           const auto img_descriptor = static_cast<egl::img_descriptor_t *>(img);
           img_descriptor->frame_timestamp = std::chrono::steady_clock::now();
 
-          // Passthrough PipeWire metadata
+          // PipeWire header metadata
           struct spa_meta_header *h = static_cast<struct spa_meta_header *>(
             spa_buffer_find_meta_data(buf, SPA_META_Header, sizeof(*h))
           );
           if (h) {
             img_descriptor->seq = h->seq;
             img_descriptor->pts = h->pts;
+          }
+
+          // PipeWire flags
+          if (buf->n_datas > 0) {
+            img_descriptor->pw_flags = buf->datas[0].chunk->flags;
+          }
+
+          // PipeWire damage metadata
+          struct spa_meta_region *damage = (struct spa_meta_region *) spa_buffer_find_meta_data(
+            stream_data.current_buffer->buffer,
+            SPA_META_VideoDamage,
+            sizeof(*damage)
+          );
+          if (damage) {
+            img_descriptor->pw_damage = (damage->region.size.width > 0 && damage->region.size.height > 0);
+          } else {
+            img_descriptor->pw_damage = std::nullopt;
           }
 
           if (buf->datas[0].type == SPA_DATA_DmaBuf) {
@@ -874,10 +899,6 @@ namespace portal {
             // Point the encoder to the front buffer
             img->data = stream_data.front_buffer->data();
             img->row_pitch = stream_data.local_stride;
-
-            // Reset flags
-            stream_data.frame_ready = false;
-            stream_data.current_buffer = nullptr;
           }
         }
       } else {
@@ -1088,7 +1109,7 @@ namespace portal {
 
       // Ack the buffer type and metadata
       std::array<uint8_t, SPA_POD_BUFFER_SIZE> buffer;
-      std::array<const struct spa_pod *, 2> params;
+      std::array<const struct spa_pod *, 3> params;
       int n_params = 0;
       struct spa_pod_builder pod_builder = SPA_POD_BUILDER_INIT(buffer.data(), buffer.size());
       auto buffer_param = static_cast<const struct spa_pod *>(spa_pod_builder_add_object(&pod_builder, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers, SPA_PARAM_BUFFERS_dataType, SPA_POD_Int(buffer_types)));
@@ -1096,6 +1117,10 @@ namespace portal {
       n_params++;
       auto meta_param = static_cast<const struct spa_pod *>(spa_pod_builder_add_object(&pod_builder, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_Header), SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_header))));
       params[n_params] = meta_param;
+      n_params++;
+      int videoDamageRegionCount = 16;
+      auto damage_param = static_cast<const struct spa_pod *>(spa_pod_builder_add_object(&pod_builder, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage), SPA_PARAM_META_size, SPA_POD_CHOICE_RANGE_Int(sizeof(struct spa_meta_region) * videoDamageRegionCount, sizeof(struct spa_meta_region) * 1, sizeof(struct spa_meta_region) * videoDamageRegionCount)));
+      params[n_params] = damage_param;
       n_params++;
 
       pw_stream_update_params(d->stream, params.data(), n_params);
@@ -1192,9 +1217,17 @@ namespace portal {
 
     platf::capture_e snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool show_cursor) {
       // FIXME: show_cursor is ignored
-      auto start_time = std::chrono::steady_clock::now();
+      auto deadline = std::chrono::steady_clock::now() + timeout;
+      int retries = 0;
 
       while (true) {
+        if (!wait_for_frame(deadline)) {
+          if (stream_stopped.load()) {
+            return platf::capture_e::interrupted;
+          }
+          return platf::capture_e::timeout;
+        }
+
         if (!pull_free_image_cb(img_out)) {
           return platf::capture_e::interrupted;
         }
@@ -1204,35 +1237,27 @@ namespace portal {
         pipewire.fill_img(img_egl);
 
         // Check if we got valid data (either DMA-BUF fd or memory pointer)
-        bool is_valid_data = (img_egl->sd.fds[0] >= 0 || img_egl->data != nullptr);
+        bool is_valid = (img_egl->sd.fds[0] >= 0 || img_egl->data != nullptr);
+        // Check for duplicates
+        bool is_dup = last_pts.has_value() && is_buffer_redundant(img_egl, last_pts);
 
-        // Duplicate detection: PipeWire seq increments on each new frame,
-        // pts advances with each buffer update. Both must advance to accept frame.
-        bool is_duplicate = (img_egl->seq.has_value() && img_egl->pts.has_value() && last_pts.has_value() && last_seq.has_value() && img_egl->pts.value() == last_pts.value() && img_egl->seq.value() == last_seq.value());
-
-        if (is_valid_data && !is_duplicate) {
-          // Frame found; check deadline
-          auto end_time = std::chrono::steady_clock::now();
-          if (end_time - start_time > timeout) {
+        // Valid & non-duplicate frame
+        if (is_valid && !is_dup) {
+          // Check deadline
+          if (std::chrono::steady_clock::now() >= deadline) {
             return platf::capture_e::timeout;
           }
 
-          if (img_egl->seq.has_value() && img_egl->pts.has_value()) {
-            last_seq = img_egl->seq.value();
-            last_pts = img_egl->pts.value();
-          }
-          img_egl->sequence = ++sequence;
+          // Update frame metadata
+          update_frame_metadata(img_egl, retries);
           return platf::capture_e::ok;
         }
 
         // No valid frame yet, or it was a duplicate
-        auto now = std::chrono::steady_clock::now();
-        if (now - start_time >= timeout) {
+        retries++;
+        if (std::chrono::steady_clock::now() >= deadline) {
           return platf::capture_e::timeout;
         }
-
-        std::unique_lock lock(pipewire.frame_mutex());
-        pipewire.frame_cv().wait_until(lock, start_time + timeout);
       }
     }
 
@@ -1349,6 +1374,61 @@ namespace portal {
     }
 
   private:
+    static bool is_buffer_redundant(const egl::img_descriptor_t *img, const std::optional<uint64_t> &last_pts) {
+      // Check for corrupted frame
+      if (img->pw_flags.has_value()) {
+        if (img->pw_flags.value() & SPA_CHUNK_FLAG_CORRUPTED) {
+          return true;
+        }
+      }
+
+      // Damage & PTS checks
+      if (img->pts.has_value() && last_pts.has_value()) {
+        int64_t delta = (int64_t) img->pts.value() - (int64_t) last_pts.value();
+
+        // PTS hasn't advanced:
+        if (delta <= 0) {
+          // Case A: Compositor says "No Damage"
+          if (img->pw_damage.has_value() && !img->pw_damage.value()) {
+            BOOST_LOG(debug) << "Dropping frame: PTS delta 0 and Damage metadata confirms NO pixels changed."sv;
+            return true;
+          }
+          // Case B: No damage metadata available, but delta is 0
+          if (!img->pw_damage.has_value()) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+
+    void update_frame_metadata(egl::img_descriptor_t *img_egl, int retries) {
+      if (img_egl->seq.has_value() && img_egl->pts.has_value()) {
+        last_seq = img_egl->seq.value();
+        last_pts = img_egl->pts.value();
+      }
+      img_egl->sequence = ++sequence;
+
+      if (retries > 0) {
+        BOOST_LOG(debug) << "Processed frame after " << retries << " redundant events."sv;
+      }
+    }
+
+    bool wait_for_frame(std::chrono::steady_clock::time_point deadline) {
+      std::unique_lock<std::mutex> lock(pipewire.frame_mutex());
+
+      bool success = pipewire.frame_cv().wait_until(lock, deadline, [&] {
+        return pipewire.is_frame_ready() || stream_stopped.load();
+      });
+
+      if (success && !stream_stopped.load()) {
+        pipewire.set_frame_ready(false);
+        return true;
+      }
+      return false;
+    }
+
     static uint32_t lookup_pw_format(uint64_t fourcc) {
       for (const auto &fmt : format_map) {
         if (fmt.fourcc == 0) {

--- a/src/platform/linux/portalgrab.cpp
+++ b/src/platform/linux/portalgrab.cpp
@@ -1225,45 +1225,30 @@ namespace portal {
       auto deadline = std::chrono::steady_clock::now() + timeout;
       int retries = 0;
 
-      while (true) {
+      while (std::chrono::steady_clock::now() < deadline) {
         if (!wait_for_frame(deadline)) {
-          if (stream_stopped.load()) {
-            return platf::capture_e::interrupted;
-          }
-          return platf::capture_e::timeout;
+          return stream_stopped.load() ? platf::capture_e::interrupted : platf::capture_e::timeout;
         }
 
         if (!pull_free_image_cb(img_out)) {
           return platf::capture_e::interrupted;
         }
 
-        const auto img_egl = static_cast<egl::img_descriptor_t *>(img_out.get());
+        auto *img_egl = static_cast<egl::img_descriptor_t *>(img_out.get());
         img_egl->reset();
         pipewire.fill_img(img_egl);
 
-        // Check if we got valid data (either DMA-BUF fd or memory pointer)
-        bool is_valid = (img_egl->sd.fds[0] >= 0 || img_egl->data != nullptr);
-        // Check for duplicates
-        bool is_dup = last_pts.has_value() && is_buffer_redundant(img_egl, last_pts);
-
-        // Valid & non-duplicate frame
-        if (is_valid && !is_dup) {
-          // Check deadline
-          if (std::chrono::steady_clock::now() >= deadline) {
-            return platf::capture_e::timeout;
-          }
-
+        // Check if we got valid data (either DMA-BUF fd or memory pointer), then filter duplicates
+        if ((img_egl->sd.fds[0] >= 0 || img_egl->data != nullptr) && !is_buffer_redundant(img_egl)) {
           // Update frame metadata
-          update_frame_metadata(img_egl, retries);
+          update_metadata(img_egl, retries);
           return platf::capture_e::ok;
         }
 
         // No valid frame yet, or it was a duplicate
         retries++;
-        if (std::chrono::steady_clock::now() >= deadline) {
-          return platf::capture_e::timeout;
-        }
       }
+      return platf::capture_e::timeout;
     }
 
     std::shared_ptr<platf::img_t> alloc_img() override {
@@ -1381,41 +1366,24 @@ namespace portal {
     }
 
   private:
-    static bool is_buffer_redundant(const egl::img_descriptor_t *img, const std::optional<uint64_t> &last_pts) {
+    bool is_buffer_redundant(const egl::img_descriptor_t *img) {
       // Check for corrupted frame
-      if (img->pw_flags.has_value()) {
-        if (img->pw_flags.value() & SPA_CHUNK_FLAG_CORRUPTED) {
-          return true;
-        }
+      if (img->pw_flags.has_value() && (img->pw_flags.value() & SPA_CHUNK_FLAG_CORRUPTED)) {
+        return true;
       }
 
-      // Damage & PTS checks
-      if (img->pts.has_value() && last_pts.has_value()) {
-        int64_t delta = (int64_t) img->pts.value() - (int64_t) last_pts.value();
-
-        // PTS hasn't advanced:
-        if (delta <= 0) {
-          // Case A: Compositor says "No Damage"
-          if (img->pw_damage.has_value() && !img->pw_damage.value()) {
-            BOOST_LOG(debug) << "Dropping frame: PTS delta 0 and Damage metadata confirms NO pixels changed."sv;
-            return true;
-          }
-          // Case B: No damage metadata available, but delta is 0
-          if (!img->pw_damage.has_value()) {
-            return true;
-          }
-        }
+      // If PTS is identical, only drop if damage metadata confirms no change
+      if (img->pts.has_value() && last_pts.has_value() && img->pts.value() == last_pts.value()) {
+        return img->pw_damage.has_value() && !img->pw_damage.value();
       }
 
       return false;
     }
 
-    void update_frame_metadata(egl::img_descriptor_t *img_egl, int retries) {
-      if (img_egl->seq.has_value() && img_egl->pts.has_value()) {
-        last_seq = img_egl->seq.value();
-        last_pts = img_egl->pts.value();
-      }
-      img_egl->sequence = ++sequence;
+    void update_metadata(egl::img_descriptor_t *img, int retries) {
+      last_seq = img->seq;
+      last_pts = img->pts;
+      img->sequence = ++sequence;
 
       if (retries > 0) {
         BOOST_LOG(debug) << "Processed frame after " << retries << " redundant events."sv;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

```
feat(linux/xdgportal): implement event-driven capture

Summary of changes:
* Synchronized capture:
  - Move frame_cv wait to beginning of loop as a more efficient way to
    wait for a new buffer whilst ensuring that unintentional buffer
    reuse doesn't occur.
* Improved duplicate detection:
  - Transition to duplicate detection logic using a combination
    of SPA_META_Header (PTS) and SPA_META_VideoDamage metadata.
  - Drop frames when PTS delta is zero and no damage is reported;
    this helps to smoothen out stuttering unique to KWin.
```

Additional fixes:
```
fix(linux/xdgportal): fix pipewire teardown logic, GNOME XDG stop icon

* Destroying the core and context during a reinit can cause a deadlock
which can be reproduced when PW_STREAM_FLAG_RT_PROCESS is set. Fix
by ensuring that full teardown is only done in pipewire destructor.
* Add a delay before sending the interrupt signal, as the GNOME
XDG portal needs time to detect changes, otherwise Sunshine will
crash when the users manually stops the stream on mutter.
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [x] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
