### PR TITLE
Add macOS left Alt to Command mapping option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -614,6 +614,30 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### key_leftalt_to_key_cmd
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            On macOS, map the Left Alt key from Moonlight to the left Command key. This can be useful when the client cannot send the Windows key directly.
+            @caution{Applies to macOS only.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}
+            disabled
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            key_leftalt_to_key_cmd = enabled
+            @endcode</td>
+    </tr>
+</table>
+
 ### mouse
 
 <table>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -580,6 +580,7 @@ namespace config {
     true,  // mouse enabled
     true,  // controller enabled
     true,  // always send scancodes
+    false,  // map left alt to command on macOS
     true,  // high resolution scrolling
     true,  // native pen/touch support
   };
@@ -1278,6 +1279,8 @@ namespace config {
     if (map_rightalt_to_win) {
       input.keybindings.emplace(0xA5, 0x5B);
     }
+
+    bool_f(vars, "key_leftalt_to_key_cmd", input.key_leftalt_to_key_cmd);
 
     to = std::numeric_limits<int>::min();
     int_f(vars, "back_button_timeout", to);

--- a/src/config.h
+++ b/src/config.h
@@ -212,6 +212,7 @@ namespace config {
     bool controller;
 
     bool always_send_scancodes;
+    bool key_leftalt_to_key_cmd;
 
     bool high_resolution_scrolling;
     bool native_pen_touch;

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -14,6 +14,7 @@
 #include <mach/mach.h>
 
 // local includes
+#include "src/config.h"
 #include "src/display_device.h"
 #include "src/input.h"
 #include "src/logging.h"
@@ -229,6 +230,10 @@ const KeyCodeMap kKeyCodesMap[] = {
   // clang-format on
 
   int keysym(int keycode) {
+    if (config::input.key_leftalt_to_key_cmd && keycode == 0xA4 /* VKEY_LMENU */) {
+      return kVK_Command;
+    }
+
     KeyCodeMap key_map {};
 
     key_map.win_keycode = keycode;

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -209,6 +209,7 @@
               "key_repeat_frequency": 24.9,
               "always_send_scancodes": "enabled",
               "key_rightalt_to_key_win": "disabled",
+              "key_leftalt_to_key_cmd": "disabled",
               "mouse": "enabled",
               "high_resolution_scrolling": "enabled",
               "native_pen_touch": "enabled",

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -155,6 +155,15 @@ const config = ref(props.config)
               default="false"
     ></Checkbox>
 
+    <!-- Mapping Key AltLeft to Key Command -->
+    <Checkbox v-if="config.keyboard === 'enabled' && platform === 'macos'"
+              class="mb-3"
+              id="key_leftalt_to_key_cmd"
+              locale-prefix="config"
+              v-model="config.key_leftalt_to_key_cmd"
+              default="false"
+    ></Checkbox>
+
     <!-- Enable Mouse Input -->
     <hr>
     <Checkbox class="mb-3"

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -252,6 +252,8 @@
     "key_repeat_frequency_desc": "How often keys repeat every second. This configurable option supports decimals.",
     "key_rightalt_to_key_win": "Map Right Alt key to Windows key",
     "key_rightalt_to_key_win_desc": "It may be possible that you cannot send the Windows Key from Moonlight directly. In those cases it may be useful to make Sunshine think the Right Alt key is the Windows key",
+    "key_leftalt_to_key_cmd": "Map Left Alt key to Command key",
+    "key_leftalt_to_key_cmd_desc": "On macOS, map the Left Alt key from Moonlight to the left Command key. This can be useful when the client cannot send the Windows key directly.",
     "keybindings": "Keybindings",
     "keyboard": "Enable Keyboard Input",
     "keyboard_desc": "Allows guests to control the host system with the keyboard",

--- a/src_assets/common/assets/web/public/assets/locale/en_GB.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_GB.json
@@ -249,6 +249,8 @@
     "key_repeat_frequency_desc": "How often keys repeat every second. This configurable option supports decimals.",
     "key_rightalt_to_key_win": "Map Right Alt key to Windows key",
     "key_rightalt_to_key_win_desc": "It may be possible that you cannot send the Windows Key from Moonlight directly. In those cases it may be useful to make Sunshine think the Right Alt key is the Windows key",
+    "key_leftalt_to_key_cmd": "Map Left Alt key to Command key",
+    "key_leftalt_to_key_cmd_desc": "On macOS, map the Left Alt key from Moonlight to the left Command key. This can be useful when the client cannot send the Windows key directly.",
     "keybindings": "Keybindings",
     "keyboard": "Enable Keyboard Input",
     "keyboard_desc": "Allows guests to control the host system with the keyboard",

--- a/src_assets/common/assets/web/public/assets/locale/en_US.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_US.json
@@ -249,6 +249,8 @@
     "key_repeat_frequency_desc": "How often keys repeat every second. This configurable option supports decimals.",
     "key_rightalt_to_key_win": "Map Right Alt key to Windows key",
     "key_rightalt_to_key_win_desc": "It may be possible that you cannot send the Windows Key from Moonlight directly. In those cases it may be useful to make Sunshine think the Right Alt key is the Windows key",
+    "key_leftalt_to_key_cmd": "Map Left Alt key to Command key",
+    "key_leftalt_to_key_cmd_desc": "On macOS, map the Left Alt key from Moonlight to the left Command key. This can be useful when the client cannot send the Windows key directly.",
     "keybindings": "Keybindings",
     "keyboard": "Enable Keyboard Input",
     "keyboard_desc": "Allows guests to control the host system with the keyboard",


### PR DESCRIPTION
## Description

This adds an opt-in macOS input setting, `key_leftalt_to_key_cmd`, that maps Moonlight's Left Alt key (`VKEY_LMENU`) to the left macOS Command key.

The mapping happens in the macOS platform key translation layer rather than through `keybindings`. This matters because `keybindings = [0xA4, 0x5B]` remaps the key before Sunshine updates its internal modifier state; later key packets that still carry the Alt modifier can then cause Sunshine to synthesize Option in addition to Command. By leaving the core keycode as `VKEY_LMENU` and only changing the macOS virtual key emitted to CoreGraphics, Sunshine continues to track Alt internally while macOS receives Command.

This is useful for macOS hosts accessed from clients or operating systems that intercept the Windows key before Moonlight can send it, but can still send Left Alt.

## Changes

- Adds `key_leftalt_to_key_cmd`, default disabled.
- Applies the remap only in `src/platform/macos/input.cpp`.
- Adds the option to the web UI for macOS hosts.
- Updates configuration docs and English locale strings.

## Testing

- `git diff --check`
- `jq empty` on updated English locale JSON files
- `npm install --no-package-lock --no-audit --no-fund`
- `npm run build`
