### PR TITLE
fix(linux/wlgrab): add frame_timestamp using wayland's ready timestamp

### DIFF
--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -485,7 +485,7 @@ namespace wl {
 
     std::uint64_t sec = (std::uint64_t(tv_sec_hi) << 32) | tv_sec_lo;
     auto ready_ts = std::chrono::seconds(sec) + std::chrono::nanoseconds(tv_nsec);
-    current_frame->frame_timestamp = std::chrono::steady_clock::time_point{
+    current_frame->frame_timestamp = std::chrono::steady_clock::time_point {
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(ready_ts)
     };
 

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -31,6 +31,7 @@ namespace wl {
     void destroy();
 
     egl::surface_descriptor_t sd;
+    std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
   };
 
   class dmabuf_t {

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -29,7 +29,18 @@ namespace wl {
   class wlr_t: public platf::display_t {
   public:
     int init(platf::mem_type_e hwdevice_type, const std::string &display_name, const ::video::config_t &config) {
-      delay = std::chrono::nanoseconds {1s} / config.framerate;
+      // calculate frame interval we should capture at
+      if (config.framerateX100 > 0) {
+        AVRational fps_strict = ::video::framerateX100_to_rational(config.framerateX100);
+        delay = std::chrono::nanoseconds(
+          (static_cast<int64_t>(fps_strict.den) * 1'000'000'000LL) / fps_strict.num
+        );
+        BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << fps_strict.num << "/" << fps_strict.den << ", approx. " << av_q2d(fps_strict) << " fps]";
+      } else {
+        delay = std::chrono::nanoseconds {1s} / config.framerate;
+        BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << config.framerate << "fps]";
+      }
+
       mem_type = hwdevice_type;
 
       if (display.init()) {
@@ -41,12 +52,12 @@ namespace wl {
       display.roundtrip();
 
       if (!interface[wl::interface_t::XDG_OUTPUT]) {
-        BOOST_LOG(error) << "Missing Wayland wire for xdg_output"sv;
+        BOOST_LOG(error) << "[wlgrab] Missing Wayland wire for xdg_output"sv;
         return -1;
       }
 
       if (!interface[wl::interface_t::WLR_EXPORT_DMABUF]) {
-        BOOST_LOG(error) << "Missing Wayland wire for wlr-export-dmabuf"sv;
+        BOOST_LOG(error) << "[wlgrab] Missing Wayland wire for wlr-export-dmabuf"sv;
         return -1;
       }
 
@@ -88,12 +99,12 @@ namespace wl {
       this->env_logical_width = desktop_logical_width;
       this->env_logical_height = desktop_logical_height;
 
-      BOOST_LOG(info) << "Selected monitor ["sv << monitor->description << "] for streaming"sv;
-      BOOST_LOG(debug) << "Offset: "sv << offset_x << 'x' << offset_y;
-      BOOST_LOG(debug) << "Resolution: "sv << width << 'x' << height;
-      BOOST_LOG(debug) << "Logical Resolution: "sv << logical_width << 'x' << logical_height;
-      BOOST_LOG(debug) << "Desktop Resolution: "sv << env_width << 'x' << env_height;
-      BOOST_LOG(debug) << "Logical Desktop Resolution: "sv << env_logical_width << 'x' << env_logical_height;
+      BOOST_LOG(info) << "[wlgrab] Selected monitor ["sv << monitor->description << "] for streaming"sv;
+      BOOST_LOG(debug) << "[wlgrab] Offset: "sv << offset_x << 'x' << offset_y;
+      BOOST_LOG(debug) << "[wlgrab] Resolution: "sv << width << 'x' << height;
+      BOOST_LOG(debug) << "[wlgrab] Logical Resolution: "sv << logical_width << 'x' << logical_height;
+      BOOST_LOG(debug) << "[wlgrab] Desktop Resolution: "sv << env_width << 'x' << env_height;
+      BOOST_LOG(debug) << "[wlgrab] Logical Desktop Resolution: "sv << env_logical_width << 'x' << env_logical_height;
 
       return 0;
     }
@@ -177,7 +188,7 @@ namespace wl {
             }
             break;
           default:
-            BOOST_LOG(error) << "Unrecognized capture status ["sv << (int) status << ']';
+            BOOST_LOG(error) << "[wlgrab] Unrecognized capture status ["sv << (int) status << ']';
             return status;
         }
       }
@@ -210,10 +221,12 @@ namespace wl {
       int w;
       gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
       gl::ctx.GetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
-      BOOST_LOG(debug) << "width and height: w "sv << w << " h "sv << h;
+      BOOST_LOG(debug) << "[wlgrab] width and height: w "sv << w << " h "sv << h;
 
       gl::ctx.GetTextureSubImage((*rgb_opt)->tex[0], 0, 0, 0, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
       gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
+
+      img_out->frame_timestamp = current_frame->frame_timestamp;
 
       return platf::capture_e::ok;
     }
@@ -308,7 +321,7 @@ namespace wl {
             }
             break;
           default:
-            BOOST_LOG(error) << "Unrecognized capture status ["sv << (int) status << ']';
+            BOOST_LOG(error) << "[wlgrab] Unrecognized capture status ["sv << (int) status << ']';
             return status;
         }
       }
@@ -334,6 +347,7 @@ namespace wl {
       img->sequence = sequence;
 
       img->sd = current_frame->sd;
+      img->frame_timestamp = current_frame->frame_timestamp;
 
       // Prevent dmabuf from closing the file descriptors.
       std::fill_n(current_frame->sd.fds, 4, -1);
@@ -385,7 +399,7 @@ namespace wl {
 namespace platf {
   std::shared_ptr<display_t> wl_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config) {
     if (hwdevice_type != platf::mem_type_e::system && hwdevice_type != platf::mem_type_e::vaapi && hwdevice_type != platf::mem_type_e::cuda) {
-      BOOST_LOG(error) << "Could not initialize display with the given hw device type."sv;
+      BOOST_LOG(error) << "[wlgrab] Could not initialize display with the given hw device type."sv;
       return nullptr;
     }
 
@@ -420,12 +434,12 @@ namespace platf {
     display.roundtrip();
 
     if (!interface[wl::interface_t::XDG_OUTPUT]) {
-      BOOST_LOG(warning) << "Missing Wayland wire for xdg_output"sv;
+      BOOST_LOG(warning) << "[wlgrab] Missing Wayland wire for xdg_output"sv;
       return {};
     }
 
     if (!interface[wl::interface_t::WLR_EXPORT_DMABUF]) {
-      BOOST_LOG(warning) << "Missing Wayland wire for wlr-export-dmabuf"sv;
+      BOOST_LOG(warning) << "[wlgrab] Missing Wayland wire for wlr-export-dmabuf"sv;
       return {};
     }
 
@@ -438,7 +452,7 @@ namespace platf {
 
     display.roundtrip();
 
-    BOOST_LOG(info) << "-------- Start of Wayland monitor list --------"sv;
+    BOOST_LOG(info) << "[wlgrab] -------- Start of Wayland monitor list --------"sv;
 
     for (int x = 0; x < interface.monitors.size(); ++x) {
       auto monitor = interface.monitors[x].get();
@@ -446,12 +460,12 @@ namespace platf {
       wl::env_width = std::max(wl::env_width, (int) (monitor->viewport.offset_x + monitor->viewport.width));
       wl::env_height = std::max(wl::env_height, (int) (monitor->viewport.offset_y + monitor->viewport.height));
 
-      BOOST_LOG(info) << "Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
+      BOOST_LOG(info) << "[wlgrab] Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
 
       display_names.emplace_back(std::to_string(x));
     }
 
-    BOOST_LOG(info) << "--------- End of Wayland monitor list ---------"sv;
+    BOOST_LOG(info) << "[wlgrab] --------- End of Wayland monitor list ---------"sv;
 
     return display_names;
   }

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -188,7 +188,7 @@ namespace wl {
             }
             break;
           default:
-            BOOST_LOG(error) << "[wlgrab] Unrecognized capture status ["sv << (int) status << ']';
+            BOOST_LOG(error) << "[wlgrab] Unrecognized capture status ["sv << std::to_underlying(status) << ']';
             return status;
         }
       }
@@ -321,7 +321,7 @@ namespace wl {
             }
             break;
           default:
-            BOOST_LOG(error) << "[wlgrab] Unrecognized capture status ["sv << (int) status << ']';
+            BOOST_LOG(error) << "[wlgrab] Unrecognized capture status ["sv << std::to_underlying(status) << ']';
             return status;
         }
       }
@@ -457,8 +457,8 @@ namespace platf {
     for (int x = 0; x < interface.monitors.size(); ++x) {
       auto monitor = interface.monitors[x].get();
 
-      wl::env_width = std::max(wl::env_width, (int) (monitor->viewport.offset_x + monitor->viewport.width));
-      wl::env_height = std::max(wl::env_height, (int) (monitor->viewport.offset_y + monitor->viewport.height));
+      wl::env_width = std::max(wl::env_width, monitor->viewport.offset_x + monitor->viewport.width);
+      wl::env_height = std::max(wl::env_height, monitor->viewport.offset_y + monitor->viewport.height);
 
       BOOST_LOG(info) << "[wlgrab] Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
This PR adds frame_timestamp to the wlgrab backend, used with headless Wayland. The timestamp comes from Wayland's ready callback, which I think is the best place to take it from. I also added framerateX100 support since it's very simple.

I also wanted to make the logs a bit easier to understand across all the various Wayland code, so I added prefixes to all the logging. I also removed a couple logs from very hot callbacks. 

I'll submit a future PR for wlgrab to ignore duplicate frames for variable fps.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
