### PR TITLE
feat(macos): implement Unicode text input

### DIFF
--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <vector>
 
 // platform includes
 #include <ApplicationServices/ApplicationServices.h>
@@ -295,7 +296,42 @@ const KeyCodeMap kKeyCodesMap[] = {
   }
 
   void unicode(input_t &input, char *utf8, int size) {
-    BOOST_LOG(info) << "unicode: Unicode input not yet implemented for MacOS."sv;
+    auto macos_input = static_cast<macos_input_t *>(input.get());
+
+    // Convert UTF-8 to UTF-16 via CFString
+    CFStringRef cfStr = CFStringCreateWithBytes(kCFAllocatorDefault,
+      (const UInt8 *) utf8, size, kCFStringEncodingUTF8, false);
+    if (!cfStr) {
+      BOOST_LOG(warning) << "unicode: Failed to convert UTF-8 input"sv;
+      return;
+    }
+
+    CFIndex length = CFStringGetLength(cfStr);
+    std::vector<UniChar> utf16(length);
+    CFStringGetCharacters(cfStr, CFRangeMake(0, length), utf16.data());
+    CFRelease(cfStr);
+
+    // Inject each character (or surrogate pair) as a key down/up event
+    for (CFIndex i = 0; i < length;) {
+      UniCharCount charLen = 1;
+      if (i + 1 < length &&
+          CFStringIsSurrogateHighCharacter(utf16[i]) &&
+          CFStringIsSurrogateLowCharacter(utf16[i + 1])) {
+        charLen = 2;
+      }
+
+      CGEventRef keyDown = CGEventCreateKeyboardEvent(macos_input->source, 0, true);
+      CGEventKeyboardSetUnicodeString(keyDown, charLen, &utf16[i]);
+      CGEventPost(kCGHIDEventTap, keyDown);
+      CFRelease(keyDown);
+
+      CGEventRef keyUp = CGEventCreateKeyboardEvent(macos_input->source, 0, false);
+      CGEventKeyboardSetUnicodeString(keyUp, charLen, &utf16[i]);
+      CGEventPost(kCGHIDEventTap, keyUp);
+      CFRelease(keyUp);
+
+      i += charLen;
+    }
   }
 
   int alloc_gamepad(input_t &input, const gamepad_id_t &id, const gamepad_arrival_t &metadata, feedback_queue_t feedback_queue) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

Implement the `platf::unicode()` function for macOS, which was previously a stub that only logged "Unicode input not yet implemented for MacOS".

The implementation converts incoming UTF-8 text to UTF-16 via `CFString`, then injects each character as a `CGEvent` keyboard event using `CGEventKeyboardSetUnicodeString()`. Surrogate pairs are handled correctly for characters outside the Basic Multilingual Plane (e.g., emoji).

This enables Moonlight clients to send composed text (e.g., CJK characters from mobile IME) directly to the macOS host, matching the existing functionality on Windows (`SendInput` + `KEYEVENTF_UNICODE`) and Linux (`Ctrl+Shift+U` + hex code).

**Context:** When using Moonlight on Android/iOS with a Chinese/Japanese/Korean input method, the IME completes text composition locally and sends the final text via `LiSendUtf8TextEvent()`. On Windows and Linux hosts, this text is correctly injected into the active application. On macOS, it was silently dropped because `platf::unicode()` was unimplemented.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes