### PR TITLE
fix(linux/pipewire): calculate env_width/env_height from all displays for pipewire_display_t 

### DIFF
--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -608,31 +608,37 @@ namespace pipewire {
      *  @brief Verify and update display parameters for logical dimensions, desktop dimensions and logical desktop dimensions (default is adapted from wlgrab)
      */
     virtual void verify_and_update_display_parameters() {
-      // Set environment dimensions to stream dimensions (unless we find something better to report here)
-      if (env_height <= 0 || env_width <= 0) {
-        this->env_width = width;
-        this->env_height = height;
-        BOOST_LOG(debug) << "[pipewire] Desktop Resolution: "sv << env_width << 'x' << env_height;
-      }
-      // Query logical sizes directly using wayland wl::monitors() and match current screen based on offset/dimensions
-      if (logical_height <= 0 || logical_width <= 0 || env_logical_height <= 0 || env_logical_width <= 0) {
+      // Query outputs directly using wayland wl::monitors()
+      if (logical_height <= 0 || logical_width <= 0 || env_logical_height <= 0 || env_logical_width <= 0 || env_height <= 0 || env_width <= 0) {
+        int desktop_width = 0;
+        int desktop_height = 0;
         int desktop_logical_width = 0;
         int desktop_logical_height = 0;
         for (const auto &monitor : wl::monitors()) {
-          // If logical_width and logical_height are not valid try to update them to correct values by matching to monitor position/dimension or position/logical dimensions
-          // since we're iterating for maximum environment size anyway
+          // If logical_width and logical_height are not valid try to update them to correct values by matching to monitor
+          // position/dimension or position/logical dimensions here since we're iterating for maximum environment size anyway
           if ((logical_width <= 0 || logical_height <= 0) && monitor->viewport.offset_x == offset_x && monitor->viewport.offset_y == offset_y && ((monitor->viewport.width == width && monitor->viewport.height == height) || (monitor->viewport.logical_width == width && monitor->viewport.logical_height == height))) {
             this->logical_width = monitor->viewport.logical_width;
             this->logical_height = monitor->viewport.logical_height;
             BOOST_LOG(debug) << "[pipewire] Logical Resolution: "sv << logical_width << 'x' << logical_height;
           }
-          // Update logical dimensions to setup maximum environment size over all screens
+          // Update desktop dimensions to setup maximum environment size over all screens
+          desktop_width = std::max(desktop_width, monitor->viewport.offset_x + monitor->viewport.width);
+          desktop_height = std::max(desktop_height, monitor->viewport.offset_y + monitor->viewport.height);
+          // Update desktop logical dimensions to setup maximum logical environment size over all screens
           desktop_logical_width = std::max(desktop_logical_width, monitor->viewport.offset_x + monitor->viewport.logical_width);
           desktop_logical_height = std::max(desktop_logical_height, monitor->viewport.offset_y + monitor->viewport.logical_height);
         }
-        this->env_logical_width = std::max(env_logical_width, desktop_logical_width);
-        this->env_logical_height = std::max(env_logical_height, desktop_logical_height);
-        BOOST_LOG(debug) << "[pipewire] Logical Desktop Resolution: "sv << env_logical_width << 'x' << env_logical_height;
+        if (env_height <= 0 || env_width <= 0) {
+          this->env_width = desktop_width;
+          this->env_height = desktop_height;
+          BOOST_LOG(debug) << "[pipewire] Desktop Resolution: "sv << env_width << 'x' << env_height;
+        }
+        if (env_logical_height <= 0 || env_logical_width <= 0) {
+          this->env_logical_width = desktop_logical_width;
+          this->env_logical_height = desktop_logical_height;
+          BOOST_LOG(debug) << "[pipewire] Logical Desktop Resolution: "sv << env_logical_width << 'x' << env_logical_height;
+        }
       }
     }
 

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -615,12 +615,13 @@ namespace pipewire {
         int desktop_logical_width = 0;
         int desktop_logical_height = 0;
         for (const auto &monitor : wl::monitors()) {
+          BOOST_LOG(debug) << "[pipewire] Found output: '"sv << monitor->name << "' offset: "sv << monitor->viewport.offset_x << 'x' << monitor->viewport.offset_y << " resolution: "sv << monitor->viewport.width << 'x' << monitor->viewport.height << " logical resolution: "sv << monitor->viewport.logical_width << 'x' << monitor->viewport.logical_height;
           // If logical_width and logical_height are not valid try to update them to correct values by matching to monitor
           // position/dimension or position/logical dimensions here since we're iterating for maximum environment size anyway
           if ((logical_width <= 0 || logical_height <= 0) && monitor->viewport.offset_x == offset_x && monitor->viewport.offset_y == offset_y && ((monitor->viewport.width == width && monitor->viewport.height == height) || (monitor->viewport.logical_width == width && monitor->viewport.logical_height == height))) {
             this->logical_width = monitor->viewport.logical_width;
             this->logical_height = monitor->viewport.logical_height;
-            BOOST_LOG(debug) << "[pipewire] Logical Resolution: "sv << logical_width << 'x' << logical_height;
+            BOOST_LOG(debug) << "[pipewire] Set logical resolution: "sv << logical_width << 'x' << logical_height;
           }
           // Update desktop dimensions to setup maximum environment size over all screens
           desktop_width = std::max(desktop_width, monitor->viewport.offset_x + monitor->viewport.width);
@@ -632,12 +633,12 @@ namespace pipewire {
         if (env_height <= 0 || env_width <= 0) {
           this->env_width = desktop_width;
           this->env_height = desktop_height;
-          BOOST_LOG(debug) << "[pipewire] Desktop Resolution: "sv << env_width << 'x' << env_height;
+          BOOST_LOG(debug) << "[pipewire] Set desktop resolution: "sv << env_width << 'x' << env_height;
         }
         if (env_logical_height <= 0 || env_logical_width <= 0) {
           this->env_logical_width = desktop_logical_width;
           this->env_logical_height = desktop_logical_height;
-          BOOST_LOG(debug) << "[pipewire] Logical Desktop Resolution: "sv << env_logical_width << 'x' << env_logical_height;
+          BOOST_LOG(debug) << "[pipewire] Set desktop logical resolution: "sv << env_logical_width << 'x' << env_logical_height;
         }
       }
     }
@@ -668,7 +669,7 @@ namespace pipewire {
         BOOST_LOG(error) << "[pipewire] Could not find display with name: '"sv << display_name << "'";
         return -1;
       }
-      BOOST_LOG(info) << "[pipewire] Streaming display '"sv << display_name << "' from position: "sv << offset_x << "x"sv << offset_y << " resolution: "sv << width << "x"sv << height;
+      BOOST_LOG(info) << "[pipewire] Streaming display '"sv << display_name << "' offset: "sv << offset_x << "x"sv << offset_y << " resolution: "sv << width << "x"sv << height;
 
       // Verify or update display parameters for streaming to ensure absolute touch inputs work as expected
       verify_and_update_display_parameters();


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This PR changes the calculations for full desktop resolution in env_width/env_height to regard all wayland outputs and calculate them like env_logical_width/env_logical_height. 

I've only tested #5041 with moonlight-android (lacking necessary test-case for moonlight-qt) and there it was working fine with the previous assumption for single display. Turns out moonlight-qt is doing absolute touch events differently (sending different event type) and the only thing that was assumed in #5041 being env_width/env_height might/seems to come into play here. 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
 - Related to #5049 but only partial fix

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
