### PR TITLE
fix(amf): enable H.264 profile and coder selection

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -143,6 +143,19 @@ namespace video {
 
   }  // namespace qsv
 
+  namespace amf {
+
+    /**
+     * @brief Enumerates supported coder options for AMF encoder.
+     */
+    enum class coder_e : int {
+      auto_ = 0,  ///< Auto coder mode
+      cabac = 1,  ///< CABAC entropy coding
+      cavlc = 2,  ///< CAVLC entropy coding
+    };
+
+  }  // namespace amf
+
   /**
    * @brief Create an FFmpeg hardware device buffer for D3D11VA input.
    *
@@ -1022,9 +1035,22 @@ namespace video {
         {"rc"s, &config::video.amd.amd_rc_h264},
         {"usage"s, &config::video.amd.amd_usage_h264},
         {"vbaq"s, &config::video.amd.amd_vbaq},
+        {"coder"s, &config::video.amd.amd_coder},
         {"enforce_hrd"s, &config::video.amd.amd_enforce_hrd},
       },
-      {},  // SDR-specific options
+      {
+        // SDR-specific options
+        {"profile"s, [](const config_t &) {
+           switch (config::video.amd.amd_coder) {
+             case (int) amf::coder_e::cavlc:
+               return "constrained_baseline"s;
+             case (int) amf::coder_e::cabac:
+               return "high"s;
+             default:
+               return "main"s;
+           }
+         }},
+      },
       {},  // HDR-specific options
       {},  // YUV444 SDR-specific options
       {},  // YUV444 HDR-specific options


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
- Currently, the AMD AMF encoder (`h264_amf`) in `src/video.cpp` does not have the `profile` and `coder` options wired up in its `encoder_t` definition. This prevents clients that strictly require H.264 Baseline/CAVLC (like the Sony PSP or other legacy hardware decoders) from successfully streaming, as the encoder defaults to High Profile and CABAC regardless of the client's request or the global configuration.
- Why this is needed
Older hardware decoders often have hardwired limitations. For example, the PSP-1000's Media Engine only supports:
- H.264 Baseline Profile (not Main or High)
- CAVLC entropy coding (not CABAC)

While Sunshine/Apollo allows selecting `cavlc` in the UI, this setting is ignored by the `h264_amf` encoder because it isn't passed to the FFmpeg `avcodec_open2` dictionary.

- Proposed Fix
Update the `amdvce` definition in `src/video.cpp` to include the missing options:

```cpp
        {"coder"s, &config::video.amd.amd_coder},
        {"profile"s, [](const config_t &cfg) {
           if (cfg.profile == 66) return "baseline"s;
           if (cfg.profile == 77) return "main"s;
           return "high"s;
         }},
```
This brings the AMD implementation into parity with NVENC and QuickSync.

### Screenshot
<img width="1109" height="740" alt="image" src="https://github.com/user-attachments/assets/b2a1dffe-4cdf-4071-925e-9010467dee6d" />

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [ ] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [X] **Heavy**: AI generated most or all of the code changes