### PR TITLE
fix(linux/vulkan): add 16-bit DRM format support for HDR DMA-BUF import

### DIFF
--- a/src/platform/linux/vulkan_encode.cpp
+++ b/src/platform/linux/vulkan_encode.cpp
@@ -384,23 +384,53 @@ namespace vk {
       return true;
     }
 
-    static VkFormat drm_fourcc_to_vk_format(uint32_t fourcc) {
+    struct drm_format_info {
+      VkFormat format;
+      VkComponentMapping swizzle;
+    };
+
+    static drm_format_info drm_fourcc_to_vk_format(uint32_t fourcc) {
+      static constexpr VkComponentMapping identity = {
+        VK_COMPONENT_SWIZZLE_IDENTITY,
+        VK_COMPONENT_SWIZZLE_IDENTITY,
+        VK_COMPONENT_SWIZZLE_IDENTITY,
+        VK_COMPONENT_SWIZZLE_IDENTITY,
+      };
+      static constexpr VkComponentMapping bgr_swap = {
+        VK_COMPONENT_SWIZZLE_B,
+        VK_COMPONENT_SWIZZLE_G,
+        VK_COMPONENT_SWIZZLE_R,
+        VK_COMPONENT_SWIZZLE_A,
+      };
+
       switch (fourcc) {
         case DRM_FORMAT_XRGB8888:
         case DRM_FORMAT_ARGB8888:
-          return VK_FORMAT_B8G8R8A8_UNORM;
+          return {VK_FORMAT_B8G8R8A8_UNORM, identity};
         case DRM_FORMAT_XBGR8888:
         case DRM_FORMAT_ABGR8888:
-          return VK_FORMAT_R8G8B8A8_UNORM;
+          return {VK_FORMAT_R8G8B8A8_UNORM, identity};
         case DRM_FORMAT_XRGB2101010:
         case DRM_FORMAT_ARGB2101010:
-          return VK_FORMAT_A2R10G10B10_UNORM_PACK32;
+          return {VK_FORMAT_A2R10G10B10_UNORM_PACK32, identity};
         case DRM_FORMAT_XBGR2101010:
         case DRM_FORMAT_ABGR2101010:
-          return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+          return {VK_FORMAT_A2B10G10R10_UNORM_PACK32, identity};
+        case DRM_FORMAT_XBGR16161616:
+        case DRM_FORMAT_ABGR16161616:
+          return {VK_FORMAT_R16G16B16A16_UNORM, identity};
+        case DRM_FORMAT_XRGB16161616:
+        case DRM_FORMAT_ARGB16161616:
+          return {VK_FORMAT_R16G16B16A16_UNORM, bgr_swap};
+        case DRM_FORMAT_XBGR16161616F:
+        case DRM_FORMAT_ABGR16161616F:
+          return {VK_FORMAT_R16G16B16A16_SFLOAT, identity};
+        case DRM_FORMAT_XRGB16161616F:
+        case DRM_FORMAT_ARGB16161616F:
+          return {VK_FORMAT_R16G16B16A16_SFLOAT, bgr_swap};
         default:
           BOOST_LOG(warning) << "Unknown DRM fourcc 0x" << std::hex << fourcc << std::dec << ", assuming B8G8R8A8";
-          return VK_FORMAT_B8G8R8A8_UNORM;
+          return {VK_FORMAT_B8G8R8A8_UNORM, identity};
       }
     }
 
@@ -444,7 +474,7 @@ namespace vk {
         tiling = VK_IMAGE_TILING_LINEAR;
       }
 
-      auto vk_format = drm_fourcc_to_vk_format(sd.fourcc);
+      auto [vk_format, vk_swizzle] = drm_fourcc_to_vk_format(sd.fourcc);
 
       VkImageCreateInfo img_ci = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
       img_ci.pNext = &ext_ci;
@@ -494,11 +524,12 @@ namespace vk {
 
       vkBindImageMemory(vk_dev.dev, src.image, src_mem, 0);
 
-      // Create image view (Vulkan sampling always returns RGBA order regardless of memory layout)
+      // Create image view
       VkImageViewCreateInfo view_ci = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
       view_ci.image = src.image;
       view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
       view_ci.format = vk_format;
+      view_ci.components = vk_swizzle;
       view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
       VK_CHECK_BOOL(vkCreateImageView(vk_dev.dev, &view_ci, nullptr, &src.view));
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

The Vulkan encoder failed to import DMA-BUFs from compositors using 16-bit pixel formats (common with HDR). The format `DRM_FORMAT_ABGR16161616` (0x38344241) was unrecognized, causing a fallback to `VK_FORMAT_B8G8R8A8_UNORM` which mismatched the actual 64bpp buffer layout. This made `vkCreateImage` fail with the real modifier, breaking capture entirely.

This adds mappings for all 16-bit integer and float DRM formats:
- `DRM_FORMAT_{X,A}{RGB,BGR}16161616` → `VK_FORMAT_R16G16B16A16_UNORM`
- `DRM_FORMAT_{X,A}{RGB,BGR}16161616F` → `VK_FORMAT_R16G16B16A16_SFLOAT`

Since Vulkan has no `B16G16R16A16` format, the xRGB/ARGB variants use a `VkComponentMapping` swizzle on the image view to ensure correct channel order in the compute shader.

Tested on AMD with modifier `0x200000018801b03`.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes https://github.com/LizardByte/Sunshine/issues/4944


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes