### PR TITLE
fix(rtsp): ignore clientRefreshRateX100 if more than 1% variance from framerate

### DIFF
--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -990,6 +990,16 @@ namespace rtsp_stream {
       config.monitor.width = (int) util::from_view(args.at("x-nv-video[0].clientViewportWd"sv));
       config.monitor.framerate = (int) util::from_view(args.at("x-nv-video[0].maxFPS"sv));
       config.monitor.framerateX100 = (int) util::from_view(args.at("x-nv-video[0].clientRefreshRateX100"sv));
+      // Validate framerateX100 against framerate. Some clients (e.g. Moonlight Android) send the
+      // client display's refresh rate as clientRefreshRateX100, which may differ from the requested
+      // streaming framerate. Discard framerateX100 if the derived fps is not within 1% of framerate.
+      if (config.monitor.framerateX100 > 0) {
+        double fps_strict = config.monitor.framerateX100 / 100.0;
+        double ratio = fps_strict / config.monitor.framerate;
+        if (ratio < 0.99 || ratio > 1.01) {
+          config.monitor.framerateX100 = 0;
+        }
+      }
       config.monitor.bitrate = (int) util::from_view(args.at("x-nv-vqos[0].bw.maximumBitrateKbps"sv));
       config.monitor.slicesPerFrame = (int) util::from_view(args.at("x-nv-video[0].videoEncoderSlicesPerFrame"sv));
       config.monitor.numRefFrames = (int) util::from_view(args.at("x-nv-video[0].maxNumReferenceFrames"sv));


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
When testing https://github.com/LizardByte/Sunshine/pull/4967 I discovered an issue with Moonlight Android on my Pixel 7. Moonlight would report the `clientRefreshRateX100` as 4500. I found this strange considering the device has a 90 Hz display. After additional digging I found a couple of other interesting things.

- In Android Developer settings when enabling "Show refresh rate" it would show either 60 or 90. Not sure what causes it to vary, but even just sitting on the settings screen with nothing happening it would change between the two. Even with this at 90, Moonlight would still only send 4500.
- There is another Android Developer option, "Disable default frame rate for games". With this enabled, Moonlight would send 9000 which is what I would expect in every case.
- With "Disable default frame rate for games" disabled, Moonlight will send 6000 if the battery is at 80% or above. At 79% it will send 4500. I did not test other battery ranges so don't know if it further changes the values.

This PR ignores the `clientRefreshRateX100` value from the client if there is more than 1% variance.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
