### PR TITLE
fix(linux/pipewire): Add 10-bit RGB formats with 2-bit Alpha to format_map

### DIFF
--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -44,8 +44,12 @@ namespace pipewire {
     int32_t pw_format;
   };
 
-  static constexpr std::array<format_map_t, 3> format_map = {{
+  static constexpr std::array<format_map_t, 7> format_map = {{
     {DRM_FORMAT_XBGR2101010, SPA_VIDEO_FORMAT_xBGR_210LE},
+    {DRM_FORMAT_BGRA1010102, SPA_VIDEO_FORMAT_ARGB_210LE},
+    {DRM_FORMAT_RGBA1010102, SPA_VIDEO_FORMAT_ABGR_210LE},
+    {DRM_FORMAT_ABGR2101010, SPA_VIDEO_FORMAT_RGBA_102LE},
+    {DRM_FORMAT_ARGB2101010, SPA_VIDEO_FORMAT_BGRA_102LE},
     {DRM_FORMAT_ARGB8888, SPA_VIDEO_FORMAT_BGRA},
     {DRM_FORMAT_XRGB8888, SPA_VIDEO_FORMAT_BGRx},
   }};


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
The current PipeWire implementation only checks for xBGR2101010 - this isn't always advertised however; KWin for example may only expose formats with alpha:

https://invent.kde.org/plasma/kwin/-/merge_requests/8293/diffs#7390a641bee8f53acd66ba70f27e53b223cfaa18_88_84

With some fixes to the KWin MR, this allows HDR streaming to work with portalgrab:

```
[2026-05-08 15:15:05.282]: Info: [pipewire] Connected to pipewire version 1.6.4
[2026-05-08 15:15:05.286]: Info: [pipewire] Video format: 87
[2026-05-08 15:15:05.286]: Info: [pipewire] Size: 3840x2160
[2026-05-08 15:15:05.286]: Info: [pipewire] Color primaries: 7
[2026-05-08 15:15:05.286]: Info: [pipewire] Transfer function: 14
[2026-05-08 15:15:05.286]: Info: [pipewire] Framerate (from compositor): 0/1 (variable rate capture)
[2026-05-08 15:15:05.286]: Info: [pipewire] using DMA-BUF buffers
[2026-05-08 15:15:05.286]: Info: [pipewire] Video format: 87
[2026-05-08 15:15:05.286]: Info: [pipewire] Size: 3840x2160
[2026-05-08 15:15:05.286]: Info: [pipewire] Color primaries: 7
[2026-05-08 15:15:05.286]: Info: [pipewire] Transfer function: 14
[2026-05-08 15:15:05.286]: Info: [pipewire] Framerate (from compositor): 0/1 (variable rate capture)
[2026-05-08 15:15:05.286]: Info: [pipewire] using DMA-BUF buffers
[2026-05-08 15:15:05.292]: Info: [pipewire] Using negotiated Resolution: 3840x2160
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [ ] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
