### PR TITLE
fix(windows): skip hybrid GPU hook on single-GPU systems

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -4,6 +4,7 @@
  */
 // standard includes
 #include <cmath>
+#include <set>
 #include <thread>
 
 // platform includes
@@ -458,10 +459,51 @@ namespace platf::dxgi {
       }
 
       {
-        // We aren't calling MH_Uninitialize(), but that's okay because this hook lasts for the life of the process
-        MH_Initialize();
-        MH_CreateHookApi(L"win32u.dll", "NtGdiDdDDIGetCachedHybridQueryValue", (void *) NtGdiDdDDIGetCachedHybridQueryValueHook, nullptr);
-        MH_EnableHook(MH_ALL_HOOKS);
+        // The hybrid GPU workaround hooks NtGdiDdDDIGetCachedHybridQueryValue to prevent
+        // DXGI output reparenting that breaks DDA on multi-GPU systems. On single-GPU
+        // systems, this hook is unnecessary and can cause crashes on some Windows builds
+        // (e.g., Windows 11 24H2 build 29558+) where dxgi.dll doesn't handle the spoofed
+        // GPU preference state correctly, resulting in an access violation.
+        bool needs_hybrid_workaround = false;
+        {
+          IDXGIFactory1 *probe_factory = nullptr;
+          if (SUCCEEDED(CreateDXGIFactory1(IID_IDXGIFactory1, (void **) &probe_factory))) {
+            // Count unique physical GPUs by VendorId+DeviceId.
+            // DXGI can present the same physical GPU as multiple logical adapters
+            // (e.g., cross-adapter copies), so we deduplicate.
+            std::set<std::pair<UINT, UINT>> unique_gpus;
+            IDXGIAdapter1 *probe_adapter = nullptr;
+            for (int i = 0; probe_factory->EnumAdapters1(i, &probe_adapter) != DXGI_ERROR_NOT_FOUND; ++i) {
+              DXGI_ADAPTER_DESC1 desc;
+              probe_adapter->GetDesc1(&desc);
+              if (!(desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)) {
+                unique_gpus.emplace(desc.VendorId, desc.DeviceId);
+              }
+              probe_adapter->Release();
+            }
+            probe_factory->Release();
+            needs_hybrid_workaround = unique_gpus.size() > 1;
+            if (!needs_hybrid_workaround) {
+              BOOST_LOG(info) << "Single GPU detected, skipping hybrid GPU output reparenting workaround"sv;
+            }
+          }
+        }
+
+        if (needs_hybrid_workaround) {
+          // We aren't calling MH_Uninitialize(), but that's okay because this hook lasts for the life of the process
+          auto mh_status = MH_Initialize();
+          if (mh_status == MH_OK || mh_status == MH_ERROR_ALREADY_INITIALIZED) {
+            mh_status = MH_CreateHookApi(L"win32u.dll", "NtGdiDdDDIGetCachedHybridQueryValue", (void *) NtGdiDdDDIGetCachedHybridQueryValueHook, nullptr);
+            if (mh_status == MH_OK) {
+              MH_EnableHook(MH_ALL_HOOKS);
+              BOOST_LOG(info) << "Installed hybrid GPU output reparenting workaround"sv;
+            } else {
+              BOOST_LOG(warning) << "Failed to hook NtGdiDdDDIGetCachedHybridQueryValue (MH status: "sv << mh_status << "), skipping hybrid GPU workaround"sv;
+            }
+          } else {
+            BOOST_LOG(warning) << "Failed to initialize MinHook (MH status: "sv << mh_status << "), skipping hybrid GPU workaround"sv;
+          }
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

- Skip the `NtGdiDdDDIGetCachedHybridQueryValue` MinHook on single-GPU systems where it's unnecessary
- Prevents a crash loop (`0xc0000005` in `dxgi.dll`) on Windows 11 24H2 build 29558+
- Adds proper error handling for MinHook API return values

## Problem

The hybrid GPU workaround hook introduced in #3530 causes an access violation in `dxgi.dll` on recent Windows 11 builds (24H2, build 29558+) with single-GPU systems. The crash is deterministic — always at offset `0x6cb2f` in `dxgi.dll` — and creates an infinite crash loop where the service wrapper restarts `sunshine.exe` every ~6 seconds.

**Crash signature:**
```
Faulting module: dxgi.dll (10.0.29558.1000)
Exception: 0xc0000005 (ACCESS_VIOLATION)
Offset: 0x000000000006cb2f
```

Root cause: the hook spoofs `D3DKMT_GPU_PREFERENCE_STATE_UNSPECIFIED` as the return value, but the updated `dxgi.dll` in build 29558 doesn't handle this state correctly on a code path that only executes when the hook is active.

## Fix

Before installing the hook, enumerate DXGI adapters to detect if the system has multiple physical GPUs:
- **Multi-GPU**: install the hook as before (needed to prevent output reparenting)
- **Single-GPU**: skip the hook entirely (no reparenting issue exists)

Adapters are deduplicated by `VendorId` + `DeviceId` since the same physical GPU can appear as multiple DXGI adapters.

Also adds:
- Error handling for `MH_Initialize()` and `MH_CreateHookApi()` return values
- Logging for hook installation status (success, skip, or failure)

## Test Plan

- [x] Verified on RTX 4070 Ti single-GPU, Windows 11 24H2 build 29558, NVIDIA 591.86
- [ ] Should be tested on multi-GPU/hybrid systems to ensure hook is still applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)