### PR TITLE
feat(input): implement multiseat support and virtual device naming

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -445,48 +445,6 @@ After adding yourself to the group, log out and log back in for the changes to t
 
 ### Linux
 
-#### Virtual Input Devices
-
-Sunshine uses virtual input devices (via uinput) to inject keyboard, mouse, and gamepad events. Access to `/dev/uinput` is typically restricted to the `input` group.
-
-Add your user to the group:
-
-```bash
-sudo usermod -aG input $USER
-```
-
-> Log out and back in after running this.
-
-The required udev rules are bundled with Sunshine and installed automatically. No manual udev configuration is needed for single-seat setups.
-
----
-
-#### Multi-seat
-
-If you run multiple concurrent Wayland sessions on separate logind seats (e.g. `seat0`, `seat1`), your compositor may ignore injected input unless Sunshine's virtual devices are assigned to the correct seat.
-
-Sunshine determines its target seat from `XDG_SEAT`, which is typically set automatically by your display manager. If needed, you can override it manually in your systemd service file or shell environment before starting Sunshine.
-
-When the seat is not `seat0`, Sunshine appends the seat name to its virtual device names, for example:
-
-- `Keyboard passthrough (seat1)`
-- `Sunshine PS5 (virtual) pad (seat1)`
-
-> Sunshine creates two mouse devices: a relative one and an absolute one (suffixed with ` (absolute)`).
-
-To assign Sunshine's virtual devices to the correct seat, create this udev rules file:
-
-**`/etc/udev/rules.d/72-sunshine-virtual-seat.rules`**
-```udev
-SUBSYSTEM=="input", KERNEL=="input*", ATTR{name}=="*(seat1)*", TAG+="seat", ENV{ID_SEAT}="seat1"
-```
-
-Then reload udev:
-
-```bash
-sudo udevadm control --reload-rules && sudo udevadm trigger -s input
-```
-
 #### Services
 
 **Start once**

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -445,6 +445,48 @@ After adding yourself to the group, log out and log back in for the changes to t
 
 ### Linux
 
+#### Virtual Input Devices
+
+Sunshine uses virtual input devices (via uinput) to inject keyboard, mouse, and gamepad events. Access to `/dev/uinput` is typically restricted to the `input` group.
+
+Add your user to the group:
+
+```bash
+sudo usermod -aG input $USER
+```
+
+> Log out and back in after running this.
+
+The required udev rules are bundled with Sunshine and installed automatically. No manual udev configuration is needed for single-seat setups.
+
+---
+
+#### Multi-seat
+
+If you run multiple concurrent Wayland sessions on separate logind seats (e.g. `seat0`, `seat1`), your compositor may ignore injected input unless Sunshine's virtual devices are assigned to the correct seat.
+
+Sunshine determines its target seat from `XDG_SEAT`, which is typically set automatically by your display manager. If needed, you can override it manually in your systemd service file or shell environment before starting Sunshine.
+
+When the seat is not `seat0`, Sunshine appends the seat name to its virtual device names, for example:
+
+- `Keyboard passthrough (seat1)`
+- `Sunshine PS5 (virtual) pad (seat1)`
+
+> Sunshine creates two mouse devices: a relative one and an absolute one (suffixed with ` (absolute)`).
+
+To assign Sunshine's virtual devices to the correct seat, create this udev rules file:
+
+**`/etc/udev/rules.d/72-sunshine-virtual-seat.rules`**
+```udev
+SUBSYSTEM=="input", KERNEL=="input*", ATTR{name}=="*(seat1)*", TAG+="seat", ENV{ID_SEAT}="seat1"
+```
+
+Then reload udev:
+
+```bash
+sudo udevadm control --reload-rules && sudo udevadm trigger -s input
+```
+
 #### Services
 
 **Start once**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,6 +159,33 @@ If the input is still not working, you may need to add your user to the `input` 
 sudo usermod -aG input $USER
 ```
 
+#### Multiseat
+
+If you run multiple concurrent Wayland sessions on separate logind seats (e.g. `seat0`, `seat1`),
+your compositor may ignore injected input unless Sunshine's virtual devices are assigned to the correct seat.
+
+Sunshine determines its target seat from `XDG_SEAT`, which is typically set automatically by your display manager.
+If needed, you can override it manually in your systemd service file or shell environment before starting Sunshine.
+
+When the seat is not `seat0`, Sunshine appends the seat name to its virtual device names, for example:
+
+- Keyboard passthrough (seat1)
+- Sunshine PS5 (virtual) pad (seat1)
+
+Sunshine creates two mouse devices: a relative one and an absolute one.
+
+To assign Sunshine's virtual devices to the correct seat, create this udev rules file
+(/etc/udev/rules.d/72-sunshine-virtual-seat.rules):
+```udev
+SUBSYSTEM=="input", KERNEL=="input*", ATTR{name}=="*(seat1)*", TAG+="seat", ENV{ID_SEAT}="seat1"
+```
+
+Then reload udev:
+
+```bash
+sudo udevadm control --reload-rules && sudo udevadm trigger -s input
+```
+
 ### KMS Streaming fails
 KMS screencasting requires elevated privileges which are not allowed for Flatpak or AppImage packages.
 This means that you must install Sunshine using the native package format of your distribution, if available.

--- a/src/platform/linux/input/inputtino_common.h
+++ b/src/platform/linux/input/inputtino_common.h
@@ -13,11 +13,27 @@
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/platform/linux/input/inputtino_seat.h"
 #include "src/utility.h"
 
 using namespace std::literals;
 
 namespace platf {
+
+  inline std::string inputtino_name_for_seat(std::string_view base_name) {
+    auto seat_id = inputtino_seat::get_target_seat();
+    if (seat_id.empty() || seat_id == "seat0") {
+      return std::string(base_name);
+    }
+
+    std::string name;
+    name.reserve(base_name.size() + seat_id.size() + 3);
+    name.append(base_name);
+    name.append(" (");
+    name.append(seat_id);
+    name.push_back(')');
+    return name;
+  }
 
   using joypads_t = std::variant<inputtino::XboxOneJoypad, inputtino::SwitchJoypad, inputtino::PS5Joypad>;
 
@@ -30,13 +46,13 @@ namespace platf {
   struct input_raw_t {
     input_raw_t():
         mouse(inputtino::Mouse::create({
-          .name = "Mouse passthrough",
+          .name = inputtino_name_for_seat("Mouse passthrough"sv),
           .vendor_id = 0xBEEF,
           .product_id = 0xDEAD,
           .version = 0x111,
         })),
         keyboard(inputtino::Keyboard::create({
-          .name = "Keyboard passthrough",
+          .name = inputtino_name_for_seat("Keyboard passthrough"sv),
           .vendor_id = 0xBEEF,
           .product_id = 0xDEAD,
           .version = 0x111,
@@ -66,13 +82,13 @@ namespace platf {
   struct client_input_raw_t: public client_input_t {
     client_input_raw_t(input_t &input):
         touch(inputtino::TouchScreen::create({
-          .name = "Touch passthrough",
+          .name = inputtino_name_for_seat("Touch passthrough"sv),
           .vendor_id = 0xBEEF,
           .product_id = 0xDEAD,
           .version = 0x111,
         })),
         pen(inputtino::PenTablet::create({
-          .name = "Pen passthrough",
+          .name = inputtino_name_for_seat("Pen passthrough"sv),
           .vendor_id = 0xBEEF,
           .product_id = 0xDEAD,
           .version = 0x111,

--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -10,6 +10,7 @@
 // local includes
 #include "inputtino_common.h"
 #include "inputtino_gamepad.h"
+#include "inputtino_seat.h"
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
@@ -27,7 +28,7 @@ namespace platf::gamepad {
   };
 
   auto create_xbox_one() {
-    return inputtino::XboxOneJoypad::create({.name = "Sunshine X-Box One (virtual) pad",
+    return inputtino::XboxOneJoypad::create({.name = inputtino_name_for_seat("Sunshine X-Box One (virtual) pad"sv),
                                              // https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c#L147
                                              .vendor_id = 0x045E,
                                              .product_id = 0x02EA,
@@ -35,7 +36,7 @@ namespace platf::gamepad {
   }
 
   auto create_switch() {
-    return inputtino::SwitchJoypad::create({.name = "Sunshine Nintendo (virtual) pad",
+    return inputtino::SwitchJoypad::create({.name = inputtino_name_for_seat("Sunshine Nintendo (virtual) pad"sv),
                                             // https://github.com/torvalds/linux/blob/master/drivers/hid/hid-ids.h#L981
                                             .vendor_id = 0x057e,
                                             .product_id = 0x2009,
@@ -50,7 +51,7 @@ namespace platf::gamepad {
       device_mac = std::format("02:00:00:00:00:{:02x}", globalIndex);
     }
 
-    return inputtino::PS5Joypad::create({.name = "Sunshine PS5 (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111, .device_phys = device_mac, .device_uniq = device_mac});
+    return inputtino::PS5Joypad::create({.name = inputtino_name_for_seat("Sunshine PS5 (virtual) pad"sv), .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111, .device_phys = device_mac, .device_uniq = device_mac});
   }
 
   int alloc(input_raw_t *raw, const gamepad_id_t &id, const gamepad_arrival_t &metadata, feedback_queue_t feedback_queue) {

--- a/src/platform/linux/input/inputtino_seat.cpp
+++ b/src/platform/linux/input/inputtino_seat.cpp
@@ -2,10 +2,11 @@
  * @file src/platform/linux/input/inputtino_seat.cpp
  * @brief Implementation for multi-seat naming (udev-only).
  */
-
-#include "inputtino_seat.h"
-
+// standard includes
 #include <cstdlib>
+
+// local includes
+#include "inputtino_seat.h"
 
 namespace platf::inputtino_seat {
 

--- a/src/platform/linux/input/inputtino_seat.cpp
+++ b/src/platform/linux/input/inputtino_seat.cpp
@@ -1,0 +1,22 @@
+/**
+ * @file src/platform/linux/input/inputtino_seat.cpp
+ * @brief Implementation for multi-seat naming (udev-only).
+ */
+
+#include "inputtino_seat.h"
+
+#include <cstdlib>
+
+namespace platf::inputtino_seat {
+
+  std::string get_target_seat() {
+    if (const char *seat = std::getenv("XDG_SEAT")) {
+      if (seat[0] != '\0') {
+        return seat;
+      }
+    }
+
+    return {};
+  }
+
+}  // namespace platf::inputtino_seat

--- a/src/platform/linux/input/inputtino_seat.h
+++ b/src/platform/linux/input/inputtino_seat.h
@@ -1,0 +1,17 @@
+/**
+ * @file src/platform/linux/input/inputtino_seat.h
+ * @brief Helpers for multi-seat naming (udev-only).
+ */
+#pragma once
+
+#include <string>
+
+namespace platf::inputtino_seat {
+
+  /**
+   * Determine the target seat for the current Sunshine instance.
+   * Returns empty string if no seat could be determined.
+   */
+  std::string get_target_seat();
+
+}  // namespace platf::inputtino_seat

--- a/src_assets/linux/misc/60-sunshine.rules
+++ b/src_assets/linux/misc/60-sunshine.rules
@@ -1,11 +1,10 @@
-# Allows Sunshine to acces /dev/uinput
+# Allows Sunshine to access /dev/uinput and /dev/uhid
 KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", GROUP="input", MODE="0660", TAG+="uaccess"
+KERNEL=="uhid",                                                     GROUP="input", MODE="0660", TAG+="uaccess"
 
-# Allows Sunshine to access /dev/uhid
-KERNEL=="uhid", GROUP="input", MODE="0660", TAG+="uaccess"
-
-# Joypads
-KERNEL=="hidraw*", ATTRS{name}=="Sunshine PS5 (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors", GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
+# Virtual joypads (seat suffix e.g. "... (seat1)" is appended on multi-seat systems)
+KERNEL=="hidraw*",   ATTRS{name}=="Sunshine PS5 (virtual) pad*",                GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine PS5 (virtual) pad*",                GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad*",          GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad*",           GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors*", GROUP="input", MODE="0660", TAG+="uaccess"

--- a/src_assets/linux/misc/60-sunshine.rules
+++ b/src_assets/linux/misc/60-sunshine.rules
@@ -10,4 +10,3 @@ SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad*", GROUP="in
 SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors*", GROUP="input", MODE="0660", TAG+="uaccess"
 SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad*", GROUP="input", MODE="0660", TAG+="uaccess"
 SUBSYSTEMS=="input", ATTRS{name}=="Sunshine PS5 (virtual) pad*", GROUP="input", MODE="0660", TAG+="uaccess"
-

--- a/src_assets/linux/misc/60-sunshine.rules
+++ b/src_assets/linux/misc/60-sunshine.rules
@@ -1,10 +1,13 @@
-# Allows Sunshine to access /dev/uinput and /dev/uhid
+# Allows Sunshine to access /dev/uinput
 KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", GROUP="input", MODE="0660", TAG+="uaccess"
-KERNEL=="uhid",                                                     GROUP="input", MODE="0660", TAG+="uaccess"
 
-# Virtual joypads (seat suffix e.g. "... (seat1)" is appended on multi-seat systems)
-KERNEL=="hidraw*",   ATTRS{name}=="Sunshine PS5 (virtual) pad*",                GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine PS5 (virtual) pad*",                GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad*",          GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad*",           GROUP="input", MODE="0660", TAG+="uaccess"
+# Allows Sunshine to access /dev/uhid
+KERNEL=="uhid", GROUP="input", MODE="0660", TAG+="uaccess"
+
+# Joypads
+KERNEL=="hidraw*", ATTRS{name}=="Sunshine PS5 (virtual) pad*", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad*", GROUP="input", MODE="0660", TAG+="uaccess"
 SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors*", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad*", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine PS5 (virtual) pad*", GROUP="input", MODE="0660", TAG+="uaccess"
+


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This change introduces multiseat input support and virtual device naming on Linux, allowing multiple users to interact with Sunshine independently on the same system. The intention is to provide flexibility for shared workstations, gaming setups, and other advanced multi-user environments.

> Modern systems (based on systemd and logind) have the concept of a seat (seat0 is default), with associated input devices and graphics outputs. For example, look at `loginctl seat-status seat0`.
> When Sunshine fires up uinput, it’s logically similar to plugging in a second USB mouse: the input gets attached to the default seat (seat0).
> While I don't know exactly what the solution should look like, (it) should ideally run as a separate "seat" (as far as logind and libinput are concerned).

from https://github.com/LizardByte/Sunshine/issues/137#issuecomment-1179947943



### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
