### PR TITLE
fix(linux/vulkan): limit VBR bitrate overshoot for internet streaming

### DIFF
--- a/src/platform/linux/vulkan_encode.cpp
+++ b/src/platform/linux/vulkan_encode.cpp
@@ -144,12 +144,11 @@ namespace vk {
     }
 
     void init_codec_options(AVCodecContext *ctx, AVDictionary **options) override {
-      // When VBR mode is selected (rc_mode=4), don't pin rc_min_rate to the target bitrate.
-      // Having rc_min_rate == rc_max_rate == bit_rate in VBR mode prevents the encoder from
-      // undershooting on simple frames, which builds up headroom that causes large overshoots
-      // on complex frames.
+      // VBR: reduce bit_rate to 80% and floor at 50% to limit overshoot.
+      // FFmpeg doesn't pass VBV buffer size to the Vulkan Video API.
       if (config::video.vk.rc_mode == 4) {
-        ctx->rc_min_rate = 0;
+        ctx->rc_min_rate = ctx->bit_rate / 2;
+        ctx->bit_rate = ctx->bit_rate * 4 / 5;
       }
     }
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

Vulkan VBR encoding overshoots the client-selected bitrate, causing video lag and disconnections when streaming over the internet.

FFmpeg's Vulkan encoder does not pass `virtualBufferSizeInMs` to the Vulkan Video API, so the driver cannot enforce `rc_max_rate` per frame. This results in unconstrained bitrate spikes on complex scene changes.

To work around this, reduce `bit_rate` to 80% of the target so the average stays within the client's bandwidth budget, and set `rc_min_rate` to 50% to prevent excessive undershooting that leads to large bursts.

Tested at 7 Mbps and 20 Mbps targets using `tshark` at 100ms and 1-second granularity. Steady-state overshoots reduced significantly compared to unpatched VBR.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
