### PR TITLE
fix(wayland): use the current wl_output mode

### DIFF
--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -156,10 +156,24 @@ namespace wl {
     std::int32_t height,
     std::int32_t refresh
   ) {
-    viewport.width = width;
-    viewport.height = height;
-
     BOOST_LOG(info) << "[wayland] Resolution: "sv << width << 'x' << height;
+
+    // wl_output.mode is emitted for every advertised mode. Capture sizing must
+    // follow the compositor's current mode, otherwise we can latch onto a stale
+    // supported mode and force endless reinit from frame-size mismatches.
+    if (flags & WL_OUTPUT_MODE_CURRENT) {
+      viewport.width = width;
+      viewport.height = height;
+      has_current_mode = true;
+      return;
+    }
+
+    // Keep a conservative fallback for compositors that may omit the current
+    // bit during early enumeration, but never overwrite a known current mode.
+    if (!has_current_mode && viewport.width == 0 && viewport.height == 0) {
+      viewport.width = width;
+      viewport.height = height;
+    }
   }
 
   void monitor_t::listen(zxdg_output_manager_v1 *output_manager) {

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -163,10 +163,24 @@ namespace wl {
     std::int32_t height,
     std::int32_t refresh
   ) {
-    viewport.width = width;
-    viewport.height = height;
-
     BOOST_LOG(info) << "[wayland] Resolution: "sv << width << 'x' << height;
+
+    // wl_output.mode is emitted for every advertised mode. Capture sizing must
+    // follow the compositor's current mode, otherwise we can latch onto a stale
+    // supported mode and force endless reinit from frame-size mismatches.
+    if (flags & WL_OUTPUT_MODE_CURRENT) {
+      viewport.width = width;
+      viewport.height = height;
+      has_current_mode = true;
+      return;
+    }
+
+    // Keep a conservative fallback for compositors that may omit the current
+    // bit during early enumeration, but never overwrite a known current mode.
+    if (!has_current_mode && viewport.width == 0 && viewport.height == 0) {
+      viewport.width = width;
+      viewport.height = height;
+    }
   }
 
   void monitor_t::listen(zxdg_output_manager_v1 *output_manager) {

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -114,7 +114,7 @@ namespace wl {
     return wl_display_get_registry(display_internal.get());
   }
 
-  inline monitor_t::monitor_t(wl_output *output):
+  monitor_t::monitor_t(wl_output *output):
       output {output},
       wl_listener {
         &CLASS_CALL(monitor_t, wl_geometry),

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -165,22 +165,12 @@ namespace wl {
   ) {
     BOOST_LOG(info) << "[wayland] Resolution: "sv << width << 'x' << height;
 
-    // wl_output.mode is emitted for every advertised mode. Capture sizing must
-    // follow the compositor's current mode, otherwise we can latch onto a stale
-    // supported mode and force endless reinit from frame-size mismatches.
-    if (flags & WL_OUTPUT_MODE_CURRENT) {
-      viewport.width = width;
-      viewport.height = height;
-      has_current_mode = true;
+    if (!(flags & WL_OUTPUT_MODE_CURRENT)) {
       return;
     }
 
-    // Keep a conservative fallback for compositors that may omit the current
-    // bit during early enumeration, but never overwrite a known current mode.
-    if (!has_current_mode && viewport.width == 0 && viewport.height == 0) {
-      viewport.width = width;
-      viewport.height = height;
-    }
+    viewport.width = width;
+    viewport.height = height;
   }
 
   void monitor_t::listen(zxdg_output_manager_v1 *output_manager) {

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -127,6 +127,7 @@ namespace wl {
     std::string name;
     std::string description;
     platf::touch_port_t viewport;
+    bool has_current_mode {false};
     wl_output_listener wl_listener;
     zxdg_output_v1_listener xdg_listener;
   };

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -294,6 +294,7 @@ namespace wl {
     std::string name;  ///< xdg-output name used for display selection.
     std::string description;  ///< xdg-output description used for logs and UI.
     platf::touch_port_t viewport;  ///< Logical monitor bounds used to scale absolute input.
+    bool has_current_mode {false};  ///< Whether wl-output has reported its current pixel mode.
     wl_output_listener wl_listener;  ///< Callback table for wl-output events.
     zxdg_output_v1_listener xdg_listener;  ///< Callback table for xdg-output events.
   };

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -294,7 +294,6 @@ namespace wl {
     std::string name;  ///< xdg-output name used for display selection.
     std::string description;  ///< xdg-output description used for logs and UI.
     platf::touch_port_t viewport;  ///< Logical monitor bounds used to scale absolute input.
-    bool has_current_mode {false};  ///< Whether wl-output has reported its current pixel mode.
     wl_output_listener wl_listener;  ///< Callback table for wl-output events.
     zxdg_output_v1_listener xdg_listener;  ///< Callback table for xdg-output events.
   };

--- a/tests/unit/platform/linux/test_wayland.cpp
+++ b/tests/unit/platform/linux/test_wayland.cpp
@@ -1,0 +1,30 @@
+/**
+ * @file tests/unit/platform/linux/test_wayland.cpp
+ * @brief Test Wayland output mode selection.
+ */
+#ifdef SUNSHINE_BUILD_WAYLAND
+  #include "../../../tests_common.h"
+
+  #include <src/platform/linux/wayland.h>
+
+TEST(WaylandMonitorTest, IgnoresNonCurrentModesAroundCurrentMode) {
+  wl::monitor_t monitor {nullptr};
+
+  monitor.wl_mode(nullptr, WL_OUTPUT_MODE_PREFERRED, 1280, 720, 60000);
+  monitor.wl_mode(nullptr, WL_OUTPUT_MODE_CURRENT, 1920, 1080, 60000);
+  monitor.wl_mode(nullptr, 0, 2560, 1440, 60000);
+
+  EXPECT_EQ(monitor.viewport.width, 1920);
+  EXPECT_EQ(monitor.viewport.height, 1080);
+}
+
+TEST(WaylandMonitorTest, UpdatesCurrentMode) {
+  wl::monitor_t monitor {nullptr};
+
+  monitor.wl_mode(nullptr, WL_OUTPUT_MODE_CURRENT | WL_OUTPUT_MODE_PREFERRED, 1920, 1080, 60000);
+  monitor.wl_mode(nullptr, WL_OUTPUT_MODE_CURRENT, 2560, 1440, 120000);
+
+  EXPECT_EQ(monitor.viewport.width, 2560);
+  EXPECT_EQ(monitor.viewport.height, 1440);
+}
+#endif


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
`wl_output.mode` is emitted for every advertised mode, not just the active one.

The current code overwrites `viewport.width` and `viewport.height` on every mode event, which can leave Sunshine latched to a supported mode instead of the current mode.

When that happens, `wlgrab` sees every captured frame as a size mismatch and reinitializes endlessly.

This tracks the compositor's current mode explicitly and only falls back to the first advertised mode until a current one is seen.

### Screenshot


### Issues Fixed or Closed


#### Roadmap Issues


## Type of Change
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
