### PR TITLE
fix(system_tray): dispatch tray updates asynchronously to avoid blocking callers (#4199)

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -33,8 +33,10 @@
   #include <chrono>
   #include <csignal>
   #include <format>
+  #include <mutex>
   #include <string>
   #include <thread>
+  #include <utility>
 
   // lib includes
   #include <boost/filesystem.hpp>
@@ -54,6 +56,100 @@ using namespace std::literals;
 // system_tray namespace
 namespace system_tray {
   static std::atomic tray_initialized = false;
+
+  namespace detail {
+    // Holds the shared state used by the async tray update workers. Packaged
+    // in a Meyers-singleton accessor below so the mutex and the persistent
+    // string buffers are function-local statics rather than file-scope
+    // globals.
+    struct tray_async_state_t {
+      // Serializes mutation of the `tray` struct across the detached workers
+      // spawned by update_tray_*(). tray_update() itself is internally
+      // serialized on Linux/macOS via the tray library's own main-loop
+      // dispatch, but we can still race on the fields of `tray` without this.
+      std::mutex mutex;
+
+      // Persistent string storage for notification text. tray_update() on
+      // Linux stores pointers into these strings and needs them to stay
+      // valid until the next update, so they cannot be local to the worker.
+      // Accessed only while holding `mutex`.
+      std::string playing_msg;
+      std::string pausing_msg;
+      std::string stopped_msg;
+    };
+
+    static tray_async_state_t &tray_async_state() {
+      static tray_async_state_t state;
+      return state;
+    }
+
+    // Runs `fn` under the tray-async lock and contains any exception it
+    // throws so the detached worker thread terminates cleanly instead of
+    // propagating exceptions past std::jthread. Templated so the caller
+    // passes its lambda directly without a std::function hop.
+    template<typename F>
+    void safe_run_tray_update(F &&fn) noexcept {
+      try {
+        auto &state = tray_async_state();
+        std::lock_guard lk(state.mutex);
+        if (!tray_initialized) {
+          return;
+        }
+        std::forward<F>(fn)();
+      } catch (const std::exception &e) {
+        BOOST_LOG(warning) << "Tray update threw: "sv << e.what();
+      }
+    }
+  }  // namespace detail
+
+  // Spawn a detached worker that performs a tray update.
+  //
+  // Rationale: on Linux, tray_update() synchronously waits for the GTK
+  // main loop (i.e. the tray thread) to run the update callback — which
+  // in turn calls libnotify and libayatana-appindicator. If the active
+  // notification daemon is unresponsive (a common failure mode on
+  // Wayland compositors during desktop transitions or when the daemon
+  // crashes), the callback blocks indefinitely and the caller blocks
+  // with it.
+  //
+  // The caller is frequently stream::session::join(), which arms a
+  // 10-second NVENC-deadlock watchdog that triggers debug_trap() on
+  // timeout. A hung notification daemon therefore ends up terminating
+  // the entire sunshine process with SIGTRAP. See #4199.
+  //
+  // Running the update on a detached thread decouples the caller from
+  // the tray subsystem: session teardown completes promptly, while
+  // the worker stays blocked on tray_update() until the notification
+  // daemon eventually responds (or the process exits).
+  //
+  // Templated on `F` so the caller's lambda is forwarded directly into
+  // the worker without a std::function type-erasure hop.
+  template<typename F>
+  void run_tray_async(F &&fn) {
+    if (!tray_initialized) {
+      return;
+    }
+    try {
+      // std::jthread is used for its RAII guarantees; the thread is
+      // immediately detached because tray_update() is allowed to block
+      // indefinitely on a hung notification daemon and must not delay
+      // process shutdown or the caller's critical path.
+      // Intentional detach: the worker may block inside tray_update()
+      // indefinitely if the notification daemon is unresponsive (that is
+      // precisely the failure mode this function exists to isolate from
+      // the caller). Joining or extending the thread's scope would
+      // reintroduce the deadlock.
+      std::jthread worker([fn = std::forward<F>(fn)]() mutable {
+        detail::safe_run_tray_update(std::move(fn));
+      });
+      worker.detach();  // NOSONAR(cpp:S5962)
+    } catch (const std::system_error &e) {
+      // std::jthread construction can fail with std::system_error if the
+      // OS is out of resources; in that case we drop the update rather
+      // than surface the failure to the caller's critical path.
+      BOOST_LOG(warning) << "Failed to spawn tray update thread: "sv << e.what();
+    }
+  }
 
   void tray_open_ui_cb([[maybe_unused]] struct tray_menu *item) {
     BOOST_LOG(info) << "Opening UI from system tray"sv;
@@ -283,88 +379,84 @@ namespace system_tray {
   }
 
   void update_tray_playing(std::string app_name) {
-    if (!tray_initialized) {
-      return;
-    }
+    run_tray_async([name = std::move(app_name)]() {
+      auto &state = detail::tray_async_state();
+      tray.notification_title = nullptr;
+      tray.notification_text = nullptr;
+      tray.notification_cb = nullptr;
+      tray.notification_icon = nullptr;
+      tray.icon = TRAY_ICON_PLAYING;
+      tray_update(&tray);
 
-    tray.notification_title = nullptr;
-    tray.notification_text = nullptr;
-    tray.notification_cb = nullptr;
-    tray.notification_icon = nullptr;
-    tray.icon = TRAY_ICON_PLAYING;
-    tray_update(&tray);
-    tray.icon = TRAY_ICON_PLAYING;
-    tray.notification_title = "Stream Started";
-
-    static std::string msg = std::format("Streaming started for {}", app_name);
-    tray.notification_text = msg.c_str();
-    tray.tooltip = msg.c_str();
-    tray.notification_icon = TRAY_ICON_PLAYING;
-    tray_update(&tray);
+      state.playing_msg = std::format("Streaming started for {}", name);
+      tray.icon = TRAY_ICON_PLAYING;
+      tray.notification_title = "Stream Started";
+      tray.notification_text = state.playing_msg.c_str();
+      tray.tooltip = state.playing_msg.c_str();
+      tray.notification_icon = TRAY_ICON_PLAYING;
+      tray_update(&tray);
+    });
   }
 
   void update_tray_pausing(std::string app_name) {
-    if (!tray_initialized) {
-      return;
-    }
+    run_tray_async([name = std::move(app_name)]() {
+      auto &state = detail::tray_async_state();
+      tray.notification_title = nullptr;
+      tray.notification_text = nullptr;
+      tray.notification_cb = nullptr;
+      tray.notification_icon = nullptr;
+      tray.icon = TRAY_ICON_PAUSING;
+      tray_update(&tray);
 
-    tray.notification_title = nullptr;
-    tray.notification_text = nullptr;
-    tray.notification_cb = nullptr;
-    tray.notification_icon = nullptr;
-    tray.icon = TRAY_ICON_PAUSING;
-    tray_update(&tray);
-
-    static std::string msg = std::format("Streaming paused for {}", app_name);
-    tray.icon = TRAY_ICON_PAUSING;
-    tray.notification_title = "Stream Paused";
-    tray.notification_text = msg.c_str();
-    tray.tooltip = msg.c_str();
-    tray.notification_icon = TRAY_ICON_PAUSING;
-    tray_update(&tray);
+      state.pausing_msg = std::format("Streaming paused for {}", name);
+      tray.icon = TRAY_ICON_PAUSING;
+      tray.notification_title = "Stream Paused";
+      tray.notification_text = state.pausing_msg.c_str();
+      tray.tooltip = state.pausing_msg.c_str();
+      tray.notification_icon = TRAY_ICON_PAUSING;
+      tray_update(&tray);
+    });
   }
 
   void update_tray_stopped(std::string app_name) {
-    if (!tray_initialized) {
-      return;
-    }
+    run_tray_async([name = std::move(app_name)]() {
+      auto &state = detail::tray_async_state();
+      tray.notification_title = nullptr;
+      tray.notification_text = nullptr;
+      tray.notification_cb = nullptr;
+      tray.notification_icon = nullptr;
+      tray.icon = TRAY_ICON;
+      tray_update(&tray);
 
-    tray.notification_title = nullptr;
-    tray.notification_text = nullptr;
-    tray.notification_cb = nullptr;
-    tray.notification_icon = nullptr;
-    tray.icon = TRAY_ICON;
-    tray_update(&tray);
-
-    static std::string msg = std::format("Application {} successfully stopped", app_name);
-    tray.icon = TRAY_ICON;
-    tray.notification_icon = TRAY_ICON;
-    tray.notification_title = "Application Stopped";
-    tray.notification_text = msg.c_str();
-    tray.tooltip = PROJECT_NAME;
-    tray_update(&tray);
+      state.stopped_msg = std::format("Application {} successfully stopped", name);
+      tray.icon = TRAY_ICON;
+      tray.notification_icon = TRAY_ICON;
+      tray.notification_title = "Application Stopped";
+      tray.notification_text = state.stopped_msg.c_str();
+      tray.tooltip = PROJECT_NAME;
+      tray_update(&tray);
+    });
   }
 
   void update_tray_require_pin() {
-    if (!tray_initialized) {
-      return;
-    }
+    run_tray_async([]() {
+      tray.notification_title = nullptr;
+      tray.notification_text = nullptr;
+      tray.notification_cb = nullptr;
+      tray.notification_icon = nullptr;
+      tray.icon = TRAY_ICON;
+      tray_update(&tray);
 
-    tray.notification_title = nullptr;
-    tray.notification_text = nullptr;
-    tray.notification_cb = nullptr;
-    tray.notification_icon = nullptr;
-    tray.icon = TRAY_ICON;
-    tray_update(&tray);
-    tray.icon = TRAY_ICON;
-    tray.notification_title = "Incoming Pairing Request";
-    tray.notification_text = "Click here to complete the pairing process";
-    tray.notification_icon = TRAY_ICON_LOCKED;
-    tray.tooltip = PROJECT_NAME;
-    tray.notification_cb = []() {
-      launch_ui("/pin");
-    };
-    tray_update(&tray);
+      tray.icon = TRAY_ICON;
+      tray.notification_title = "Incoming Pairing Request";
+      tray.notification_text = "Click here to complete the pairing process";
+      tray.notification_icon = TRAY_ICON_LOCKED;
+      tray.tooltip = PROJECT_NAME;
+      tray.notification_cb = []() {
+        launch_ui("/pin");
+      };
+      tray_update(&tray);
+    });
   }
 
   // Threading functions available on all platforms


### PR DESCRIPTION
## Summary

`update_tray_*()` functions in `src/system_tray.cpp` call `tray_update()`, which on Linux blocks the caller inside `pthread_cond_wait` until the tray library's GTK main-loop callback runs. That callback calls `libayatana-appindicator` and `libnotify` synchronously. If the active desktop notification daemon is unresponsive — a common failure mode on Wayland compositors (swaync/dunst/Quickshell) during desktop transitions, lock screens, or daemon restarts — the callback blocks indefinitely and every caller of `update_tray_*` blocks with it.

One of those callers is `stream::session::join()`, which arms a 10-second NVENC-deadlock watchdog. When the tray update doesn't return in time, the watchdog fires `debug_trap()` and the entire sunshine process dies with `SIGTRAP`. Reported as #4199.

**Before:** `session::join() → update_tray_pausing() → tray_update() → pthread_cond_wait → tray_update_internal → notify_notification_show → GDBus blocked on a hung notification daemon → 10 s → debug_trap() → process dies.**

**After:** `session::join() → update_tray_pausing() → spawn detached worker → return. session teardown completes. The worker stays blocked until the daemon recovers; if the process exits first, the thread is cleaned up by the OS.`

## Change

- New helper `run_tray_async(fn)` that spawns a detached `std::thread`, takes `tray_async_mutex`, and runs `fn`. Catches exceptions so a runaway tray/notify library call can't kill the worker. No-ops cleanly if `tray_initialized` is false at post time or at worker start time (race window).
- `tray_async_mutex` serializes mutation of the shared `tray` struct across workers.
- Persistent file-scope `std::string` buffers (`playing_msg_buf`, `pausing_msg_buf`, `stopped_msg_buf`) replace the `static std::string msg = std::format(...)` pattern. The old pattern only evaluated the format expression the first time each function ran, permanently capturing the first `app_name`; this also fixes that latent bug.
- Each `update_tray_*` body moves verbatim into a lambda passed to `run_tray_async`.

## What stays the same

- Public API (`src/system_tray.h`). No call-site changes in `src/stream.cpp`, `src/main.cpp`, `src/nvhttp.cpp`, `src/process.cpp`.
- Tray event loop (`tray_thread_worker` + `process_tray_events` using `tray_loop(1)`) is untouched — #4457's power optimization is preserved.
- The `session::join()` NVENC-deadlock watchdog is untouched — it exists for a separate, legitimate NVIDIA-driver issue, and remains the intended failsafe. The fix just prevents a non-critical tray subsystem from tripping it.
- Windows and macOS tray paths work unchanged. `tray_update()` on those platforms isn't known to block, but routing through the async worker costs essentially nothing and eliminates any possibility of blocking the caller.

## Trade-offs / caveats

- Each update spawns a transient thread (~one per streaming state change — a few per session). If the notification daemon is hung and never recovers, the workers stay blocked on `tray_async_mutex` + `tray_update`'s internal cond var. Memory impact is bounded by stream state transitions per session.
- If the notification daemon is permanently wedged, tray state stops updating but sunshine otherwise runs normally. Before this patch, sunshine would SIGTRAP instead.
- `std::thread` construction can throw on resource exhaustion; this is caught and logged (warning) and the update is dropped. Dropping a tray icon update is preferable to surfacing the error on session teardown.

## Test plan

- [x] Reproduced #4199 locally on CachyOS / Hyprland (Wayland, Quickshell-based notification daemon) with the upstream `v2025.924.154138` tag: cluster of `SIGTRAP` crashes on Moonlight disconnect, `coredumpctl` showed `raise` → `pthread_once` in the tray handler path.
- [x] Built sunshine with this patch applied (v2025.924 tag port; this PR is forward-ported to master); ran 10+ connect/disconnect cycles from Moonlight — no SIGTRAP, session teardown completes cleanly each time.
- [x] Verified tray icon and notifications still work when the notification daemon is healthy.
- [ ] CI: I have only tested on Linux. Windows and macOS reviewers: please confirm tray behavior is unchanged (the only user-visible change is that updates run on a short-lived worker thread).

Fixes #4199