### PR TITLE
feat(linux/xdgportal): Simplify display matching logic

### DIFF
--- a/src/platform/linux/portalgrab.cpp
+++ b/src/platform/linux/portalgrab.cpp
@@ -96,42 +96,14 @@ namespace portal {
 
     std::string to_display_name() {
       if (!monitor_name.empty()) {
-        return std::format("n{}", monitor_name);
+        return monitor_name;
       }
-      return std::format("p{},{},{},{}", pos_x, pos_y, width, height);
+      return std::format("position-{}x{}-resolution-{}x{}", pos_x, pos_y, width, height);
     }
 
-    bool match_display_name(const std::string &display_name) const {
-      // Empty display_name never matches
-      if (display_name.empty()) {
-        return false;
-      }
-      // Method 1: Display_name starts with 'n' match by monitor_name starting from pos 1
-      if (display_name[0] == 'n') {
-        return display_name.substr(1) == monitor_name;
-      }
-      // Method 2: Display_name starts with 'p' match by position+resolution starting from pos 1
-      if (display_name[0] == 'p') {
-        auto stringstream = std::stringstream(display_name.substr(1));
-        std::string stringvalue;
-        std::vector<int> values;
-        constexpr char display_name_delimiter = ',';
-        while (std::getline(stringstream, stringvalue, display_name_delimiter)) {
-          if (std::ranges::all_of(stringvalue, ::isdigit)) {
-            values.emplace_back(std::stoi(stringvalue));
-          } else {
-            BOOST_LOG(debug) << "[portalgrab] Failed to parse int value: '"sv << stringvalue << "'";
-          }
-        }
-        // Check if the vector has 4 values (pos_x, pos_y, width, height) from display_names formatting
-        if (values.size() != 4) {
-          BOOST_LOG(debug) << "[portalgrab] Display name does not match expected format 'x,y,w,h': '"sv << display_name << "'";
-          return false;
-        }
-        return pos_x == values[0] && pos_y == values[1] && width == values[2] && height == values[3];
-      }
-      // All matching methods have failed. No match!
-      return false;
+    bool match_display_name(const std::string_view &display_name) {
+      // Check the given non-empty display name matches the display name for this struct
+      return !display_name.empty() && display_name == to_display_name();
     }
   };
 
@@ -668,7 +640,7 @@ namespace portal {
         BOOST_LOG(error) << "[portalgrab] No streams found on portal. portal_t setup failed.";
         return -1;
       }
-      for (const auto &stream_ : streams) {
+      for (auto &stream_ : streams) {
         if (stream_.match_display_name(display_name)) {
           stream = stream_;
           use_fallback = false;
@@ -768,7 +740,7 @@ namespace platf {
     }
 
     for (auto stream_ : dbus->pipewire_streams) {
-      BOOST_LOG(info) << "[portalgrab] Found stream for display: '"sv << stream_.monitor_name << "' position: "sv << stream_.pos_x << "x"sv << stream_.pos_y << " resolution: "sv << stream_.width << "x"sv << stream_.height;
+      BOOST_LOG(info) << "[portalgrab] Found stream for display id/name: '"sv << stream_.monitor_name << "' position: "sv << stream_.pos_x << "x"sv << stream_.pos_y << " resolution: "sv << stream_.width << "x"sv << stream_.height;
       display_names.emplace_back(stream_.to_display_name());
     }
     // Release the portal session as soon as possible to properly release related resources early.


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This simplifies the display name matching logic and also allows for wl_output names to be used directly for config parameter output_name to select the initial display. The latter I've noticed was possible due to a side-note in #5049. 

Note: If someone already figured out that output_name can be used with portalgrab by prefixing the wayland output name with 'n' (DP-1 getting selected by output_name=nDP-1) this will break as it will now require the output_name to be equal to the wayland output name (DP-1 being selected with output_name=DP-1 in config) which is a lot more self-explaining.

Additionally the log message for found display explicitly states the id/name parameter now so it somewhat matches the documented behaviour.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [X] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [X] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
