### PR TITLE
fix: clear tray icon when unpairing the last paired client

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -879,7 +879,13 @@ namespace confighttp {
       nlohmann::json output_tree;
       const nlohmann::json input_tree = nlohmann::json::parse(ss);
       const std::string uuid = input_tree.value("uuid", "");
-      output_tree["status"] = nvhttp::unpair_client(uuid);
+      const bool removed = nvhttp::unpair_client(uuid);
+      output_tree["status"] = removed;
+
+      if (removed && nvhttp::get_all_clients().empty()) {
+        proc::proc.terminate();
+      }
+
       send_response(response, output_tree);
     } catch (std::exception &e) {
       BOOST_LOG(warning) << "Unpair: "sv << e.what();


### PR DESCRIPTION
<!---
NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
THEY ARE IMPORTANT FOR THE MAINTAINERS.
IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
-->

## Description

When unpairing the only remaining paired device via the Web UI, the Sunshine taskbar icon remains stuck on **"Game Session Paused"** instead of returning to the idle state.

The single-client unpair API (`POST /api/unpair`) removes the paired client record but does not terminate the running app/session state. In contrast, the existing `unpair all` path calls `proc::proc.terminate()` which clears the tray icon.

This fix calls `proc::proc.terminate()` when the last paired client is removed, mirroring the existing cleanup behavior in the unpair-all path.

### Screenshot

N/A - backend fix

### Issues Fixed or Closed

- Fixes #4801

#### Roadmap Issues

N/A

## Type of Change

- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes