### PR TITLE
fix(macos): provide left/right identity for modifiers

### DIFF
--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -11,6 +11,7 @@
 #include <ApplicationServices/ApplicationServices.h>
 #import <Carbon/Carbon.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/hidsystem/IOLLEvent.h>
 #include <mach/mach.h>
 
 // local includes
@@ -36,6 +37,7 @@ namespace platf {
     CGEventSourceRef source {};
 
     // keyboard related stuff
+    CGEventSourceRef keyboard_source {};
     CGEventFlags kb_flags {};
 
     // mouse related stuff
@@ -245,6 +247,43 @@ const KeyCodeMap kKeyCodesMap[] = {
     return temp_map->mac_keycode;
   }
 
+  struct modifier_flags_t {
+    CGEventFlags generic {};
+    CGEventFlags device {};
+    CGEventFlags all_devices {};
+  };
+
+  bool modifier_flags_for_key(int key, modifier_flags_t &flags) {
+    switch (key) {
+      case kVK_Shift:
+        flags = {kCGEventFlagMaskShift, NX_DEVICELSHIFTKEYMASK, NX_DEVICELSHIFTKEYMASK | NX_DEVICERSHIFTKEYMASK};
+        return true;
+      case kVK_RightShift:
+        flags = {kCGEventFlagMaskShift, NX_DEVICERSHIFTKEYMASK, NX_DEVICELSHIFTKEYMASK | NX_DEVICERSHIFTKEYMASK};
+        return true;
+      case kVK_Command:
+        flags = {kCGEventFlagMaskCommand, NX_DEVICELCMDKEYMASK, NX_DEVICELCMDKEYMASK | NX_DEVICERCMDKEYMASK};
+        return true;
+      case kVK_RightCommand:
+        flags = {kCGEventFlagMaskCommand, NX_DEVICERCMDKEYMASK, NX_DEVICELCMDKEYMASK | NX_DEVICERCMDKEYMASK};
+        return true;
+      case kVK_Option:
+        flags = {kCGEventFlagMaskAlternate, NX_DEVICELALTKEYMASK, NX_DEVICELALTKEYMASK | NX_DEVICERALTKEYMASK};
+        return true;
+      case kVK_RightOption:
+        flags = {kCGEventFlagMaskAlternate, NX_DEVICERALTKEYMASK, NX_DEVICELALTKEYMASK | NX_DEVICERALTKEYMASK};
+        return true;
+      case kVK_Control:
+        flags = {kCGEventFlagMaskControl, NX_DEVICELCTLKEYMASK, NX_DEVICELCTLKEYMASK | NX_DEVICERCTLKEYMASK};
+        return true;
+      case kVK_RightControl:
+        flags = {kCGEventFlagMaskControl, NX_DEVICERCTLKEYMASK, NX_DEVICELCTLKEYMASK | NX_DEVICERCTLKEYMASK};
+        return true;
+      default:
+        return false;
+    }
+  }
+
   void keyboard_update(input_t &input, uint16_t modcode, bool release, uint8_t flags) {
     auto key = keysym(modcode);
 
@@ -256,43 +295,28 @@ const KeyCodeMap kKeyCodesMap[] = {
 
     auto macos_input = ((macos_input_t *) input.get());
     CGEventRef event = nullptr;
+    modifier_flags_t modifier_flags;
 
-    if (key == kVK_Shift || key == kVK_RightShift ||
-        key == kVK_Command || key == kVK_RightCommand ||
-        key == kVK_Option || key == kVK_RightOption ||
-        key == kVK_Control || key == kVK_RightControl) {
-      event = CGEventCreate(macos_input->source);
+    if (modifier_flags_for_key(key, modifier_flags)) {
+      event = CGEventCreateKeyboardEvent(macos_input->keyboard_source, key, !release);
       if (!event) {
         return;
       }
 
       CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, key);
 
-      CGEventFlags mask;
-
-      switch (key) {
-        case kVK_Shift:
-        case kVK_RightShift:
-          mask = kCGEventFlagMaskShift;
-          break;
-        case kVK_Command:
-        case kVK_RightCommand:
-          mask = kCGEventFlagMaskCommand;
-          break;
-        case kVK_Option:
-        case kVK_RightOption:
-          mask = kCGEventFlagMaskAlternate;
-          break;
-        case kVK_Control:
-        case kVK_RightControl:
-          mask = kCGEventFlagMaskControl;
-          break;
+      if (release) {
+        macos_input->kb_flags &= ~modifier_flags.device;
+        if ((macos_input->kb_flags & modifier_flags.all_devices) == 0) {
+          macos_input->kb_flags &= ~modifier_flags.generic;
+        }
+      } else {
+        macos_input->kb_flags |= modifier_flags.generic | modifier_flags.device;
       }
 
-      macos_input->kb_flags = release ? macos_input->kb_flags & ~mask : macos_input->kb_flags | mask;
       CGEventSetType(event, kCGEventFlagsChanged);
     } else {
-      event = CGEventCreateKeyboardEvent(macos_input->source, key, !release);
+      event = CGEventCreateKeyboardEvent(macos_input->keyboard_source, key, !release);
       if (!event) {
         return;
       }
@@ -301,7 +325,7 @@ const KeyCodeMap kKeyCodesMap[] = {
     }
 
     CGEventSetFlags(event, macos_input->kb_flags);
-    CGEventPost(kCGHIDEventTap, event);
+    CGEventPost(kCGSessionEventTap, event);
     CFRelease(event);
   }
 
@@ -567,6 +591,7 @@ const KeyCodeMap kKeyCodesMap[] = {
     CFRelease(mode);
 
     macos_input->source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+    macos_input->keyboard_source = CGEventSourceCreate(kCGEventSourceStatePrivate);
 
     macos_input->kb_flags = 0;
 
@@ -584,6 +609,7 @@ const KeyCodeMap kKeyCodesMap[] = {
     const auto *input = static_cast<macos_input_t *>(p);
 
     CFRelease(input->source);
+    CFRelease(input->keyboard_source);
     CFRelease(input->mouse_event);
 
     delete input;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
Preserve the left/right identity of modifier keys when reflecting keyboard input on macOS.

Moonlight sends distinct virtual keycodes for left and right Shift, etc., but Sunshine previously reflected those as generic modifier state only. That works for many consumers, but it loses information that some macOS apps use to distinguish the physical modifier key. In those cases, modified key combinations arrive as if the modifier was not pressed. For example, Apple's Remote Desktop client or products built with Apple's virtualization kit all ignore modifiers completely when sent the old way.

This PR maps Moonlights left/right modifier keycodes onto the corresponding macOS device-level modifier flags before posting the event. Apps now receive both the generic modifier state and the physical left/right identity.

The switch to `CGSessionEventTap` is intentional: the HID-level injection path does not appear to preserve the required left/right identity. This is the main behavior change worth watching for regressions.

I checked a few open-source macOS game backends. GLFW, Godot, SDL, and O3DE all read keyboard input through `NSEvent` on macOS, which is the normal AppKit path for session-posted events. SDL and O3DE also split left/right modifiers using `NX_DEVICEL*` / `NX_DEVICER*` masks, which this PR now provides.

This issue was not introduced by #5102, the fix is for a separate case the old code also did not handle.

Sorry for the fourth macOS PR in three days. I think this is the last one for a bit. Famous last words, etc.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
