### PR TITLE
fix: Resolve minimum_fps_target related issues on all platforms

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -535,10 +535,6 @@ namespace platf {
       return true;
     }
 
-    virtual bool is_event_driven() {
-      return false;
-    }
-
     virtual ~display_t() = default;
 
     // Offsets for when streaming a specific monitor. By default, they are 0.

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -858,11 +858,6 @@ namespace pipewire {
       return 0;
     }
 
-    // This capture method is event driven; don't insert duplicate frames
-    bool is_event_driven() override {
-      return true;
-    }
-
   private:
     bool is_buffer_redundant(const egl::img_descriptor_t *img) {
       // Check for corrupted frame

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -60,22 +60,19 @@ namespace safe {
     }
 
     // pop and view should not be used interchangeably
-    template<class Rep, class Period>
+    template<typename Rep, typename Period>
     status_t pop(std::chrono::duration<Rep, Period> delay) {
       std::unique_lock ul {_lock};
 
-      if (!_continue) {
+      if (bool success = _cv.wait_for(ul, delay, [this] {
+            return (bool) _status || !_continue;
+          });
+          !success || !_continue) {
         return util::false_v<status_t>;
       }
 
-      while (!_status) {
-        if (!_continue || _cv.wait_for(ul, delay) == std::cv_status::timeout) {
-          return util::false_v<status_t>;
-        }
-      }
-
       auto val = std::move(_status);
-      _status = util::false_v<status_t>;
+      _status.reset();
       return val;
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2048,9 +2048,8 @@ namespace video {
       }
     });
 
-    // set max frame time based on client-requested target framerate (or 0.5fps/2000ms for event-driven capture)
-    double def_fps_target = (disp->is_event_driven() ? 1 : config.framerate);
-    double minimum_fps_target = (config::video.minimum_fps_target > 0.0) ? config::video.minimum_fps_target : def_fps_target;
+    // set max frame time based on client-requested target framerate.
+    double minimum_fps_target = (config::video.minimum_fps_target > 0.0) ? config::video.minimum_fps_target : config.framerate;
     std::chrono::duration<double, std::milli> max_frametime {1000.0 / minimum_fps_target};
     BOOST_LOG(info) << "Minimum FPS target set to ~"sv << (minimum_fps_target / 2) << "fps ("sv << max_frametime.count() * 2 << "ms)"sv;
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2049,9 +2049,9 @@ namespace video {
     });
 
     // set max frame time based on client-requested target framerate.
-    double minimum_fps_target = (config::video.minimum_fps_target > 0.0) ? config::video.minimum_fps_target : config.framerate;
+    double minimum_fps_target = (config::video.minimum_fps_target > 0.0) ? config::video.minimum_fps_target : (config.framerate / 2);
     std::chrono::duration<double, std::milli> max_frametime {1000.0 / minimum_fps_target};
-    BOOST_LOG(info) << "Minimum FPS target set to ~"sv << (minimum_fps_target / 2) << "fps ("sv << max_frametime.count() * 2 << "ms)"sv;
+    BOOST_LOG(info) << "Minimum FPS target set to ~"sv << minimum_fps_target << "fps ("sv << max_frametime.count() << "ms)"sv;
 
     auto shutdown_event = mail->event<bool>(mail::shutdown);
     auto packets = mail::man->queue<packet_t>(mail::video_packets);


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Multiples changes that affects all platforms, aimed at resolving issues related to the minimum_fps_target setting. During testing of both portalgrab and kmsgrab, certain streaming conditions can be observed to cause the stream framerate cap to be violated, which is resolved by these changes. 

**fix(video): set correct default minimum_fps_target and max_frametime interval alignment**

The current minimum_fps_target and max_frametime intervals are set/logged incorrectly
and break capture methods on Linux. Example with a 60fps stream:

* default minimum_fps_target is populated as config.framerate (60),
* minimum FPS target is logged as 30 and interval logged as 33.33ms, but
    pop() interval is actually 16.6ms.
* result: default value is 2x what documentation implies should be the case.
    Setting a manual value logs the target FPS and interval incorrectly but
    sets the correct target interval for the duplicate insertion logic via pop().

Issues observed at 60fps:
* kmsgrab: fps cap violations and stuttering during cursor shape changes
    due to increased host processing latency triggering extra duplicates.
* portalgrab: idle desktop settles on ~52fps instead of the correct 30fps
    default target.
* portalgrab: massive framerate bursting due to irregular frame arrival
    that manifests at specific framerates; example: "strangle 45 glxgears"
    produces sustained 90fps on a 60fps stream. Can also manifest when framerate =
    stream framerate, but is harder to reproduce.

New behaviour:
* minimum_fps_target defaults to (config.framerate / 2), and max_frametime
    aligns with the actual minimum target FPS. This makes the logging accurate
    and the existing documention becomes sensible.
* kmsgrab: during expensive cursor updates, no more framerate violations
    or stuttering.
* portalgrab: desktop idles at 30fps instead of ~52fps.
* portalgrab: bursting is resolved. No more violations at 45fps, 60fps, etc.

**fix: resolve timed pop() resetting timeout on spurious wakeups**

The previous implementation called wait_for(delay) inside a manual loop,
causing the full timeout to reset on each spurious wakeup.
Replace with a single predicate-based wait_for call, which handles
spurious wakeups internally while correctly honoring the original deadline.

**Revert "fix(linux/xdgportal): avoid duplicate frame insertion (#4839)"**

This reverts commit 99d4e053bf6bee4f4a3dfa217b608600cf42a79c.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
Fixes #4906
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [x] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
