### PR TITLE
fix(macos): preserve modifier state in input events

### DIFF
--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -36,7 +36,6 @@ namespace platf {
     CGEventSourceRef source {};
 
     // keyboard related stuff
-    CGEventRef kb_event {};
     CGEventFlags kb_flags {};
 
     // mouse related stuff
@@ -256,12 +255,19 @@ const KeyCodeMap kKeyCodesMap[] = {
     }
 
     auto macos_input = ((macos_input_t *) input.get());
-    auto event = macos_input->kb_event;
+    CGEventRef event = nullptr;
 
     if (key == kVK_Shift || key == kVK_RightShift ||
         key == kVK_Command || key == kVK_RightCommand ||
         key == kVK_Option || key == kVK_RightOption ||
         key == kVK_Control || key == kVK_RightControl) {
+      event = CGEventCreate(macos_input->source);
+      if (!event) {
+        return;
+      }
+
+      CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, key);
+
       CGEventFlags mask;
 
       switch (key) {
@@ -285,13 +291,19 @@ const KeyCodeMap kKeyCodesMap[] = {
 
       macos_input->kb_flags = release ? macos_input->kb_flags & ~mask : macos_input->kb_flags | mask;
       CGEventSetType(event, kCGEventFlagsChanged);
-      CGEventSetFlags(event, macos_input->kb_flags);
     } else {
-      CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, key);
+      event = CGEventCreateKeyboardEvent(macos_input->source, key, !release);
+      if (!event) {
+        return;
+      }
+
       CGEventSetType(event, release ? kCGEventKeyUp : kCGEventKeyDown);
     }
 
+    CGEventSetFlags(event, macos_input->kb_flags);
     CGEventPost(kCGHIDEventTap, event);
+    CFRelease(event);
+
   }
 
   void unicode(input_t &input, char *utf8, int size) {
@@ -358,6 +370,8 @@ const KeyCodeMap kKeyCodesMap[] = {
     CGEventSetDoubleValueField(event, kCGMouseEventDeltaX, deltaX);
     CGEventSetDoubleValueField(event, kCGMouseEventDeltaY, deltaY);
 
+    // Inject modifier flags into mouse events so that shift+click and similar combinations work correctly.
+    CGEventSetFlags(event, macos_input->kb_flags);
     CGEventPost(kCGHIDEventTap, event);
     // For why this is here, see:
     // https://stackoverflow.com/questions/15194409/simulated-mouseevent-not-working-properly-osx
@@ -555,7 +569,6 @@ const KeyCodeMap kKeyCodesMap[] = {
 
     macos_input->source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
 
-    macos_input->kb_event = CGEventCreate(macos_input->source);
     macos_input->kb_flags = 0;
 
     macos_input->mouse_event = CGEventCreate(macos_input->source);
@@ -572,7 +585,6 @@ const KeyCodeMap kKeyCodesMap[] = {
     const auto *input = static_cast<macos_input_t *>(p);
 
     CFRelease(input->source);
-    CFRelease(input->kb_event);
     CFRelease(input->mouse_event);
 
     delete input;

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -303,7 +303,6 @@ const KeyCodeMap kKeyCodesMap[] = {
     CGEventSetFlags(event, macos_input->kb_flags);
     CGEventPost(kCGHIDEventTap, event);
     CFRelease(event);
-
   }
 
   void unicode(input_t &input, char *utf8, int size) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

Fix macOS keyboard event handling so modifier state is preserved reliably across keyboard and mouse input.

macOS input handling was reusing a mutable `CGEventRef` for keyboard events. That could leave stale event state behind and caused modifier combinations such as Shift+Enter or Cmd+Tab to be replayed inconsistently.

This change creates fresh keyboard events for each input update:

- Modifier keys use a fresh generic `CGEventCreate(...)` event with `kCGEventFlagsChanged`.
- Non-modifier keys use `CGEventCreateKeyboardEvent(...)` for key up/down events.
- The tracked modifier flags are applied to all keyboard events before posting.
- Mouse events also receive the tracked modifier flags so combinations such as Shift+Click are preserved.

Tested manually on macOS via Moonlight/Sunshine input replay:

- Releasing Shift no longer emits an extra key that was pressed before it; previously, it was prone to do that on occasion.
- Cmd+Tab app cycling works; previously Tab key-up could be lost while Cmd was held.
- Shift+Click preserves modifier state; previously modifier keys did not work with mouse clicks.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
