### PR TITLE
feat(linux/wlgrab): match output_name by xdg_output name

### DIFF
--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -61,19 +61,34 @@ namespace wl {
         return -1;
       }
 
+      // Populate xdg_output info (name, viewport) for every monitor up
+      // front so we can match by stable name in addition to index.
+      for (auto &m : interface.monitors) {
+        m->listen(interface.output_manager);
+      }
+      display.roundtrip();
+
       auto monitor = interface.monitors[0].get();
 
       if (!display_name.empty()) {
-        auto streamedMonitor = util::from_view(display_name);
-
-        if (streamedMonitor >= 0 && streamedMonitor < interface.monitors.size()) {
-          monitor = interface.monitors[streamedMonitor].get();
+        // Match by xdg_output name first (stable across hotplug, e.g.
+        // "eDP-1", "HEADLESS-2"). Fall back to numeric index for
+        // backward compatibility with existing configs.
+        bool matched = false;
+        for (auto &m : interface.monitors) {
+          if (m->name == display_name) {
+            monitor = m.get();
+            matched = true;
+            break;
+          }
+        }
+        if (!matched) {
+          auto streamedMonitor = util::from_view(display_name);
+          if (streamedMonitor >= 0 && streamedMonitor < interface.monitors.size()) {
+            monitor = interface.monitors[streamedMonitor].get();
+          }
         }
       }
-
-      monitor->listen(interface.output_manager);
-
-      display.roundtrip();
 
       output = monitor->output;
 
@@ -462,7 +477,7 @@ namespace platf {
 
       BOOST_LOG(info) << "[wlgrab] Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
 
-      display_names.emplace_back(std::to_string(x));
+      display_names.emplace_back(monitor->name.empty() ? std::to_string(x) : monitor->name);
     }
 
     BOOST_LOG(info) << "[wlgrab] --------- End of Wayland monitor list ---------"sv;


### PR DESCRIPTION
<!--

NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.

THEY ARE IMPORTANT FOR THE MAINTAINERS.

IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.

-->

## Description

<!-- Please include a summary of the changes. -->

The wlr-screencopy backend currently matches `output_name` only by parsing it as a numeric index into `interface.monitors`. That index is volatile under hotplug — connecting/disconnecting an external display shifts every other monitor's index, breaking saved configs.

This is particularly painful for setups using virtual headless outputs (e.g. `HEADLESS-2` on Hyprland) where users want a stable target across docking events. Today, `output_name = HEADLESS-2` falls through `util::from_view` (which doesn't validate digits) and silently picks monitor 0 instead of failing loudly.

This PR makes `output_name` accept the `xdg_output` name (e.g. `eDP-1`, `HEADLESS-2`, `DP-2`) in addition to the numeric index:

1. Listens on every monitor's `xdg_output` before selection so that names and viewport data are populated and matchable.
2. Tries name-based matching first (stable across hotplug), then falls back to numeric index for backward compatibility with existing configs.
3. Exposes monitor names from `wl_display_names()` so the configuration UI offers the stable name instead of the volatile index.

The pipewire backend already supports stable selection via object serial (#5053); this brings the wlr backend to parity.

### Screenshot

<!-- Include screenshots if the changes are UI-related. -->

N/A — backend change. The picker UI label changes from `0`/`1`/`2` to `eDP-1`/`HEADLESS-2`/etc. when `xdg_output` names are available.

### Issues Fixed or Closed

<!-- If this PR fixes or closes any issues, please list them here. -->

<!-- Close issue example: `- Closes #1` -->

<!-- Fix bug issue example: `- Fixes #2` -->

<!-- Resolve issue example: `- Resolves #3` -->

#### Roadmap Issues

<!-- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. -->

<!-- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` -->

## Type of Change

<!-- Select the type of change your PR introduces. You can select multiple types. -->

- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist

<!-- Please check all applicable boxes. If a box does not apply, leave it unchecked. -->

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage

<!-- Select the option that best describes AI usage in this PR (choose only one). -->

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes