### PR TITLE
fix(build): ensure libopus is statically linked

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -130,7 +130,8 @@ jobs:
                 --apple-id "${APPLE_ID}" \
                 --team-id "${APPLE_TEAM_ID}" \
                 --password "${APPLE_NOTARYTOOL_PASSWORD}" \
-                --wait
+                --wait \
+                --timeout 15m
               xcrun stapler staple -v build/cpack_artifacts/Sunshine.dmg
             fi
           fi

--- a/cmake/dependencies/FindOpus.cmake
+++ b/cmake/dependencies/FindOpus.cmake
@@ -36,6 +36,8 @@ set(Opus_ROOT_DIR  # cmake-lint: disable=C0103
     "${Opus_ROOT_DIR}"
     CACHE PATH "Root to search for opus")
 
+option(OPUS_USE_STATIC "Prefer linking against a static Opus library" OFF)
+
 # Todo: handle in-tree/fetch-content builds?
 
 if(NOT OPUS_FOUND)
@@ -62,6 +64,17 @@ if(NOT ANDROID)
     endif()
 endif()
 
+set(_opus_library_names opus)
+if(OPUS_USE_STATIC)
+    set(_opus_library_names libopus opus)
+endif()
+
+# Temporarily prefer static suffixes when requested.
+set(_old_find_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+if(OPUS_USE_STATIC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".lib" ${_old_find_suffixes})
+endif()
+
 find_path(
     Opus_INCLUDE_DIR
     NAMES opus/opus.h
@@ -70,10 +83,12 @@ find_path(
     PATH_SUFFIXES include)
 find_library(
     Opus_LIBRARY
-    NAMES opus
+    NAMES ${_opus_library_names}
     PATHS ${Opus_ROOT_DIR}
     HINTS ${PC_opus_LIBRARY_DIRS}
     PATH_SUFFIXES lib)
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES "${_old_find_suffixes}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Opus REQUIRED_VARS Opus_LIBRARY
@@ -85,7 +100,11 @@ if(Opus_FOUND)
             add_library(Opus::opus ALIAS ${Opus_LIBRARY})
         else()
             # we want an imported target
-            add_library(Opus::opus UNKNOWN IMPORTED)
+            if(OPUS_USE_STATIC)
+                add_library(Opus::opus STATIC IMPORTED)
+            else()
+                add_library(Opus::opus UNKNOWN IMPORTED)
+            endif()
 
             set_target_properties(
                 Opus::opus

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -33,6 +33,7 @@ include_directories(SYSTEM ${MINIUPNP_INCLUDE_DIRS})
 include("${CMAKE_MODULE_PATH}/dependencies/ffmpeg.cmake")
 
 # Opus
+set(OPUS_USE_STATIC ON CACHE BOOL "Static linking for libopus")
 include("${CMAKE_MODULE_PATH}/dependencies/FindOpus.cmake")
 
 # platform specific dependencies

--- a/scripts/macos_build.sh
+++ b/scripts/macos_build.sh
@@ -13,6 +13,7 @@ build_docs="OFF"
 build_tests="ON"
 build_type="Release"
 sign_app="true"
+notarize="true"
 
 # environment variables
 # BUILD_VERSION should be empty or cmake will assume a CI build
@@ -66,6 +67,7 @@ Options:
   --build-docs             Build docs.
   --skip-tests             Don't build the test suite.
   --skip-codesign          Don't sign/notarize the bundle.
+  --skip-notarize          Don't notarize the dmg.
 
 Steps:
   deps                     Install dependencies only
@@ -147,8 +149,11 @@ function run_step_dmg() {
 
   cpack -G DragNDrop --config "${build_dir}/CPackConfig.cmake" --verbose
 
-  if [[ -n "${sign_app}" ]]; then
-    xcrun notarytool submit "${build_dir}/cpack_artifacts/Sunshine.dmg" --keychain-profile "notarytool-password" --wait
+  if [[ -n "${sign_app}" && -n "${notarize}" ]]; then
+    time xcrun notarytool submit "${build_dir}/cpack_artifacts/Sunshine.dmg" \
+      --keychain-profile "notarytool-password" \
+      --wait \
+      --timeout 15m
     xcrun stapler staple -v "${build_dir}/cpack_artifacts/Sunshine.dmg"
   fi
   return 0
@@ -215,6 +220,9 @@ while getopts ":h-:" opt; do
           ;;
         skip-codesign)
          sign_app=""
+          ;;
+        skip-notarize)
+         notarize=""
           ;;
         *)
           echo "Invalid option: --${OPTARG}" 1>&2


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
Add OPUS_USE_STATIC to FindOpus so the build prefers statically linking libopus.a. Manually tested on Mac and Windows.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
- Fixes #4816 


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
