### PR TITLE
fix(linux): auto-detect GPU with connected display for VAAPI and Vulkan

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -861,7 +861,14 @@ namespace platf {
    */
   std::string get_host_name();
 
-  std::string find_render_node_with_display();
+  /**
+   * @brief Resolves the render device path to use for hardware encoding.
+   * @details If `config::video.adapter_name` is set, returns that.
+   *          Otherwise, auto-detects the GPU with a connected display via `find_render_node_with_display()`.
+   *          Falls back to `/dev/dri/renderD128` if detection fails.
+   * @return Resolved render device path (may be empty on non-Linux platforms).
+   */
+  std::string resolve_render_device();
 
   /**
    * @brief Gets the supported gamepads for this platform backend.

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -861,6 +861,8 @@ namespace platf {
    */
   std::string get_host_name();
 
+  std::string find_render_node_with_display();
+
   /**
    * @brief Gets the supported gamepads for this platform backend.
    * @details This may be called prior to `platf::input()`!

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1218,4 +1218,12 @@ namespace platf {
 #endif
   }
 
+  std::string resolve_render_device() {
+    if (!config::video.adapter_name.empty()) {
+      return config::video.adapter_name;
+    }
+    auto detected = find_render_node_with_display();
+    return detected.empty() ? "/dev/dri/renderD128" : detected;
+  }
+
 }  // namespace platf

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -38,6 +38,12 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#ifdef SUNSHINE_BUILD_DRM
+  #include <dirent.h>
+  #include <xf86drm.h>
+  #include <xf86drmMode.h>
+#endif
+
 // local includes
 #include "graphics.h"
 #include "misc.h"
@@ -1163,4 +1169,53 @@ namespace platf {
   std::unique_ptr<high_precision_timer> create_high_precision_timer() {
     return std::make_unique<linux_high_precision_timer>();
   }
+
+  std::string find_render_node_with_display() {
+#ifdef SUNSHINE_BUILD_DRM
+    auto *dir = opendir("/dev/dri");
+    if (!dir) {
+      return {};
+    }
+
+    std::string result;
+    while (auto *entry = readdir(dir)) {
+      if (strncmp(entry->d_name, "card", 4) != 0 || !isdigit(entry->d_name[4])) {
+        continue;
+      }
+
+      std::string path = std::string("/dev/dri/") + entry->d_name;
+      int fd = open(path.c_str(), O_RDWR);
+      if (fd < 0) {
+        continue;
+      }
+
+      auto *res = drmModeGetResources(fd);
+      if (res) {
+        for (int i = 0; i < res->count_connectors && result.empty(); i++) {
+          auto *conn = drmModeGetConnector(fd, res->connectors[i]);
+          if (conn) {
+            if (conn->connection == DRM_MODE_CONNECTED) {
+              char *render = drmGetRenderDeviceNameFromFd(fd);
+              if (render) {
+                result = render;
+                free(render);
+              }
+            }
+            drmModeFreeConnector(conn);
+          }
+        }
+        drmModeFreeResources(res);
+      }
+      close(fd);
+      if (!result.empty()) {
+        break;
+      }
+    }
+    closedir(dir);
+    return result;
+#else
+    return {};
+#endif
+  }
+
 }  // namespace platf

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -522,9 +522,7 @@ namespace va {
 
     va::display_t display {vaGetDisplayDRM(fd)};
     if (!display) {
-      auto render_device = config::video.adapter_name.empty() ? "/dev/dri/renderD128" : config::video.adapter_name.c_str();
-
-      BOOST_LOG(error) << "Couldn't open a va display from DRM with device: "sv << render_device;
+      BOOST_LOG(error) << "Couldn't open a va display from DRM with device: "sv << platf::resolve_render_device();
       return -1;
     }
 
@@ -642,9 +640,9 @@ namespace va {
   }
 
   std::unique_ptr<platf::avcodec_encode_device_t> make_avcodec_encode_device(int width, int height, int offset_x, int offset_y, bool vram) {
-    auto render_device = config::video.adapter_name.empty() ? "/dev/dri/renderD128" : config::video.adapter_name.c_str();
+    auto render_device = platf::resolve_render_device();
 
-    file_t file = open(render_device, O_RDWR);
+    file_t file = open(render_device.c_str(), O_RDWR);
     if (file.el < 0) {
       char string[1024];
       BOOST_LOG(error) << "Couldn't open "sv << render_device << ": " << strerror_r(errno, string, sizeof(string));

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -642,7 +642,7 @@ namespace va {
   std::unique_ptr<platf::avcodec_encode_device_t> make_avcodec_encode_device(int width, int height, int offset_x, int offset_y, bool vram) {
     auto render_device = platf::resolve_render_device();
 
-    file_t file = open(render_device.c_str(), O_RDWR);
+    file_t file = ::open(render_device.c_str(), O_RDWR);
     if (file.el < 0) {
       char string[1024];
       BOOST_LOG(error) << "Couldn't open "sv << render_device << ": " << strerror_r(errno, string, sizeof(string));

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -642,7 +642,7 @@ namespace va {
   std::unique_ptr<platf::avcodec_encode_device_t> make_avcodec_encode_device(int width, int height, int offset_x, int offset_y, bool vram) {
     auto render_device = platf::resolve_render_device();
 
-    file_t file = ::open(render_device.c_str(), O_RDWR);
+    file_t file = ::open(render_device.c_str(), O_RDWR);  // NOSONAR(cpp:S1874) - `_sopen_s` not available
     if (file.el < 0) {
       char string[1024];
       BOOST_LOG(error) << "Couldn't open "sv << render_device << ": " << strerror_r(errno, string, sizeof(string));

--- a/src/platform/linux/vulkan_encode.cpp
+++ b/src/platform/linux/vulkan_encode.cpp
@@ -79,7 +79,9 @@ namespace vk {
 
   static int create_vulkan_hwdevice(AVBufferRef **hw_device_buf) {
     // Resolve render device path to Vulkan device index
-    if (auto render_path = config::video.adapter_name.empty() ? "/dev/dri/renderD128" : config::video.adapter_name; render_path[0] == '/') {
+    auto detected = platf::find_render_node_with_display();
+    auto fallback = detected.empty() ? std::string("/dev/dri/renderD128") : detected;
+    if (auto render_path = config::video.adapter_name.empty() ? fallback : config::video.adapter_name; render_path[0] == '/') {
       if (auto idx = find_vulkan_index_for_render_node(render_path.c_str()); !idx.empty() && av_hwdevice_ctx_create(hw_device_buf, AV_HWDEVICE_TYPE_VULKAN, idx.c_str(), nullptr, 0) >= 0) {
         return 0;
       }

--- a/src/platform/linux/vulkan_encode.cpp
+++ b/src/platform/linux/vulkan_encode.cpp
@@ -79,9 +79,8 @@ namespace vk {
 
   static int create_vulkan_hwdevice(AVBufferRef **hw_device_buf) {
     // Resolve render device path to Vulkan device index
-    auto detected = platf::find_render_node_with_display();
-    auto fallback = detected.empty() ? std::string("/dev/dri/renderD128") : detected;
-    if (auto render_path = config::video.adapter_name.empty() ? fallback : config::video.adapter_name; render_path[0] == '/') {
+    auto render_path = platf::resolve_render_device();
+    if (render_path[0] == '/') {
       if (auto idx = find_vulkan_index_for_render_node(render_path.c_str()); !idx.empty() && av_hwdevice_ctx_create(hw_device_buf, AV_HWDEVICE_TYPE_VULKAN, idx.c_str(), nullptr, 0) >= 0) {
         return 0;
       }

--- a/src/platform/linux/vulkan_encode.cpp
+++ b/src/platform/linux/vulkan_encode.cpp
@@ -79,8 +79,7 @@ namespace vk {
 
   static int create_vulkan_hwdevice(AVBufferRef **hw_device_buf) {
     // Resolve render device path to Vulkan device index
-    auto render_path = platf::resolve_render_device();
-    if (render_path[0] == '/') {
+    if (auto render_path = platf::resolve_render_device(); render_path[0] == '/') {
       if (auto idx = find_vulkan_index_for_render_node(render_path.c_str()); !idx.empty() && av_hwdevice_ctx_create(hw_device_buf, AV_HWDEVICE_TYPE_VULKAN, idx.c_str(), nullptr, 0) >= 0) {
         return 0;
       }

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -560,6 +560,10 @@ namespace platf {
   std::unique_ptr<high_precision_timer> create_high_precision_timer() {
     return std::make_unique<macos_high_precision_timer>();
   }
+
+  std::string find_render_node_with_display() {
+    return {};
+  }
 }  // namespace platf
 
 namespace dyn {

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -561,7 +561,7 @@ namespace platf {
     return std::make_unique<macos_high_precision_timer>();
   }
 
-  std::string find_render_node_with_display() {
+  std::string resolve_render_device() {
     return {};
   }
 }  // namespace platf

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1792,7 +1792,7 @@ namespace platf {
     return true;
   }
 
-  std::string find_render_node_with_display() {
+  std::string resolve_render_device() {
     return {};
   }
 }  // namespace platf

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1791,4 +1791,8 @@ namespace platf {
 
     return true;
   }
+
+  std::string find_render_node_with_display() {
+    return {};
+  }
 }  // namespace platf

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2994,10 +2994,9 @@ namespace video {
       return hw_device_buf;
     }
 
-    auto detected = platf::find_render_node_with_display();
-    auto render_device = config::video.adapter_name.empty() ? detected.c_str() : config::video.adapter_name.c_str();
+    auto render_device = platf::resolve_render_device();
 
-    auto status = av_hwdevice_ctx_create(&hw_device_buf, AV_HWDEVICE_TYPE_VAAPI, render_device[0] ? render_device : nullptr, nullptr, 0);
+    auto status = av_hwdevice_ctx_create(&hw_device_buf, AV_HWDEVICE_TYPE_VAAPI, render_device.empty() ? nullptr : render_device.c_str(), nullptr, 0);
     if (status < 0) {
       char string[AV_ERROR_MAX_STRING_SIZE];
       BOOST_LOG(error) << "Failed to create a VAAPI device: "sv << av_make_error_string(string, AV_ERROR_MAX_STRING_SIZE, status);
@@ -3021,11 +3020,9 @@ namespace video {
     }
 
     // Try render device path first, auto-detecting the GPU with a connected display
-    auto detected = platf::find_render_node_with_display();
-    auto fallback = detected.empty() ? std::string("/dev/dri/renderD128") : detected;
-    auto render_device = config::video.adapter_name.empty() ? fallback.c_str() : config::video.adapter_name.c_str();
+    auto render_device = platf::resolve_render_device();
 
-    auto status = av_hwdevice_ctx_create(&hw_device_buf, AV_HWDEVICE_TYPE_VULKAN, render_device, nullptr, 0);
+    auto status = av_hwdevice_ctx_create(&hw_device_buf, AV_HWDEVICE_TYPE_VULKAN, render_device.c_str(), nullptr, 0);
     if (status >= 0) {
       BOOST_LOG(info) << "Using Vulkan device: "sv << render_device;
       return hw_device_buf;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2994,9 +2994,10 @@ namespace video {
       return hw_device_buf;
     }
 
-    auto render_device = config::video.adapter_name.empty() ? nullptr : config::video.adapter_name.c_str();
+    auto detected = platf::find_render_node_with_display();
+    auto render_device = config::video.adapter_name.empty() ? detected.c_str() : config::video.adapter_name.c_str();
 
-    auto status = av_hwdevice_ctx_create(&hw_device_buf, AV_HWDEVICE_TYPE_VAAPI, render_device, nullptr, 0);
+    auto status = av_hwdevice_ctx_create(&hw_device_buf, AV_HWDEVICE_TYPE_VAAPI, render_device[0] ? render_device : nullptr, nullptr, 0);
     if (status < 0) {
       char string[AV_ERROR_MAX_STRING_SIZE];
       BOOST_LOG(error) << "Failed to create a VAAPI device: "sv << av_make_error_string(string, AV_ERROR_MAX_STRING_SIZE, status);
@@ -3019,8 +3020,10 @@ namespace video {
       return hw_device_buf;
     }
 
-    // Try render device path first (like VAAPI does), then fallback to device indices
-    auto render_device = config::video.adapter_name.empty() ? "/dev/dri/renderD128" : config::video.adapter_name.c_str();
+    // Try render device path first, auto-detecting the GPU with a connected display
+    auto detected = platf::find_render_node_with_display();
+    auto fallback = detected.empty() ? std::string("/dev/dri/renderD128") : detected;
+    auto render_device = config::video.adapter_name.empty() ? fallback.c_str() : config::video.adapter_name.c_str();
 
     auto status = av_hwdevice_ctx_create(&hw_device_buf, AV_HWDEVICE_TYPE_VULKAN, render_device, nullptr, 0);
     if (status >= 0) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

On multi-GPU Linux systems, both VAAPI and Vulkan encoders hardcoded `/dev/dri/renderD128` (or passed `nullptr` for FFmpeg auto-detect) as the default render device when `adapter_name` was not configured. This caused the encoder to use the wrong GPU (e.g. Intel iGPU instead of the Nvidia dGPU driving the display), leading to encode failures or unnecessary cross-GPU copies.

This PR introduces `platf::resolve_render_device()` which centralizes render device resolution:
1. User's `adapter_name` config → used as-is
2. Auto-detected GPU with connected display (via DRM connector scanning)
3. `/dev/dri/renderD128` if detection fails

The DRM detection logic (`find_render_node_with_display()`) scans card devices for a connector in `DRM_MODE_CONNECTED` state and returns the corresponding render node via `drmGetRenderDeviceNameFromFd()`. This is kept internal to `linux/misc.cpp`.

All Linux encoder paths now use `platf::resolve_render_device()` consistently:
- `video.cpp` — VAAPI and Vulkan hardware input buffer init
- `vaapi.cpp` — encode device creation and error reporting
- `vulkan_encode.cpp` — Vulkan hardware device creation

Previously the `adapter_name → render_device` resolution logic was duplicated across these files. Now it lives in one place, avoiding potential mismatches.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes https://github.com/LizardByte/Sunshine/issues/4952


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [x] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes