### PR TITLE
fix(web): disconnect only the disabled client instead of all sessions

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -882,7 +882,10 @@ namespace confighttp {
       output_tree["status"] = nvhttp::set_client_enabled(uuid, enabled);
 
       if (!enabled && output_tree["status"]) {
-        rtsp_stream::terminate_sessions();
+        auto cert = nvhttp::get_cert_by_uuid(uuid);
+        if (!cert.empty()) {
+          rtsp_stream::terminate_sessions_by_cert(cert);
+        }
 
         if (rtsp_stream::session_count() == 0 && proc::proc.running() > 0) {
           proc::proc.terminate();

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -144,6 +144,9 @@ namespace nvhttp {
   client_t client_root;
   std::atomic<uint32_t> session_id_counter;
 
+  // Set by TLS verify callback, read by launch/resume handler (single-threaded HTTPS server)
+  std::string last_verified_client_cert;  // NOSONAR(cpp:S5421) - intentionally mutable global
+
   using args_t = SimpleWeb::CaseInsensitiveMultimap;
   using resp_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SunshineHTTPS>::Response>;
   using req_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SunshineHTTPS>::Request>;
@@ -326,6 +329,7 @@ namespace nvhttp {
       launch_session->rtsp_iv_counter = 0;
     }
     launch_session->rtsp_url_scheme = launch_session->rtsp_cipher ? "rtspenc://"s : "rtsp://"s;
+    launch_session->client_cert = last_verified_client_cert;
 
     // Generate the unique identifiers for this connection that we will send later during RTSP handshake
     unsigned char raw_payload[8];
@@ -1141,6 +1145,7 @@ namespace nvhttp {
         return verified;
       }
 
+      last_verified_client_cert = pem;
       verified = 1;
 
       return verified;
@@ -1253,6 +1258,15 @@ namespace nvhttp {
       }
     }
     return false;
+  }
+
+  std::string get_cert_by_uuid(const std::string_view uuid) {
+    for (const auto &named_cert : client_root.named_devices) {
+      if (named_cert.uuid == uuid) {
+        return named_cert.cert;
+      }
+    }
+    return {};
   }
 
   bool is_client_enabled(const std::string_view cert_pem) {

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -191,6 +191,7 @@ namespace nvhttp {
    * @return true if the client was found and updated.
    */
   bool set_client_enabled(std::string_view uuid, bool enabled);
+  std::string get_cert_by_uuid(std::string_view uuid);
 
   /**
    * @brief Get all paired clients.

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -569,6 +569,20 @@ namespace rtsp_stream {
       }
     }
 
+    void clear_by_cert(std::string_view cert) {
+      auto lg = _session_slots.lock();
+      for (auto i = _session_slots->begin(); i != _session_slots->end();) {
+        auto &slot = *(*i);
+        if (stream::session::client_cert(slot) == cert) {
+          stream::session::stop(slot);
+          stream::session::join(slot);
+          i = _session_slots->erase(i);
+        } else {
+          i++;
+        }
+      }
+    }
+
     /**
      * @brief Removes the provided session from the set of sessions.
      * @param session The session to remove.
@@ -641,6 +655,10 @@ namespace rtsp_stream {
 
   void terminate_sessions() {
     server.clear(true);
+  }
+
+  void terminate_sessions_by_cert(std::string_view cert) {
+    server.clear_by_cert(cert);
   }
 
   int send(tcp::socket &sock, const std::string_view &sv) {

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -39,6 +39,7 @@ namespace rtsp_stream {
     std::optional<crypto::cipher::gcm_t> rtsp_cipher;
     std::string rtsp_url_scheme;
     uint32_t rtsp_iv_counter;
+    std::string client_cert;
   };
 
   void launch_session_raise(std::shared_ptr<launch_session_t> launch_session);
@@ -59,6 +60,7 @@ namespace rtsp_stream {
    * @brief Terminates all running streaming sessions.
    */
   void terminate_sessions();
+  void terminate_sessions_by_cert(std::string_view cert);
 
   /**
    * @brief Runs the RTSP server loop.

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -405,6 +405,7 @@ namespace stream {
     } control;
 
     std::uint32_t launch_session_id;
+    std::string client_cert;
 
     safe::mail_raw_t::event_t<bool> shutdown_event;
     safe::signal_t controlEnd;
@@ -1902,6 +1903,10 @@ namespace stream {
       return session.state.load(std::memory_order_relaxed);
     }
 
+    const std::string &client_cert(session_t &session) {
+      return session.client_cert;
+    }
+
     void stop(session_t &session) {
       while_starting_do_nothing(session.state);
       auto expected = state_e::RUNNING;
@@ -2009,6 +2014,7 @@ namespace stream {
 
       session->shutdown_event = mail->event<bool>(mail::shutdown);
       session->launch_session_id = launch_session.id;
+      session->client_cert = launch_session.client_cert;
 
       session->config = config;
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -51,5 +51,6 @@ namespace stream {
     void stop(session_t &session);
     void join(session_t &session);
     state_e state(session_t &session);
+    const std::string &client_cert(session_t &session);
   }  // namespace session
 }  // namespace stream


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

When disabling a client via the web UI, all active streaming sessions were terminated. This change makes it so only the disabled client's session is disconnected, leaving other clients unaffected.

The client's TLS certificate (already stored in `named_cert_t`) is used to identify which session belongs to the disabled client. The cert is propagated from the TLS verify callback through `launch_session_t` into `session_t`, enabling per-client session termination.

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes