### PR TITLE
fix(network): restore ExternalIP in server info response

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -761,6 +761,10 @@ namespace nvhttp {
     }
     tree.put("root.ServerCodecModeSupport", codec_mode_flags);
 
+    if (!config::nvhttp.external_ip.empty()) {
+      tree.put("root.ExternalIP", config::nvhttp.external_ip);
+    }
+
     auto current_appid = proc::proc.running();
     tree.put("root.PairStatus", pair_status);
     tree.put("root.currentgame", current_appid);


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Restore the `ExternalIP` field in the server info response sent to Moonlight clients.

This field was [removed in commit 25e02447](https://github.com/LizardByte/Sunshine/commit/25e0244705b6e544a185e2286874884299f0e43e) (May 2023) with the rationale that Moonlight's STUN logic should suffice, and that an incorrect `ExternalIP` could override STUN and make things worse.

However, for setups where the default gateway is not the path to the Sunshine host, STUN-based discovery fails and the `ExternalIP` field is the only way for Moonlight clients to connect over the internet. This has been an open issue for years (see [#1453](https://github.com/LizardByte/Sunshine/issues/1453), filed July 2023, closed without resolution). I have been carrying this fix in my personal builds ever since.

My use case: my ISP does not provide a public IPv4 address, so I route connectivity from a VPS with a public IPv4 through a VPN tunnel to my Sunshine host. In this setup, the default gateway is not a gateway to the Sunshine host — it's the VPN server. Without `ExternalIP` exposed to Moonlight clients, they cannot determine the correct WAN address to reach the host.

No impact on existing users: the `external_ip` config option is empty by default. The `ExternalIP` field is only included in the server info response when the user explicitly sets `external_ip` in their config. If it's not set, the field is simply not there — Moonlight's STUN logic works exactly as it does today, nothing changes.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #1453

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [X] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes