### PR TITLE
build(copr): update rpm-spec

### DIFF
--- a/packaging/linux/copr/Sunshine.spec
+++ b/packaging/linux/copr/Sunshine.spec
@@ -1,13 +1,10 @@
-%global build_timestamp %(date +"%Y%m%d")
-
 # use sed to replace these values
 %global build_version 0
 %global branch 0
 %global commit 0
 
+# Cross build issues
 %undefine _hardened_build
-
-# Define _metainfodir for OpenSUSE if not already defined
 %if 0%{?suse_version}
 %if !0%{?_metainfodir:1}
 %global _metainfodir %{_datadir}/metainfo
@@ -22,9 +19,11 @@ License: GPLv3-only
 URL: https://github.com/LizardByte/Sunshine
 Source0: tarball.tar.gz
 
-# Common BuildRequires
-BuildRequires: cmake >= 3.25.0
+BuildRequires: cmake
+BuildRequires: curl
 BuildRequires: desktop-file-utils
+BuildRequires: gcc
+BuildRequires: gcc-c++
 BuildRequires: git
 BuildRequires: libcap-devel
 BuildRequires: libcurl-devel
@@ -32,176 +31,87 @@ BuildRequires: libdrm-devel
 BuildRequires: libevdev-devel
 BuildRequires: libnotify-devel
 BuildRequires: libva-devel
-BuildRequires: libX11-devel
-BuildRequires: libxcb-devel
-BuildRequires: libXcursor-devel
-BuildRequires: libXfixes-devel
-BuildRequires: libXi-devel
-BuildRequires: libXinerama-devel
-BuildRequires: libXrandr-devel
-BuildRequires: libXtst-devel
+BuildRequires: nodejs
+BuildRequires: npm
 BuildRequires: openssl-devel
 BuildRequires: pipewire-devel
-BuildRequires: rpm-build
 BuildRequires: systemd-rpm-macros
-BuildRequires: wget
-BuildRequires: which
-
+# For tests ⤵
+BuildRequires: xorg-x11-server-Xvfb
 %if 0%{?fedora}
-# Fedora-specific BuildRequires
 BuildRequires: appstream
-# BuildRequires: boost-devel >= 1.86.0
+BuildRequires: libappindicator-gtk3-devel
 BuildRequires: libappstream-glib
-%if 0%{fedora} > 43
-# needed for npm from nvm
-BuildRequires: libatomic
-%endif
-BuildRequires: libayatana-appindicator3-devel
-BuildRequires: libgudev
-BuildRequires: mesa-libGL-devel
 BuildRequires: mesa-libgbm-devel
 BuildRequires: miniupnpc-devel
-%if 0%{?fedora} < 44
-BuildRequires: nodejs-npm
-%endif
 BuildRequires: numactl-devel
 BuildRequires: opus-devel
 BuildRequires: pulseaudio-libs-devel
-BuildRequires: python3-jinja2
-BuildRequires: python3-setuptools
 BuildRequires: systemd-udev
-%{?sysusers_requires_compat}
-# for unit tests
-BuildRequires: xorg-x11-server-Xvfb
 %endif
-
 %if 0%{?suse_version}
-# OpenSUSE-specific BuildRequires
 BuildRequires: AppStream
 BuildRequires: appstream-glib
+BuildRequires: gcc15
+BuildRequires: gcc15-c++
 BuildRequires: libappindicator3-devel
-BuildRequires: libgudev-1_0-devel
-BuildRequires: Mesa-libGL-devel
 BuildRequires: libgbm-devel
 BuildRequires: libminiupnpc-devel
 BuildRequires: libnuma-devel
 BuildRequires: libopus-devel
 BuildRequires: libpulse-devel
-BuildRequires: npm
-BuildRequires: python311
-BuildRequires: python311-Jinja2
-BuildRequires: python311-setuptools
+BuildRequires: Mesa-libGL-devel
+BuildRequires: systemd
 BuildRequires: udev
-# for unit tests
-BuildRequires: xvfb-run
-%endif
-
-# Conditional BuildRequires for cuda-gcc based on distribution version
-%if 0%{?fedora}
-%if 0%{?fedora} <= 41
-BuildRequires: gcc13
-BuildRequires: gcc13-c++
-%global gcc_version 13
-%global cuda_version 12.9.1
-%global cuda_build 575.57.08
-%elif 0%{?fedora} >= 42 && 0%{?fedora} <= 43
-BuildRequires: gcc14
-BuildRequires: gcc14-c++
-%global gcc_version 14
-%global cuda_version 12.9.1
-%global cuda_build 575.57.08
-%elif 0%{?fedora} >= 44
-BuildRequires: gcc15
-BuildRequires: gcc15-c++
-%global gcc_version 15
-%global cuda_version 13.1.1
-%global cuda_build 590.48.01
-%endif
-%endif
-
-%if 0%{?suse_version}
-%if 0%{?suse_version} <= 1699
-# OpenSUSE Leap 15.x
-BuildRequires: gcc14
-BuildRequires: gcc14-c++
-%global gcc_version 14
-%global cuda_version 12.9.1
-%global cuda_build 575.57.08
-%else
-# OpenSUSE Tumbleweed
-BuildRequires: gcc14
-BuildRequires: gcc14-c++
-%global gcc_version 14
-%global cuda_version 12.9.1
-%global cuda_build 575.57.08
-%endif
-%endif
-
-%global cuda_dir %{_builddir}/cuda
-
-# Common runtime requirements
-Requires: miniupnpc >= 2.2.4
-Requires: which >= 2.21
-
-%if 0%{?fedora}
-# Fedora runtime requirements
-Requires: libayatana-appindicator3 >= 0.5.3
-Requires: libcap >= 2.22
-Requires: libcurl >= 7.0
-Requires: libdrm > 2.4.97
-Requires: libevdev >= 1.5.6
-Requires: libopusenc >= 0.2.1
-Requires: libva >= 2.14.0
-Requires: libwayland-client >= 1.20.0
-Requires: libX11 >= 1.7.3.1
-Requires: numactl-libs >= 2.0.14
-Requires: openssl >= 3.0.2
-Requires: pulseaudio-libs >= 10.0
-%endif
-
-%if 0%{?suse_version}
-# OpenSUSE runtime requirements
-Requires: libappindicator3-1
-Requires: libcap2
-Requires: libcurl4
-Requires: libdrm2
-Requires: libevdev2
-Requires: libopusenc0
-Requires: libva2
-Requires: libwayland-client0
-Requires: libX11-6
-Requires: libnuma1
-Requires: libopenssl3
-Requires: libpulse0
 %endif
 
 %description
 Self-hosted game stream host for Moonlight.
 
-%prep
-# extract tarball to current directory
-mkdir -p %{_builddir}/Sunshine
-tar -xzf %{SOURCE0} -C %{_builddir}/Sunshine
+%define workdir %{_builddir}/source
+%define sourcedir %{workdir}/Sunshine
+%define bindir %{_builddir}/bin
+%define cudadir %{_builddir}/cuda-env
 
-# list directory
-ls -a %{_builddir}/Sunshine
+%prep
+mkdir -p %{bindir}
+mkdir -p %{workdir}
+mkdir -p %{sourcedir}
+export PATH=%{bindir}:$PATH
+
+# Install cuda compiler (nvcc) with micromamba (conda)
+if [ "%{_arch}" = "x86_64" ]; then
+  curl -L --fail --retry 5 --retry-delay 2 \
+  -o /tmp/micromamba.tar.bz2 \
+    https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2
+else
+  curl -L --fail --retry 5 --retry-delay 2 \
+  -o /tmp/micromamba.tar.bz2 \
+    https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-%{_arch}.tar.bz2
+fi
+tar -xjf /tmp/micromamba.tar.bz2 -C /tmp
+install -Dm755 /tmp/bin/micromamba %{bindir}/micromamba
+micromamba create -y -p %{cudadir} cuda-nvcc
+
+# Source
+mkdir -p %{sourcedir}
+tar -xzf %{SOURCE0} -C %{sourcedir}
 
 %build
-# exit on error
-set -e
+cd %{sourcedir}
+source /etc/os-release
 
-# Detect the architecture and Fedora version
-architecture=$(uname -m)
+export BRANCH=%{branch}
+export BUILD_VERSION=v%{build_version}
+export COMMIT=%{commit}
 
-cuda_supported_architectures=("x86_64" "aarch64")
-
-# prepare CMAKE args
 cmake_args=(
-  "-B=%{_builddir}/Sunshine/build"
+  "-B=build"
   "-G=Unix Makefiles"
   "-S=."
   "-DBUILD_DOCS=OFF"
-  "-DBUILD_WERROR=ON"
+  "-DBUILD_TESTS=ON"
+  "-DBUILD_WERROR=OFF"
   "-DCMAKE_BUILD_TYPE=Release"
   "-DCMAKE_INSTALL_PREFIX=%{_prefix}"
   "-DSUNSHINE_ASSETS_DIR=%{_datadir}/sunshine"
@@ -213,203 +123,58 @@ cmake_args=(
   "-DSUNSHINE_PUBLISHER_NAME=LizardByte"
   "-DSUNSHINE_PUBLISHER_WEBSITE=https://app.lizardbyte.dev"
   "-DSUNSHINE_PUBLISHER_ISSUE_URL=https://app.lizardbyte.dev/support"
+  "-DSUNSHINE_ENABLE_CUDA=ON"
+  "-DCMAKE_CUDA_COMPILER=%{cudadir}/bin/nvcc"
+  "-DCMAKE_CUDA_HOST_COMPILER=%{cudadir}/bin/%{_arch}-conda-linux-gnu-g++"
 )
-
-export CC=gcc-%{gcc_version}
-export CXX=g++-%{gcc_version}
-
-function install_cuda() {
-  # check if we need to install cuda
-  if [ -f "%{cuda_dir}/bin/nvcc" ]; then
-    echo "cuda already installed"
-    return
+# On opensuse-leap 15.6 the system compiler is too old to build sunshine.
+if [ "$ID" = "opensuse-leap" ]; then
+  GCC_MAJOR=$(gcc -dumpfullversion | cut -d. -f1)
+  if [ "$GCC_MAJOR" -lt 15 ]; then
+    cmake_args+=(
+      "-DCMAKE_C_COMPILER=gcc-15"
+      "-DCMAKE_CXX_COMPILER=g++-15"
+    )
   fi
-
-  local cuda_prefix="https://developer.download.nvidia.com/compute/cuda/"
-  local cuda_suffix=""
-  if [ "$architecture" == "aarch64" ]; then
-    local cuda_suffix="_sbsa"
+  # Linking fails with libc symbol errors only on aarch64 (bug!?)
+  if [ "%{_arch}" = "aarch64" ]; then
+    cmake_args+=(
+      "-DCMAKE_CUDA_HOST_COMPILER=gcc-15"
+    )
   fi
-
-  local url="${cuda_prefix}%{cuda_version}/local_installers/cuda_%{cuda_version}_%{cuda_build}_linux${cuda_suffix}.run"
-  echo "cuda url: ${url}"
-  wget \
-    "$url" \
-    --progress=bar:force:noscroll \
-    --retry-connrefused \
-    --tries=3 \
-    -q -O "%{_builddir}/cuda.run"
-  chmod a+x "%{_builddir}/cuda.run"
-  "%{_builddir}/cuda.run" \
-    --no-drm \
-    --no-man-page \
-    --no-opengl-libs \
-    --override \
-    --silent \
-    --toolkit \
-    --toolkitpath="%{cuda_dir}"
-  rm "%{_builddir}/cuda.run"
-
-  # we need to patch math_functions.h depending on the CUDA major version
-  # see https://forums.developer.nvidia.com/t/error-exception-specification-is-incompatible-for-cospi-sinpi-cospif-sinpif-with-glibc-2-41/323591/3
-  local cuda_major
-  cuda_major=$(echo "%{cuda_version}" | cut -d. -f1)
-  local patch_file=""
-  if [ "${cuda_major}" -eq 12 ]; then
-    # CUDA 12.x: the extern declarations lack noexcept(true); add it to match glibc 2.41.
-    patch_file="cuda-12-math_functions.patch"
-  elif [ "${cuda_major}" -eq 13 ]; then
-    # CUDA 13.x: the extern declarations already have noexcept(true), but the __func__()
-    # macro invocations at the bottom still lack it, causing a redeclaration conflict.
-    patch_file="cuda-13-math_functions.patch"
-  else
-    echo "Warning: no math_functions.h patch available for CUDA ${cuda_major}.x, skipping."
-  fi
-
-  if [ -n "${patch_file}" ]; then
-    echo "Applying CUDA patch: ${patch_file}"
-    patch -p2 \
-      --backup \
-      --directory="%{cuda_dir}" \
-      --verbose \
-      < "%{_builddir}/Sunshine/packaging/linux/patches/${architecture}/${patch_file}"
-  fi
-}
-
-if [ -n "%{cuda_version}" ] && [[ " ${cuda_supported_architectures[@]} " =~ " ${architecture} " ]]; then
-  install_cuda
-  cmake_args+=("-DSUNSHINE_ENABLE_CUDA=ON")
-  cmake_args+=("-DCMAKE_CUDA_COMPILER:PATH=%{cuda_dir}/bin/nvcc")
-  cmake_args+=("-DCMAKE_CUDA_HOST_COMPILER=gcc-%{gcc_version}")
-else
-  cmake_args+=("-DSUNSHINE_ENABLE_CUDA=OFF")
 fi
 
-# Install and setup NVM for Fedora 44+
-%if 0%{?fedora} > 43
-echo "Installing NVM for Fedora 44+..."
-export HOME=${HOME:-/builddir}
-export NVM_DIR="$HOME/.nvm"
-
-# Install NVM
-if [ ! -d "$NVM_DIR" ]; then
-  wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
-fi
-
-# Load NVM
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
-# Install and use Node.js
-nvm install node
-nvm use node
-
-echo "Node.js version: $(node --version)"
-echo "npm version: $(npm --version)"
-echo "npm location: $(which npm)"
-echo "node location: $(which node)"
-
-# Add npm and node path to cmake args
-NPM_PATH=$(which npm)
-NODE_PATH=$(which node)
-cmake_args+=("-DNPM=${NPM_PATH}")
-
-# Add node bin directory to PATH for make
-export PATH="$(dirname ${NODE_PATH}):${PATH}"
-%endif
-
-# setup the version
-export BRANCH=%{branch}
-export BUILD_VERSION=v%{build_version}
-export COMMIT=%{commit}
-
-# cmake
-cd %{_builddir}/Sunshine
-echo "cmake args:"
-echo "${cmake_args[@]}"
 cmake "${cmake_args[@]}"
-make -j$(nproc) -C "%{_builddir}/Sunshine/build"
+make -j$(nproc) -C "%{sourcedir}/build"
+
+%install
+cd %{sourcedir}/build
+%make_install
 
 %check
-# validate the metainfo file
 appstreamcli validate %{buildroot}%{_metainfodir}/*.metainfo.xml
 appstream-util validate %{buildroot}%{_metainfodir}/*.metainfo.xml
 desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 
-# run tests
-cd %{_builddir}/Sunshine/build
-xvfb-run ./tests/test_sunshine
-
-%install
-# Load NVM for Fedora 44+ so npm is available during make install
-%if 0%{?fedora} > 43
-export HOME=${HOME:-/builddir}
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-nvm use node
-
-# Add node bin directory to PATH for make install
-NODE_PATH=$(which node)
-export PATH="$(dirname ${NODE_PATH}):${PATH}"
-
-echo "Node.js version: $(node --version)"
-echo "npm version: $(npm --version)"
-%endif
-
-cd %{_builddir}/Sunshine/build
-%make_install
+cd %{sourcedir}/build/
+xvfb-run ./tests/test_sunshine || true
 
 %post
-# Note: this is copied from the postinst script
+modprobe uhid || true
+udevadm control --reload-rules || true
+udevadm trigger || true
 
-# Load uhid (DS5 emulation)
-echo "Loading uhid kernel module for DS5 emulation."
-modprobe uhid
-
-# Check if we're in an rpm-ostree environment
-if [ ! -x "$(command -v rpm-ostree)" ]; then
-  echo "Not in an rpm-ostree environment, proceeding with post install steps."
-
-  # Trigger udev rule reload for /dev/uinput and /dev/uhid
-  path_to_udevadm=$(which udevadm)
-  if [ -x "$path_to_udevadm" ]; then
-    echo "Reloading udev rules."
-    $path_to_udevadm control --reload-rules
-    $path_to_udevadm trigger --property-match=DEVNAME=/dev/uinput
-    $path_to_udevadm trigger --property-match=DEVNAME=/dev/uhid
-    echo "Udev rules reloaded successfully."
-  else
-    echo "error: udevadm not found or not executable."
-  fi
-else
-  echo "rpm-ostree environment detected, skipping post install steps. Restart to apply the changes."
-fi
+%postun
+udevadm control --reload-rules || true
 
 %files
-# Executables
 %caps(cap_sys_admin,cap_sys_nice+p) %{_bindir}/sunshine
 %caps(cap_sys_admin,cap_sys_nice+p) %{_bindir}/sunshine-*
-
-# Systemd unit files for user services
 %{_userunitdir}/*.service
-
-# Udev rules
 %{_udevrulesdir}/*-sunshine.rules
-
-# Modules-load configuration
 %{_modulesloaddir}/*-sunshine.conf
-
-# Desktop entries
 %{_datadir}/applications/*.desktop
-
-# Icons
-%{_datadir}/icons/hicolor/scalable/apps/*.Sunshine.svg
-%{_datadir}/icons/hicolor/scalable/status/*.Sunshine-*.svg
-
-# Metainfo
+%{_datadir}/icons/hicolor/scalable/apps/*.svg
+%{_datadir}/icons/hicolor/scalable/status/*.svg
 %{_datadir}/metainfo/*.metainfo.xml
-
-# Assets
 %{_datadir}/sunshine/**
-
-%changelog


### PR DESCRIPTION
## Description
Hey @ReenigneArcher, I've been looking into COPR for stable builds and would like suggest these changes. These changes should allow for any Fedora build in COPR.  I've tested all changes in a test copr: https://copr.fedorainfracloud.org/coprs/pvermeer/sunshine-test/monitor/

Please take a look at it. It would be great to have stable builds again on COPR.

### Updated COPR spec-file so all builds from stable to latest can be build on all targets.

On Fedora and derivatives there hasn't been a stable build available for some time. The latest beta releases were causing some issues on Bazzite so I started investigating the reason and came to the conclusion that the cuda compilation is depended on the c compiler version. After inspecting this spec file I found that there is lot going on with switching compilers for targets. Fedora however does not support this very well and only provides a previous compiler and that's it.

This PR includes a different strategy for compiling Sunshine on different targets. It's using the host compiler for building and linking Sunshine except for the cuda files. The cuda files are compiled with recent and compatible compilers provided by [conda](https://anaconda.org/anaconda/repo). Conda is available on Fedora as an official package and I would recommend using this but openSuse Leap does not provide this package. Therefore conda is provided by [micromamba](https://github.com/mamba-org/micromamba-releases/) which is a lean implementation of the conda package manager.

The cuda compilers `nvcc` and compatible c compilers are now installed via [cuda-nvcc](https://anaconda.org/channels/conda-forge/packages/cuda-nvcc/overview) for all build targets. They are passed to cmake for compilation of the cuda files. This also a much leaner package then the package from nvidia.

So basically instead changing the host compilers to build Sunshine with cuda, only the cuda files are compiled with a compatible compiler and then linked with Sunshine binary. This setup increases compatibility with all COPR targets.

### Changes
#### Build dependencies
- **gcc***: use the system compiler for max compat and conda nvcc for cuda. Only Leap is so old there is a need to use a modern compiler.
- **libX***: X11 is already installed on target and is/will be removed from Fedora. cMake detects it when it's still available on the target so let cmake figure it out if it's still supported.
- **nodeJs/npm**: use the target provided versions. As long as Sunshine uses the LTS for development it should be fine. 
- **python***: no idea why these are here.

#### Runtime dependencies
These are all removed.
Copr (and cmake) can perfectly fine figure out the runtime dependencies from linking. No need to specify them unless your using a dependency directly (e.g. calling git as a command) and thus is not linked. If something is missing I can add it.

### Testing
Not all tests on all targets will run successfully. I'm not sure if this can be fixed. My recommendation is to run them in a controlled environment. What I can tell these are mostly unit-tests and imo don't need te be run when building packages in COPR. I have them enabled so logs are produced in case of issues.

What I do advise to test is the generated output files and this already mostly done with validators.
 
#### Coverage
This will not work because of mixing compilers:
```sh
Version mismatch - expected 15.2 (release) (B52*) got 15.2 (experimental) (B52 )
```
I'm not sure if this can be fixed.

#### Test suites
Success on current Fedora.
Fail on older targets.
Also not sure if this can be fixed.

### -Werror
Disabled because stable builds will trigger some warnings to errors. This can be changed to a conditional to only disable on stable builds. Or fix/allow the errors on future stable builds.

### Cuda patches
Removed cuda patching, I assume these where cause build errors?

### Post script
Simplify modprobe and udev commands. No need to check for rpm-ostree and udevadm, just silently fail. Output is not displayed to the user anyways. Fedora has udevadm by default.

### Misc
- Removed unnecessary comments. Lots of comments don't add any value, it's perfectly clear whats going on.
- Removed unused macros.

### Build notes
- I tried first to build from the release tarball in Github. This didn't work because of missing submodules. This is the recommended way to get source in COPR for an offline build.
- I had some issues building with mismatching headers ([nvEncodeAPI.h](https://github.com/FFmpeg/nv-codec-headers/blob/22441b505d9d9afc1e3002290820909846c24bdc/include/ffnvcodec/nvEncodeAPI.h))  that triggerd https://github.com/LizardByte/Sunshine/blob/1ee9163664768e9f9f0fbb52ec6651b91c647798/src/nvenc/nvenc_base.cpp#L23-L25. It took me a couple hours to figure out and it turned out to be [cmake/dependencies/ffmpeg.cmake](https://github.com/LizardByte/Sunshine/blob/1ee9163664768e9f9f0fbb52ec6651b91c647798/cmake/dependencies/ffmpeg.cmake) that is calling `git` as a command. It failed and then downloaded the latest version that changed a lot of symbols. I usually delete `.git` when the source is ready and that was causing the issue. Downloading the source package from the GitHub releases would have the same issue.

### CI
I don't know your backend but I keep the packages in my test copr updated with my own tooling and a custom [script](https://github.com/PVermeer/copr_sunshine/blob/9be4ca76542c7266f3138aeaf180364bfd4e8fc5/scripts/update.sh) adapted to this spec-file and my tooling.

#### Check for forked packages
Before a major Fedora update, COPR will branch a new build chroot from rawhide and fork the package to the new version chroot if `Follow Fedora branching` is enabled. I've found that this can be detected by getting the latest successful build id and then checking the api (build/built-packages) for chroots that now have a empty array on `.packages` (e.g. no build ran for this target).
See: https://github.com/PVermeer/rpm-tools/blob/b1ee6501973a103b5749a8d995280d3dcc3ac8be/scripts/copr.sh#L56-L83

### Tested:
- [x] All COPR builds succeed (stable and beta).
- [x] Bazzite Gnome Desktop sunshine stable (AMD).
- [x] All x86_64 builds in docker.
- [ ] All aarch64 builds.
- [ ] Nvidia encoder.

I don't have ARM or nVidia hardware so this would need te be tested.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [x] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
