### PR TITLE
fix(linux): security: drop CAP_SYS_ADMIN when possible, retain CAP_SYS_NICE

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -895,13 +895,15 @@ namespace platf {
 
   /**
    * @brief Check is the current process is running with elevated privileges (e.g. system admin/etc.)
-   * @return True if system admin capabilities are present.
+   * @param all_caps Bool that specifies whether to check all caps or only CAP_SYS_ADMIN
+   * @return True if capabilities specified to be checked are present.
    */
-  bool has_elevated_privileges();
+  bool has_elevated_privileges(bool all_caps);
 
   /**
-   * @brief Drop elevated privileges (e.g. system admin/etc.)
+   * @brief Drop elevated privileges (e.g. system admin/nice etc.)
+   * @param all_caps Bool that specifies whether to drop all caps or only CAP_SYS_ADMIN
    */
-  void drop_elevated_privileges();
+  void drop_elevated_privileges(bool all_caps);
 
 }  // namespace platf

--- a/src/platform/linux/kwingrab.cpp
+++ b/src/platform/linux/kwingrab.cpp
@@ -675,8 +675,8 @@ namespace platf {
     }
 
     // Drop CAP_SYS_ADMIN so KWin's permission check (if active) can see and match the executable
-    if (!kwin::screencast_permission_helper_t::is_permission_system_deactivated() && has_elevated_privileges()) {
-      drop_elevated_privileges();
+    if (!kwin::screencast_permission_helper_t::is_permission_system_deactivated() && has_elevated_privileges(false)) {
+      drop_elevated_privileges(false);
     }
 
     auto display = std::make_shared<kwin::kwin_t>();
@@ -688,7 +688,7 @@ namespace platf {
   }
 
   std::vector<std::string> kwin_display_names() {
-    if (!kwin::screencast_permission_helper_t::is_permission_system_deactivated() && has_elevated_privileges()) {
+    if (!kwin::screencast_permission_helper_t::is_permission_system_deactivated() && has_elevated_privileges(false)) {
       // We're still in the probing phase of Sunshine startup. Dropping portal security early will break KMS.
       // Just return a dummy screen for now. Display re-enumeration after encoder probing will yield full result.
       std::vector<std::string> display_names;

--- a/src/platform/linux/kwingrab.cpp
+++ b/src/platform/linux/kwingrab.cpp
@@ -674,11 +674,6 @@ namespace platf {
       return nullptr;
     }
 
-    // Drop CAP_SYS_ADMIN so KWin's permission check (if active) can see and match the executable
-    if (!kwin::screencast_permission_helper_t::is_permission_system_deactivated() && has_elevated_privileges(false)) {
-      drop_elevated_privileges(false);
-    }
-
     auto display = std::make_shared<kwin::kwin_t>();
     if (display->init(hwdevice_type, display_name, config)) {
       return nullptr;
@@ -688,7 +683,7 @@ namespace platf {
   }
 
   std::vector<std::string> kwin_display_names() {
-    if (!kwin::screencast_permission_helper_t::is_permission_system_deactivated() && has_elevated_privileges(false)) {
+    if (has_elevated_privileges(false)) {
       // We're still in the probing phase of Sunshine startup. Dropping portal security early will break KMS.
       // Just return a dummy screen for now. Display re-enumeration after encoder probing will yield full result.
       std::vector<std::string> display_names;

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1261,18 +1261,22 @@ namespace platf {
   }
 
 #if !defined(__FreeBSD__)
-  constexpr std::array<cap_value_t, 2> ELEVATED_PRIVILEGES_EFFECTIVE {CAP_SYS_ADMIN, CAP_SYS_NICE};
-  constexpr std::array<cap_value_t, 2> ELEVATED_PRIVILEGES_PERMITTED {CAP_SYS_ADMIN, CAP_SYS_NICE};
+  static constexpr cap_value_t FULL_CAPS[] = {CAP_SYS_ADMIN, CAP_SYS_NICE};
+  static constexpr cap_value_t ADMIN_CAPS[] = {CAP_SYS_ADMIN};
+
+  constexpr std::span<const cap_value_t> ELEVATED_PRIVILEGES_FULL {FULL_CAPS};
+  constexpr std::span<const cap_value_t> ELEVATED_PRIVILEGES_ADMIN {ADMIN_CAPS};
 #endif
 
-  bool has_elevated_privileges() {
+  bool has_elevated_privileges(bool all_caps) {
 #if !defined(__FreeBSD__)
+    const auto caps_to_check = all_caps ? ELEVATED_PRIVILEGES_FULL : ELEVATED_PRIVILEGES_ADMIN;
     const cap_t caps = cap_get_proc();
     if (!caps) {
       BOOST_LOG(error) << "[misc] has_elevated_privileges failed to get process capabilities."sv;
       return false;
     }
-    for (const auto c : ELEVATED_PRIVILEGES_EFFECTIVE) {
+    for (const auto c : caps_to_check) {
       cap_flag_value_t cap_flags_value;
       cap_get_flag(caps, c, CAP_EFFECTIVE, &cap_flags_value);
       if (cap_flags_value == CAP_SET) {
@@ -1280,7 +1284,7 @@ namespace platf {
         return true;
       }
     }
-    for (const auto c : ELEVATED_PRIVILEGES_PERMITTED) {
+    for (const auto c : caps_to_check) {
       cap_flag_value_t cap_flags_value;
       cap_get_flag(caps, c, CAP_PERMITTED, &cap_flags_value);
       if (cap_flags_value == CAP_SET) {
@@ -1293,17 +1297,18 @@ namespace platf {
     return false;
   }
 
-  void drop_elevated_privileges() {
+  void drop_elevated_privileges(bool all_caps) {
 #if !defined(__FreeBSD__)
     bool failed = false;
+    const auto caps_to_drop = all_caps ? ELEVATED_PRIVILEGES_FULL : ELEVATED_PRIVILEGES_ADMIN;
     const cap_t caps = cap_get_proc();
     if (!caps) {
       BOOST_LOG(error) << "[misc] drop_elevated_privileges failed to get process capabilities"sv;
       return;
     }
 
-    cap_set_flag(caps, CAP_EFFECTIVE, ELEVATED_PRIVILEGES_EFFECTIVE.size(), ELEVATED_PRIVILEGES_EFFECTIVE.data(), CAP_CLEAR);
-    cap_set_flag(caps, CAP_PERMITTED, ELEVATED_PRIVILEGES_PERMITTED.size(), ELEVATED_PRIVILEGES_PERMITTED.data(), CAP_CLEAR);
+    cap_set_flag(caps, CAP_EFFECTIVE, caps_to_drop.size(), caps_to_drop.data(), CAP_CLEAR);
+    cap_set_flag(caps, CAP_PERMITTED, caps_to_drop.size(), caps_to_drop.data(), CAP_CLEAR);
 
     if (cap_set_proc(caps) != 0) {
       BOOST_LOG(error) << "[misc] drop_elevated_privileges failed to prune capabilities: "sv << std::strerror(errno);

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1076,6 +1076,19 @@ namespace platf {
   }
 
   std::shared_ptr<display_t> display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config) {
+    // Keep KMS as first element to check before dropping CAP_SYS_ADMIN
+#ifdef SUNSHINE_BUILD_DRM
+    if (sources[source::KMS]) {
+      BOOST_LOG(info) << "Screencasting with KMS"sv;
+      return kms_display(hwdevice_type, display_name, config);
+    }
+#endif
+
+    // KMS capture was passed; drop CAP_SYS_ADMIN only.
+    if (has_elevated_privileges(false)) {
+      drop_elevated_privileges(false);
+    }
+
 #ifdef SUNSHINE_BUILD_CUDA
     if (sources[source::NVFBC] && hwdevice_type == mem_type_e::cuda) {
       BOOST_LOG(info) << "Screencasting with NvFBC"sv;
@@ -1086,12 +1099,6 @@ namespace platf {
     if (sources[source::WAYLAND]) {
       BOOST_LOG(info) << "Screencasting with Wayland's protocol"sv;
       return wl_display(hwdevice_type, display_name, config);
-    }
-#endif
-#ifdef SUNSHINE_BUILD_DRM
-    if (sources[source::KMS]) {
-      BOOST_LOG(info) << "Screencasting with KMS"sv;
-      return kms_display(hwdevice_type, display_name, config);
     }
 #endif
 #ifdef SUNSHINE_BUILD_X11

--- a/src/platform/linux/portalgrab.cpp
+++ b/src/platform/linux/portalgrab.cpp
@@ -705,9 +705,9 @@ namespace platf {
       return nullptr;
     }
 
-    // Drop CAP_SYS_ADMIN and set DUMPABLE flag to allow XDG /root access
-    if (has_elevated_privileges()) {
-      drop_elevated_privileges();
+    // Drop CAP_SYS_ADMIN, CAP_SYS_NICE and set DUMPABLE flag to allow XDG /root access
+    if (has_elevated_privileges(true)) {
+      drop_elevated_privileges(true);
     }
 
     auto portal = std::make_shared<portal::portal_t>();
@@ -727,7 +727,7 @@ namespace platf {
       return {};
     }
 
-    if (has_elevated_privileges()) {
+    if (has_elevated_privileges(true)) {
       // We're still in the probing phase of Sunshine startup. Dropping portal security early will break KMS.
       // Just return a dummy screen for now. Display re-enumeration after encoder probing will yield full result.
       display_names.emplace_back("init");


### PR DESCRIPTION
**fix(linux/kwingrab): retain CAP_SYS_NICE capabilities**
Since KWin acts as the DRM master, it has CAP_SYS_NICE capabilities:

$ cat /proc/$(pidof kwin_wayland)/status | grep Cap
CapInh: 0000000800000000
CapPrm: 0000000000800000
CapEff: 0000000000800000
CapBnd: 000001ffffffffff
CapAmb: 0000000000000000
$ capsh --decode=0000000000800000
0x0000000000800000=cap_sys_nice

Unlike XDG Portal, retaining this capability in Sunshine does not interfere with KWin's ability to access /proc/pid/root when required. Keeping CAP_SYS_NICE is desirable to allow high priority EGL context creation for the VAAPI encoder.

Change {has,drop}_elevated_privileges() to accept a bool that specifies whether to check/drop all caps or only CAP_SYS_ADMIN, and ensure that kwingrab only drops CAP_SYS_ADMIN whilst keeping xdgportal's behaviour unchanged.

**fix(linux): security: drop CAP_SYS_ADMIN as soon as possible**
Reorder Linux capture method initialization to first check KMS capture.
If KMS is passed over, immediately drop CAP_SYS_ADMIN but leave other
caps (i.e. CAP_SYS_NICE) intact so that EGL high priority contexts
are still possible.

Remove kwingrab capability dropping, as CAP_SYS_ADMIN will already be
dropped after probe, and CAP_SYS_NICE does not interfere with /root access.

Retain portalgrab capability check/drop, as CAP_SYS_NICE must be dropped
to allow /root access from the XDG Portal service.

Increases security for all all non-KMS capture methods, as
CAP_SYS_ADMIN will no longer be present in the permitted set and thus cannot
be elevated by malicious actors during runtime.

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [x] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
