### PR TITLE
feat(web-ui): Updated `Add` / `Edit` app form to use modals + new `Delete` App UI flow

### DIFF
--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -81,7 +81,7 @@
                 <edit :size="16" class="icon"></edit>
                 {{ $t('apps.edit') }}
               </button>
-              <button class="btn btn-sm btn-danger" @click="showDeleteForm(index)">
+              <button class="btn btn-sm btn-danger" @click="showDeleteModal(index)">
                 <trash-2 :size="16" class="icon"></trash-2>
               </button>
             </div>
@@ -455,6 +455,32 @@
       </div>
     </div>
 
+    <!-- Delete confirmation modal -->
+    <div class="modal fade" ref="deleteModal" tabindex="-1" aria-labelledby="appDeleteModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content" v-if="deleteTarget">
+          <div class="modal-header">
+            <h5 class="modal-title" id="appDeleteModalLabel">{{ $t('apps.delete_title') }}</h5>
+            <button type="button" class="btn-close" @click="closeDeleteModal"
+              :aria-label="$t('_common.close')"></button>
+          </div>
+          <div class="modal-body">
+            {{ $t('apps.delete_confirm', { name: deleteTarget.name }) }}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" @click="closeDeleteModal">
+              <x :size="18" class="icon"></x>
+              {{ $t('_common.cancel') }}
+            </button>
+            <button type="button" class="btn btn-danger" @click="confirmDelete">
+              <trash-2 :size="18" class="icon"></trash-2>
+              {{ $t('apps.delete') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Shared file browser modal -->
     <div class="modal fade" ref="fileBrowserModal" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-lg modal-dialog-scrollable modal-fullscreen-md-down">
@@ -604,6 +630,7 @@
         fileBrowserTypedPath: "",
         searchQuery: "",
         sortMode: "default",
+        deleteTarget: null,
         version: null,
         githubVersion: null,
       };
@@ -723,20 +750,25 @@
         }
         this.openEditModal();
       },
-      showDeleteForm(id) {
-        let resp = confirm(
-          "Are you sure to delete " + this.apps[id].name + "?"
-        );
-        if (resp) {
-          apiFetch("./api/apps/" + id, {
-            method: "DELETE",
-            headers: {
-              "Content-Type": "application/json"
-            },
-          }).then((r) => {
-            if (r.status === 200) document.location.reload();
-          });
-        }
+      showDeleteModal(id) {
+        this.deleteTarget = { index: id, name: this.apps[id].name };
+        this.$nextTick(() => {
+          Modal.getOrCreateInstance(this.$refs.deleteModal).show();
+        });
+      },
+      closeDeleteModal() {
+        const modal = Modal.getInstance(this.$refs.deleteModal);
+        if (modal) modal.hide();
+      },
+      confirmDelete() {
+        apiFetch("./api/apps/" + this.deleteTarget.index, {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json"
+          },
+        }).then((r) => {
+          if (r.status === 200) document.location.reload();
+        });
       },
       addPrepCmd() {
         let template = {

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -104,8 +104,19 @@
       </div>
     </div>
 
-    <div class="edit-form card mt-4" v-if="showEditForm">
-      <div class="card-body">
+    <!-- Edit / Add Application modal -->
+    <div class="modal fade" ref="editModal" tabindex="-1" aria-labelledby="appEditModalLabel"
+         aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+      <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-md-down">
+        <div class="modal-content" v-if="editForm">
+          <div class="modal-header">
+            <h5 class="modal-title" id="appEditModalLabel">
+              {{ editForm.index === -1 ? $t('apps.add_new') : $t('apps.edit') }}
+            </h5>
+            <button type="button" class="btn-close" @click="closeEditModal"
+              :aria-label="$t('_common.close')"></button>
+          </div>
+          <div class="modal-body">
         <!-- Application Name -->
         <div class="mb-3">
           <label for="appName" class="form-label">{{ $t('apps.app_name') }}</label>
@@ -294,76 +305,12 @@
               @click="browseFor('file', 'file_browser.select_file', editForm['image-path'], v => editForm['image-path'] = v)">
               <folder-open :size="18" class="icon"></folder-open>
             </button>
-            <button class="btn btn-secondary" type="button" data-bs-toggle="modal" data-bs-target="#coverFinderModal"
-              @click="showCoverFinder">
+            <button class="btn btn-secondary" type="button" @click="showCoverFinder">
               <search :size="18" class="icon"></search>
               {{ $t('apps.find_cover') }}
             </button>
           </div>
           <div id="appImagePathHelp" class="form-text">{{ $t('apps.image_desc') }}</div>
-        </div>
-
-        <!-- Cover Finder Modal -->
-        <div class="modal fade" id="coverFinderModal" tabindex="-1" aria-labelledby="coverFinderModalLabel" aria-hidden="true" ref="coverFinderModal">
-          <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-md-down">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h5 class="modal-title" id="coverFinderModalLabel">
-                  <span v-if="coverSearching">{{ $t('apps.searching_covers') }}</span>
-                  <span v-else-if="coverCandidates.length > 0">{{ $t('apps.covers_found') }} ({{ coverCandidates.length }})</span>
-                  <span v-else>{{ $t('apps.no_covers_found') }}</span>
-                </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-              </div>
-              <div class="modal-body">
-                <div class="mb-3">
-                  <div class="input-group">
-                    <input
-                      type="text"
-                      class="form-control"
-                      v-model="coverSearchQuery"
-                      :placeholder="editForm.name"
-                      @keyup.enter="performCoverSearch"
-                    />
-                    <button class="btn btn-primary" type="button" @click="performCoverSearch">
-                      <search :size="18" class="icon"></search>
-                      {{ $t('_common.search') }}
-                    </button>
-                  </div>
-                  <div class="form-text mt-2">
-                    <b>{{ $t('_common.note') }}</b> {{ $t('apps.cover_search_hint') }}
-                    <a href="https://www.igdb.com/" target="_blank" rel="noopener noreferrer">IGDB</a>
-                  </div>
-                </div>
-                <div class="cover-results" :class="{ busy: coverFinderBusy }">
-                  <div class="row">
-                    <div v-if="coverSearching" class="col-12 col-sm-6 col-lg-4 mb-3">
-                      <div class="cover-container">
-                        <div class="spinner-border" role="status">
-                          <span class="visually-hidden">{{ $t('apps.loading') }}</span>
-                        </div>
-                      </div>
-                    </div>
-                    <div v-for="(cover,i) in coverCandidates" :key="'i'" class="col-12 col-sm-6 col-lg-3 mb-3"
-                      @click="useCover(cover)">
-                      <div class="cover-container result">
-                        <img class="rounded" :src="cover.url" />
-                      </div>
-                      <label class="d-block text-nowrap text-center text-truncate">
-                        {{cover.name}}
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                  <x :size="18" class="icon"></x>
-                  {{ $t('_common.cancel') }}
-                </button>
-              </div>
-            </div>
-          </div>
         </div>
         <div class="env-hint alert alert-info">
           <div class="form-text">
@@ -429,16 +376,81 @@
               :href="`${documentationBaseUrl}/md_docs_2app__examples.html`"
               target="_blank">{{ $t('_common.see_more') }}</a></div>
         </div>
-        <!-- Save buttons -->
-        <div class="d-flex">
-          <button @click="showEditForm = false" class="btn btn-secondary m-2">
-            <x :size="18" class="icon"></x>
-            {{ $t('_common.cancel') }}
-          </button>
-          <button class="btn btn-primary m-2" @click="save">
-            <save :size="18" class="icon"></save>
-            {{ $t('_common.save') }}
-          </button>
+          </div>
+          <!-- Save buttons -->
+          <div class="modal-footer">
+            <button @click="closeEditModal" class="btn btn-secondary">
+              <x :size="18" class="icon"></x>
+              {{ $t('_common.cancel') }}
+            </button>
+            <button class="btn btn-primary" @click="save">
+              <save :size="18" class="icon"></save>
+              {{ $t('_common.save') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Cover Finder modal -->
+    <div class="modal fade" id="coverFinderModal" tabindex="-1" aria-labelledby="coverFinderModalLabel" aria-hidden="true" ref="coverFinderModal">
+      <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-md-down">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="coverFinderModalLabel">
+              <span v-if="coverSearching">{{ $t('apps.searching_covers') }}</span>
+              <span v-else-if="coverCandidates.length > 0">{{ $t('apps.covers_found') }} ({{ coverCandidates.length }})</span>
+              <span v-else>{{ $t('apps.no_covers_found') }}</span>
+            </h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <div class="input-group">
+                <input
+                  type="text"
+                  class="form-control"
+                  v-model="coverSearchQuery"
+                  :placeholder="editForm?.name"
+                  @keyup.enter="performCoverSearch"
+                />
+                <button class="btn btn-primary" type="button" @click="performCoverSearch">
+                  <search :size="18" class="icon"></search>
+                  {{ $t('_common.search') }}
+                </button>
+              </div>
+              <div class="form-text mt-2">
+                <b>{{ $t('_common.note') }}</b> {{ $t('apps.cover_search_hint') }}
+                <a href="https://www.igdb.com/" target="_blank" rel="noopener noreferrer">IGDB</a>
+              </div>
+            </div>
+            <div class="cover-results" :class="{ busy: coverFinderBusy }">
+              <div class="row">
+                <div v-if="coverSearching" class="col-12 col-sm-6 col-lg-4 mb-3">
+                  <div class="cover-container">
+                    <div class="spinner-border" role="status">
+                      <span class="visually-hidden">{{ $t('apps.loading') }}</span>
+                    </div>
+                  </div>
+                </div>
+                <div v-for="(cover,i) in coverCandidates" :key="'i'" class="col-12 col-sm-6 col-lg-3 mb-3"
+                  @click="useCover(cover)">
+                  <div class="cover-container result">
+                    <img class="rounded" :src="cover.url" />
+                  </div>
+                  <label class="d-block text-nowrap text-center text-truncate">
+                    {{cover.name}}
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+              <x :size="18" class="icon"></x>
+              {{ $t('_common.cancel') }}
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -573,7 +585,6 @@
     data() {
       return {
         apps: [],
-        showEditForm: false,
         editForm: null,
         detachedCmd: "",
         coverSearching: false,
@@ -688,7 +699,7 @@
           "image-path": ""
         };
         this.editForm.index = -1;
-        this.showEditForm = true;
+        this.openEditModal();
       },
       editApp(id) {
         this.editForm = JSON.parse(JSON.stringify(this.apps[id]));
@@ -711,7 +722,7 @@
         if (this.editForm["exit-timeout"] === undefined) {
           this.editForm["exit-timeout"] = 5;
         }
-        this.showEditForm = true;
+        this.openEditModal();
       },
       showDeleteForm(id) {
         let resp = confirm(
@@ -750,6 +761,8 @@
         // Reset search state
         this.coverCandidates = [];
         this.coverSearchQuery = "";
+
+        this.showStacked(this.$refs.coverFinderModal);
 
         // Perform initial search with app name
         this.performCoverSearch();
@@ -848,7 +861,7 @@
         this.fileBrowserTypedPath = startPath || '';
         this.fileBrowserError = '';
         this.fileBrowserNavigate(startPath || '');
-        Modal.getOrCreateInstance(this.$refs.fileBrowserModal).show();
+        this.showStacked(this.$refs.fileBrowserModal);
       },
       fileBrowserClose() {
         const modal = Modal.getInstance(this.$refs.fileBrowserModal);
@@ -947,6 +960,32 @@
           this.sortMode = "desc";
         else
           this.sortMode = "default";
+      },
+      openEditModal() {
+        // Use $nextTick because if the edit version of the modal is created too early, it breaks...
+        this.$nextTick(() => {
+          Modal.getOrCreateInstance(this.$refs.editModal).show();
+        });
+      },
+      closeEditModal() {
+        const modal = Modal.getInstance(this.$refs.editModal);
+        if (modal) modal.hide();
+      },
+      // We need to update the z-index since bootstrap gives all modals the same z-index
+      // Fixes the stacking issue of modals (cover finder / file browser)
+      showStacked(modalEl) {
+        modalEl.addEventListener('show.bs.modal', () => {
+          const openCount = document.querySelectorAll('.modal.show').length;
+          const z = 1055 + (openCount + 1) * 20;
+          modalEl.style.zIndex = z;
+
+          requestAnimationFrame(() => {
+            const backdrops = document.querySelectorAll('.modal-backdrop');
+            const backdrop = backdrops[backdrops.length - 1];
+            if (backdrop) backdrop.style.zIndex = z - 10;
+          });
+        }, { once: true });
+        Modal.getOrCreateInstance(modalEl).show();
       },
     },
   });

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -402,7 +402,7 @@
               <span v-else-if="coverCandidates.length > 0">{{ $t('apps.covers_found') }} ({{ coverCandidates.length }})</span>
               <span v-else>{{ $t('apps.no_covers_found') }}</span>
             </h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" :aria-label="$t('_common.close')"></button>
           </div>
           <div class="modal-body">
             <div class="mb-3">

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -465,7 +465,9 @@
               :aria-label="$t('_common.close')"></button>
           </div>
           <div class="modal-body">
-            {{ $t('apps.delete_confirm', { name: deleteTarget.name }) }}
+            <i18n-t keypath="apps.delete_confirm" tag="span">
+              <template #name><strong>{{ deleteTarget.name }}</strong></template>
+            </i18n-t>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" @click="closeDeleteModal">

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -14,27 +14,37 @@
     </div>
 
     <!-- Actions toolbar -->
-    <div class="apps-toolbar d-flex flex-wrap justify-content-end align-items-center gap-2 mb-3"
-         v-if="apps && apps.length > 0">
-      <!-- Sort by name toggle -->
-      <button class="btn btn-outline-secondary" type="button" @click="toggleSort"
-              :class="{ active: sortMode !== 'default' }"
-              :aria-pressed="sortMode !== 'default'"
-              :title="$t('apps.sort_by_name') + ': ' + sortModeLabel">
-        <arrow-up-down v-if="sortMode === 'default'" :size="16" class="icon me-1"></arrow-up-down>
-        <arrow-up v-else-if="sortMode === 'asc'" :size="16" class="icon me-1"></arrow-up>
-        <arrow-down v-else :size="16" class="icon me-1"></arrow-down>
-        {{ $t('apps.sort_by_name') }}
-      </button>
-      <!-- Search box -->
-      <div class="input-group">
-        <span class="input-group-text">
-          <search :size="16" class="icon"></search>
-        </span>
-        <input type="text" class="form-control" v-model="searchQuery" :placeholder="$t('apps.search_placeholder')" />
-        <button v-if="searchQuery" class="btn btn-outline-secondary" type="button" @click="resetSearchQuery" :aria-label="$t('_common.close')">
-          <x :size="16" class="icon"></x>
+    <div class="apps-toolbar d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+      <!-- Left side actions -->
+      <div class="d-flex align-items-center gap-2">
+        <!-- Add new application -->
+        <button class="btn btn-primary" @click="newApp">
+          <layers-plus :size="18" class="icon"></layers-plus>
+          {{ $t('apps.add_new') }}
         </button>
+      </div>
+      <!-- Right side actions -->
+      <div class="d-flex align-items-center gap-2" v-if="apps && apps.length > 0">
+        <!-- Sort by name toggle -->
+        <button class="btn btn-outline-secondary text-nowrap" type="button" @click="toggleSort"
+                :class="{ active: sortMode !== 'default' }"
+                :aria-pressed="sortMode !== 'default'"
+                :title="$t('apps.sort_by_name') + ': ' + sortModeLabel">
+          <arrow-up-down v-if="sortMode === 'default'" :size="16" class="icon me-1"></arrow-up-down>
+          <arrow-up v-else-if="sortMode === 'asc'" :size="16" class="icon me-1"></arrow-up>
+          <arrow-down v-else :size="16" class="icon me-1"></arrow-down>
+          {{ $t('apps.sort_by_name') }}
+        </button>
+        <!-- Search box -->
+        <div class="input-group">
+          <span class="input-group-text">
+            <search :size="16" class="icon"></search>
+          </span>
+          <input type="text" class="form-control" v-model="searchQuery" :placeholder="$t('apps.search_placeholder')" />
+          <button v-if="searchQuery" class="btn btn-outline-secondary" type="button" @click="resetSearchQuery" :aria-label="$t('_common.close')">
+            <x :size="16" class="icon"></x>
+          </button>
+        </div>
       </div>
     </div>
 
@@ -431,12 +441,6 @@
           </button>
         </div>
       </div>
-    </div>
-    <div class="mt-4" v-else>
-      <button class="btn btn-primary" @click="newApp">
-        <layers-plus :size="18" class="icon"></layers-plus>
-        {{ $t('apps.add_new') }}
-      </button>
     </div>
 
     <!-- Shared file browser modal -->

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -37,13 +37,13 @@
         </button>
         <!-- Search box -->
         <div class="input-group">
-          <span class="input-group-text">
-            <search :size="16" class="icon"></search>
-          </span>
           <input type="text" class="form-control" v-model="searchQuery" :placeholder="$t('apps.search_placeholder')" />
           <button v-if="searchQuery" class="btn btn-outline-secondary" type="button" @click="resetSearchQuery" :aria-label="$t('_common.close')">
             <x :size="16" class="icon"></x>
           </button>
+          <span v-else class="input-group-text">
+            <search :size="16" class="icon"></search>
+          </span>
         </div>
       </div>
     </div>
@@ -55,7 +55,7 @@
           <div class="app-poster-container">
             <img
               v-if="app['image-path']"
-              :src="'/api/covers/' + index + '?v=' + encodeURIComponent(app['image-path'])"
+              :src="'/api/covers/' + index"
               class="app-poster"
               :alt="app.name"
               @error="handleImageError"
@@ -107,7 +107,7 @@
     <!-- Edit / Add Application modal -->
     <div class="modal fade" ref="editModal" tabindex="-1" aria-labelledby="appEditModalLabel"
          aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
-      <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-md-down">
+      <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-lg-down">
         <div class="modal-content" v-if="editForm">
           <div class="modal-header">
             <h5 class="modal-title" id="appEditModalLabel">
@@ -783,11 +783,7 @@
             "Content-Type": "application/json"
           },
         }).then((r) => {
-          if (r.status === 200) {
-            // re-fetch the grid instead of reloading the whole page now
-            this.closeDeleteModal();
-            this.loadApps();
-          }
+          if (r.status === 200) document.location.reload();
         });
       },
       addPrepCmd() {
@@ -989,10 +985,7 @@
           },
           body: JSON.stringify(this.editForm),
         }).then((r) => {
-          if (r.status === 200) {
-            this.closeEditModal();
-            this.loadApps();
-          }
+          if (r.status === 200) document.location.reload();
         });
       },
       handleImageError(event) {

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -55,7 +55,7 @@
           <div class="app-poster-container">
             <img
               v-if="app['image-path']"
-              :src="'/api/covers/' + index"
+              :src="'/api/covers/' + index + '?v=' + encodeURIComponent(app['image-path'])"  
               class="app-poster"
               :alt="app.name"
               @error="handleImageError"
@@ -690,12 +690,7 @@
       },
     },
     created() {
-      fetch("./api/apps")
-        .then((r) => r.json())
-        .then((r) => {
-          console.log(r);
-          this.apps = r.apps;
-        });
+      this.loadApps();
 
       fetch("./api/config")
         .then(r => r.json())
@@ -760,6 +755,13 @@
         const modal = Modal.getInstance(this.$refs.deleteModal);
         if (modal) modal.hide();
       },
+      loadApps() {
+        return fetch("./api/apps")
+          .then((r) => r.json())
+          .then((r) => {
+            this.apps = r.apps;
+          });
+      },
       confirmDelete() {
         apiFetch("./api/apps/" + this.deleteTarget.index, {
           method: "DELETE",
@@ -767,7 +769,11 @@
             "Content-Type": "application/json"
           },
         }).then((r) => {
-          if (r.status === 200) document.location.reload();
+          if (r.status === 200) {
+            // re-fetch the grid instead of reloading the whole page now
+            this.closeDeleteModal();
+            this.loadApps();
+          }
         });
       },
       addPrepCmd() {
@@ -969,7 +975,10 @@
           },
           body: JSON.stringify(this.editForm),
         }).then((r) => {
-          if (r.status === 200) document.location.reload();
+          if (r.status === 200) {
+            this.closeEditModal();
+            this.loadApps();
+          }
         });
       },
       handleImageError(event) {

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -55,7 +55,7 @@
           <div class="app-poster-container">
             <img
               v-if="app['image-path']"
-              :src="'/api/covers/' + index + '?v=' + encodeURIComponent(app['image-path'])"  
+              :src="'/api/covers/' + index + '?v=' + encodeURIComponent(app['image-path'])"
               class="app-poster"
               :alt="app.name"
               @error="handleImageError"
@@ -111,7 +111,7 @@
         <div class="modal-content" v-if="editForm">
           <div class="modal-header">
             <h5 class="modal-title" id="appEditModalLabel">
-              {{ editForm.index === -1 ? $t('apps.add_new') : $t('apps.edit') }}
+              {{ editModalTitle }}
             </h5>
             <button type="button" class="btn-close" @click="closeEditModal"
               :aria-label="$t('_common.close')"></button>
@@ -687,6 +687,18 @@
         return shown === total
           ? `${total}`
           : `${shown} / ${total}`;
+      },
+      editModalTitle() {
+        if (!this.editForm) {
+          return "";
+        }
+        const action = this.editForm.index === -1
+          ? this.$t("apps.add_new")
+          : this.$t("apps.edit");
+
+        return this.editForm.name
+          ? `${action}: ${this.editForm.name}`
+          : action;
       },
     },
     created() {

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -117,265 +117,265 @@
               :aria-label="$t('_common.close')"></button>
           </div>
           <div class="modal-body">
-        <!-- Application Name -->
-        <div class="mb-3">
-          <label for="appName" class="form-label">{{ $t('apps.app_name') }}</label>
-          <input type="text" class="form-control" id="appName" aria-describedby="appNameHelp" v-model="editForm.name" />
-          <div id="appNameHelp" class="form-text">{{ $t('apps.app_name_desc') }}</div>
-        </div>
-        <!-- output -->
-        <div class="mb-3">
-          <label for="appOutput" class="form-label">{{ $t('apps.output_name') }}</label>
-          <div class="input-group">
-            <input type="text" class="form-control monospace" id="appOutput" aria-describedby="appOutputHelp"
-              v-model="editForm.output" />
-            <button class="btn btn-secondary" type="button"
-              @click="browseFor('any', 'file_browser.select_file', editForm.output, v => editForm.output = v)">
-              <folder-open :size="18" class="icon"></folder-open>
-            </button>
-          </div>
-          <div id="appOutputHelp" class="form-text">{{ $t('apps.output_desc') }}</div>
-        </div>
-        <!-- prep-cmd -->
-        <Checkbox class="mb-3"
-                  id="excludeGlobalPrep"
-                  label="apps.global_prep_name"
-                  desc="apps.global_prep_desc"
-                  v-model="editForm['exclude-global-prep-cmd']"
-                  default="true"
-                  inverse-values
-        ></Checkbox>
-        <div class="mb-3">
-          <label for="appName" class="form-label">{{ $t('apps.cmd_prep_name') }}</label>
-          <div class="form-text">{{ $t('apps.cmd_prep_desc') }}</div>
-          <div class="d-flex justify-content-start mb-3 mt-3" v-if="editForm['prep-cmd'].length === 0">
-            <button class="btn btn-success" @click="addPrepCmd">
-              <plus :size="18" class="icon"></plus>
-              {{ $t('apps.add_cmds') }}
-            </button>
-          </div>
-          <table class="table" v-if="editForm['prep-cmd'].length > 0">
-            <thead>
-              <tr>
-                <th scope="col">
-                  <play :size="18" class="icon"></play>
-                  {{ $t('_common.do_cmd') }}
-                </th>
-                <th scope="col">
-                  <rotate-ccw :size="18" class="icon"></rotate-ccw>
-                  {{ $t('_common.undo_cmd') }}
-                </th>
-                <th scope="col" v-if="platform === 'windows'">
-                  <shield :size="18" class="icon"></shield>
-                  {{ $t('_common.run_as') }}
-                </th>
-                <th scope="col"></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="(c, i) in editForm['prep-cmd']">
-                <td>
-                  <div class="input-group">
-                    <input type="text" class="form-control monospace" v-model="c.do" />
-                    <button class="btn btn-secondary btn-sm" type="button" @click="browsePrep(i, 'do')">
-                      <folder-open :size="14" class="icon"></folder-open>
-                    </button>
-                  </div>
-                </td>
-                <td>
-                  <div class="input-group">
-                    <input type="text" class="form-control monospace" v-model="c.undo" />
-                    <button class="btn btn-secondary btn-sm" type="button" @click="browsePrep(i, 'undo')">
-                      <folder-open :size="14" class="icon"></folder-open>
-                    </button>
-                  </div>
-                </td>
-                <td v-if="platform === 'windows'" class="align-middle">
-                  <Checkbox :id="'prep-cmd-admin-' + i"
-                            label="_common.elevated"
-                            desc=""
-                            v-model="c.elevated"
-                  ></Checkbox>
-                </td>
-                <td class="align-middle">
-                  <button class="btn btn-danger btn-sm ms-2" @click="deletePrepCmd(i)">
-                    <trash-2 :size="16" class="icon"></trash-2>
-                  </button>
-                  <button class="btn btn-success btn-sm ms-2" @click="addPrepCmd">
-                    <plus :size="16" class="icon"></plus>
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <!-- detached -->
-        <div class="mb-3">
-          <label for="appName" class="form-label">{{ $t('apps.detached_cmds') }}</label>
-          <div v-for="(c,i) in editForm.detached" class="d-flex justify-content-between align-items-center my-2">
-            <input type="text" v-model="editForm.detached[i]" class="form-control monospace">
-            <button class="btn btn-secondary btn-sm ms-2" @click="browseDetached(i)">
-              <folder-open :size="14" class="icon"></folder-open>
-            </button>
-            <button class="btn btn-danger btn-sm ms-2" @click="editForm.detached.splice(i,1)">
-              <trash-2 :size="16" class="icon"></trash-2>
-            </button>
-            <button class="btn btn-success btn-sm ms-2" @click="addDetached">
-              <plus :size="16" class="icon"></plus>
-            </button>
-          </div>
-          <div class="d-flex justify-content-start mb-3 mt-3" v-if="editForm.detached.length === 0">
-            <button class="btn btn-success" @click="addDetached">
-              <plus :size="18" class="icon"></plus>
-              {{ $t('apps.detached_cmds_add') }}
-            </button>
-          </div>
-          <div class="form-text">
-            {{ $t('apps.detached_cmds_desc') }}<br>
-            <b>{{ $t('_common.note') }}</b> {{ $t('apps.detached_cmds_note') }}
-          </div>
-        </div>
-        <!-- command -->
-        <div class="mb-3">
-          <label for="appCmd" class="form-label">{{ $t('apps.cmd') }}</label>
-          <div class="input-group">
-            <input type="text" class="form-control monospace" id="appCmd" aria-describedby="appCmdHelp"
-              v-model="editForm.cmd" />
-            <button class="btn btn-secondary" type="button"
-              @click="browseFor('executable', 'file_browser.select_executable', editForm.cmd, v => editForm.cmd = v)">
-              <folder-open :size="18" class="icon"></folder-open>
-            </button>
-          </div>
-          <div id="appCmdHelp" class="form-text">
-            {{ $t('apps.cmd_desc') }}<br>
-            <b>{{ $t('_common.note') }}</b> {{ $t('apps.cmd_note') }}
-          </div>
-        </div>
-        <!-- working dir -->
-        <div class="mb-3">
-          <label for="appWorkingDir" class="form-label">{{ $t('apps.working_dir') }}</label>
-          <div class="input-group">
-            <input type="text" class="form-control monospace" id="appWorkingDir" aria-describedby="appWorkingDirHelp"
-              v-model="editForm['working-dir']" />
-            <button class="btn btn-secondary" type="button"
-              @click="browseFor('directory', 'file_browser.select_directory', editForm['working-dir'], v => editForm['working-dir'] = v)">
-              <folder-open :size="18" class="icon"></folder-open>
-            </button>
-          </div>
-          <div id="appWorkingDirHelp" class="form-text">{{ $t('apps.working_dir_desc') }}</div>
-        </div>
-        <!-- elevation -->
-        <Checkbox v-if="platform === 'windows'"
-                  class="mb-3"
-                  id="appElevation"
-                  label="_common.run_as"
-                  desc="apps.run_as_desc"
-                  v-model="editForm.elevated"
-                  default="false"
-        ></Checkbox>
-        <!-- auto-detach -->
-        <Checkbox class="mb-3"
-                  id="autoDetach"
-                  label="apps.auto_detach"
-                  desc="apps.auto_detach_desc"
-                  v-model="editForm['auto-detach']"
-                  default="true"
-        ></Checkbox>
-        <!-- wait for all processes -->
-        <Checkbox class="mb-3"
-                  id="waitAll"
-                  label="apps.wait_all"
-                  desc="apps.wait_all_desc"
-                  v-model="editForm['wait-all']"
-                  default="true"
-        ></Checkbox>
-        <!-- exit timeout -->
-        <div class="mb-3">
-          <label for="exitTimeout" class="form-label">{{ $t('apps.exit_timeout') }}</label>
-          <input type="number" class="form-control monospace" id="exitTimeout" aria-describedby="exitTimeoutHelp"
-                 v-model="editForm['exit-timeout']" min="0" placeholder="5" />
-          <div id="exitTimeoutHelp" class="form-text">{{ $t('apps.exit_timeout_desc') }}</div>
-        </div>
-        <div class="mb-3">
-          <label for="appImagePath" class="form-label">{{ $t('apps.image') }}</label>
-          <div class="input-group">
-            <input type="text" class="form-control monospace" id="appImagePath" aria-describedby="appImagePathHelp"
-              v-model="editForm['image-path']" />
-            <button class="btn btn-secondary" type="button"
-              @click="browseFor('file', 'file_browser.select_file', editForm['image-path'], v => editForm['image-path'] = v)">
-              <folder-open :size="18" class="icon"></folder-open>
-            </button>
-            <button class="btn btn-secondary" type="button" @click="showCoverFinder">
-              <search :size="18" class="icon"></search>
-              {{ $t('apps.find_cover') }}
-            </button>
-          </div>
-          <div id="appImagePathHelp" class="form-text">{{ $t('apps.image_desc') }}</div>
-        </div>
-        <div class="env-hint alert alert-info">
-          <div class="form-text">
-            <h4>{{ $t('apps.env_vars_about') }}</h4>
-            {{ $t('apps.env_vars_desc') }}
-          </div>
-          <table class="env-table">
-            <tr>
-              <td><b>{{ $t('apps.env_var_name') }}</b></td>
-              <td><b></b></td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_APP_ID</td>
-              <td>{{ $t('apps.env_app_id') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_APP_NAME</td>
-              <td>{{ $t('apps.env_app_name') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_WIDTH</td>
-              <td>{{ $t('apps.env_client_width') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_HEIGHT</td>
-              <td>{{ $t('apps.env_client_height') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_FPS</td>
-              <td>{{ $t('apps.env_client_fps') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_HDR</td>
-              <td>{{ $t('apps.env_client_hdr') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_GCMAP</td>
-              <td>{{ $t('apps.env_client_gcmap') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_HOST_AUDIO</td>
-              <td>{{ $t('apps.env_client_host_audio') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_ENABLE_SOPS</td>
-              <td>{{ $t('apps.env_client_enable_sops') }}</td>
-            </tr>
-            <tr>
-              <td style="font-family: monospace">SUNSHINE_CLIENT_AUDIO_CONFIGURATION</td>
-              <td>{{ $t('apps.env_client_audio_config') }}</td>
-            </tr>
-          </table>
-          <div class="form-text" v-if="platform === 'windows'"><b>{{ $t('apps.env_qres_example') }}</b>
-            <pre>cmd /C &lt;{{ $t('apps.env_qres_path') }}&gt;\QRes.exe /X:%SUNSHINE_CLIENT_WIDTH% /Y:%SUNSHINE_CLIENT_HEIGHT% /R:%SUNSHINE_CLIENT_FPS%</pre>
-          </div>
-          <div class="form-text" v-else-if="platform === 'freebsd' || platform === 'linux'"><b>{{ $t('apps.env_xrandr_example') }}</b>
-            <pre>sh -c "xrandr --output HDMI-1 --mode \"${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT}\" --rate ${SUNSHINE_CLIENT_FPS}"</pre>
-          </div>
-          <div class="form-text" v-else-if="platform === 'macos'"><b>{{ $t('apps.env_displayplacer_example') }}</b>
-            <pre>sh -c "displayplacer "id:&lt;screenId&gt; res:${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT} hz:${SUNSHINE_CLIENT_FPS} scaling:on origin:(0,0) degree:0""</pre>
-          </div>
-          <div class="form-text"><a
-              :href="`${documentationBaseUrl}/md_docs_2app__examples.html`"
-              target="_blank">{{ $t('_common.see_more') }}</a></div>
-        </div>
+            <!-- Application Name -->
+            <div class="mb-3">
+              <label for="appName" class="form-label">{{ $t('apps.app_name') }}</label>
+              <input type="text" class="form-control" id="appName" aria-describedby="appNameHelp" v-model="editForm.name" />
+              <div id="appNameHelp" class="form-text">{{ $t('apps.app_name_desc') }}</div>
+            </div>
+            <!-- output -->
+            <div class="mb-3">
+              <label for="appOutput" class="form-label">{{ $t('apps.output_name') }}</label>
+              <div class="input-group">
+                <input type="text" class="form-control monospace" id="appOutput" aria-describedby="appOutputHelp"
+                  v-model="editForm.output" />
+                <button class="btn btn-secondary" type="button"
+                  @click="browseFor('any', 'file_browser.select_file', editForm.output, v => editForm.output = v)">
+                  <folder-open :size="18" class="icon"></folder-open>
+                </button>
+              </div>
+              <div id="appOutputHelp" class="form-text">{{ $t('apps.output_desc') }}</div>
+            </div>
+            <!-- prep-cmd -->
+            <Checkbox class="mb-3"
+                      id="excludeGlobalPrep"
+                      label="apps.global_prep_name"
+                      desc="apps.global_prep_desc"
+                      v-model="editForm['exclude-global-prep-cmd']"
+                      default="true"
+                      inverse-values
+            ></Checkbox>
+            <div class="mb-3">
+              <label for="appName" class="form-label">{{ $t('apps.cmd_prep_name') }}</label>
+              <div class="form-text">{{ $t('apps.cmd_prep_desc') }}</div>
+              <div class="d-flex justify-content-start mb-3 mt-3" v-if="editForm['prep-cmd'].length === 0">
+                <button class="btn btn-success" @click="addPrepCmd">
+                  <plus :size="18" class="icon"></plus>
+                  {{ $t('apps.add_cmds') }}
+                </button>
+              </div>
+              <table class="table" v-if="editForm['prep-cmd'].length > 0">
+                <thead>
+                  <tr>
+                    <th scope="col">
+                      <play :size="18" class="icon"></play>
+                      {{ $t('_common.do_cmd') }}
+                    </th>
+                    <th scope="col">
+                      <rotate-ccw :size="18" class="icon"></rotate-ccw>
+                      {{ $t('_common.undo_cmd') }}
+                    </th>
+                    <th scope="col" v-if="platform === 'windows'">
+                      <shield :size="18" class="icon"></shield>
+                      {{ $t('_common.run_as') }}
+                    </th>
+                    <th scope="col"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(c, i) in editForm['prep-cmd']">
+                    <td>
+                      <div class="input-group">
+                        <input type="text" class="form-control monospace" v-model="c.do" />
+                        <button class="btn btn-secondary btn-sm" type="button" @click="browsePrep(i, 'do')">
+                          <folder-open :size="14" class="icon"></folder-open>
+                        </button>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="input-group">
+                        <input type="text" class="form-control monospace" v-model="c.undo" />
+                        <button class="btn btn-secondary btn-sm" type="button" @click="browsePrep(i, 'undo')">
+                          <folder-open :size="14" class="icon"></folder-open>
+                        </button>
+                      </div>
+                    </td>
+                    <td v-if="platform === 'windows'" class="align-middle">
+                      <Checkbox :id="'prep-cmd-admin-' + i"
+                                label="_common.elevated"
+                                desc=""
+                                v-model="c.elevated"
+                      ></Checkbox>
+                    </td>
+                    <td class="align-middle">
+                      <button class="btn btn-danger btn-sm ms-2" @click="deletePrepCmd(i)">
+                        <trash-2 :size="16" class="icon"></trash-2>
+                      </button>
+                      <button class="btn btn-success btn-sm ms-2" @click="addPrepCmd">
+                        <plus :size="16" class="icon"></plus>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <!-- detached -->
+            <div class="mb-3">
+              <label for="appName" class="form-label">{{ $t('apps.detached_cmds') }}</label>
+              <div v-for="(c,i) in editForm.detached" class="d-flex justify-content-between align-items-center my-2">
+                <input type="text" v-model="editForm.detached[i]" class="form-control monospace">
+                <button class="btn btn-secondary btn-sm ms-2" @click="browseDetached(i)">
+                  <folder-open :size="14" class="icon"></folder-open>
+                </button>
+                <button class="btn btn-danger btn-sm ms-2" @click="editForm.detached.splice(i,1)">
+                  <trash-2 :size="16" class="icon"></trash-2>
+                </button>
+                <button class="btn btn-success btn-sm ms-2" @click="addDetached">
+                  <plus :size="16" class="icon"></plus>
+                </button>
+              </div>
+              <div class="d-flex justify-content-start mb-3 mt-3" v-if="editForm.detached.length === 0">
+                <button class="btn btn-success" @click="addDetached">
+                  <plus :size="18" class="icon"></plus>
+                  {{ $t('apps.detached_cmds_add') }}
+                </button>
+              </div>
+              <div class="form-text">
+                {{ $t('apps.detached_cmds_desc') }}<br>
+                <b>{{ $t('_common.note') }}</b> {{ $t('apps.detached_cmds_note') }}
+              </div>
+            </div>
+            <!-- command -->
+            <div class="mb-3">
+              <label for="appCmd" class="form-label">{{ $t('apps.cmd') }}</label>
+              <div class="input-group">
+                <input type="text" class="form-control monospace" id="appCmd" aria-describedby="appCmdHelp"
+                  v-model="editForm.cmd" />
+                <button class="btn btn-secondary" type="button"
+                  @click="browseFor('executable', 'file_browser.select_executable', editForm.cmd, v => editForm.cmd = v)">
+                  <folder-open :size="18" class="icon"></folder-open>
+                </button>
+              </div>
+              <div id="appCmdHelp" class="form-text">
+                {{ $t('apps.cmd_desc') }}<br>
+                <b>{{ $t('_common.note') }}</b> {{ $t('apps.cmd_note') }}
+              </div>
+            </div>
+            <!-- working dir -->
+            <div class="mb-3">
+              <label for="appWorkingDir" class="form-label">{{ $t('apps.working_dir') }}</label>
+              <div class="input-group">
+                <input type="text" class="form-control monospace" id="appWorkingDir" aria-describedby="appWorkingDirHelp"
+                  v-model="editForm['working-dir']" />
+                <button class="btn btn-secondary" type="button"
+                  @click="browseFor('directory', 'file_browser.select_directory', editForm['working-dir'], v => editForm['working-dir'] = v)">
+                  <folder-open :size="18" class="icon"></folder-open>
+                </button>
+              </div>
+              <div id="appWorkingDirHelp" class="form-text">{{ $t('apps.working_dir_desc') }}</div>
+            </div>
+            <!-- elevation -->
+            <Checkbox v-if="platform === 'windows'"
+                      class="mb-3"
+                      id="appElevation"
+                      label="_common.run_as"
+                      desc="apps.run_as_desc"
+                      v-model="editForm.elevated"
+                      default="false"
+            ></Checkbox>
+            <!-- auto-detach -->
+            <Checkbox class="mb-3"
+                      id="autoDetach"
+                      label="apps.auto_detach"
+                      desc="apps.auto_detach_desc"
+                      v-model="editForm['auto-detach']"
+                      default="true"
+            ></Checkbox>
+            <!-- wait for all processes -->
+            <Checkbox class="mb-3"
+                      id="waitAll"
+                      label="apps.wait_all"
+                      desc="apps.wait_all_desc"
+                      v-model="editForm['wait-all']"
+                      default="true"
+            ></Checkbox>
+            <!-- exit timeout -->
+            <div class="mb-3">
+              <label for="exitTimeout" class="form-label">{{ $t('apps.exit_timeout') }}</label>
+              <input type="number" class="form-control monospace" id="exitTimeout" aria-describedby="exitTimeoutHelp"
+                     v-model="editForm['exit-timeout']" min="0" placeholder="5" />
+              <div id="exitTimeoutHelp" class="form-text">{{ $t('apps.exit_timeout_desc') }}</div>
+            </div>
+            <div class="mb-3">
+              <label for="appImagePath" class="form-label">{{ $t('apps.image') }}</label>
+              <div class="input-group">
+                <input type="text" class="form-control monospace" id="appImagePath" aria-describedby="appImagePathHelp"
+                  v-model="editForm['image-path']" />
+                <button class="btn btn-secondary" type="button"
+                  @click="browseFor('file', 'file_browser.select_file', editForm['image-path'], v => editForm['image-path'] = v)">
+                  <folder-open :size="18" class="icon"></folder-open>
+                </button>
+                <button class="btn btn-secondary" type="button" @click="showCoverFinder">
+                  <search :size="18" class="icon"></search>
+                  {{ $t('apps.find_cover') }}
+                </button>
+              </div>
+              <div id="appImagePathHelp" class="form-text">{{ $t('apps.image_desc') }}</div>
+            </div>
+            <div class="env-hint alert alert-info">
+              <div class="form-text">
+                <h4>{{ $t('apps.env_vars_about') }}</h4>
+                {{ $t('apps.env_vars_desc') }}
+              </div>
+              <table class="env-table">
+                <tr>
+                  <td><b>{{ $t('apps.env_var_name') }}</b></td>
+                  <td><b></b></td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_APP_ID</td>
+                  <td>{{ $t('apps.env_app_id') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_APP_NAME</td>
+                  <td>{{ $t('apps.env_app_name') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_WIDTH</td>
+                  <td>{{ $t('apps.env_client_width') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_HEIGHT</td>
+                  <td>{{ $t('apps.env_client_height') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_FPS</td>
+                  <td>{{ $t('apps.env_client_fps') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_HDR</td>
+                  <td>{{ $t('apps.env_client_hdr') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_GCMAP</td>
+                  <td>{{ $t('apps.env_client_gcmap') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_HOST_AUDIO</td>
+                  <td>{{ $t('apps.env_client_host_audio') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_ENABLE_SOPS</td>
+                  <td>{{ $t('apps.env_client_enable_sops') }}</td>
+                </tr>
+                <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_AUDIO_CONFIGURATION</td>
+                  <td>{{ $t('apps.env_client_audio_config') }}</td>
+                </tr>
+              </table>
+              <div class="form-text" v-if="platform === 'windows'"><b>{{ $t('apps.env_qres_example') }}</b>
+                <pre>cmd /C &lt;{{ $t('apps.env_qres_path') }}&gt;\QRes.exe /X:%SUNSHINE_CLIENT_WIDTH% /Y:%SUNSHINE_CLIENT_HEIGHT% /R:%SUNSHINE_CLIENT_FPS%</pre>
+              </div>
+              <div class="form-text" v-else-if="platform === 'freebsd' || platform === 'linux'"><b>{{ $t('apps.env_xrandr_example') }}</b>
+                <pre>sh -c "xrandr --output HDMI-1 --mode \"${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT}\" --rate ${SUNSHINE_CLIENT_FPS}"</pre>
+              </div>
+              <div class="form-text" v-else-if="platform === 'macos'"><b>{{ $t('apps.env_displayplacer_example') }}</b>
+                <pre>sh -c "displayplacer "id:&lt;screenId&gt; res:${SUNSHINE_CLIENT_WIDTH}x${SUNSHINE_CLIENT_HEIGHT} hz:${SUNSHINE_CLIENT_FPS} scaling:on origin:(0,0) degree:0""</pre>
+              </div>
+              <div class="form-text"><a
+                  :href="`${documentationBaseUrl}/md_docs_2app__examples.html`"
+                  target="_blank">{{ $t('_common.see_more') }}</a></div>
+            </div>
           </div>
           <!-- Save buttons -->
           <div class="modal-footer">
@@ -433,7 +433,7 @@
                     </div>
                   </div>
                 </div>
-                <div v-for="(cover,i) in coverCandidates" :key="'i'" class="col-12 col-sm-6 col-lg-3 mb-3"
+                <div v-for="cover in coverCandidates" :key="cover.url" class="col-12 col-sm-6 col-lg-3 mb-3"
                   @click="useCover(cover)">
                   <div class="cover-container result">
                     <img class="rounded" :src="cover.url" />
@@ -698,7 +698,6 @@
           detached: [],
           "image-path": ""
         };
-        this.editForm.index = -1;
         this.openEditModal();
       },
       editApp(id) {

--- a/src_assets/common/assets/web/public/assets/css/sunshine.css
+++ b/src_assets/common/assets/web/public/assets/css/sunshine.css
@@ -1713,7 +1713,8 @@ p {
 }
 
 .apps-toolbar .input-group {
-    max-width: 18rem;
+    width: 15rem;
+    max-width: 100%;
 }
 
 .apps-toolbar .btn-outline-secondary {

--- a/src_assets/common/assets/web/public/assets/css/sunshine.css
+++ b/src_assets/common/assets/web/public/assets/css/sunshine.css
@@ -682,6 +682,11 @@ body {
 .modal-header,
 .modal-footer {
     border-color: var(--color-border) !important;
+    background-color: var(--color-surface-raised) !important;
+}
+
+.modal-header {
+    border-bottom: 2px solid var(--color-primary) !important;
 }
 
 .list-group-item {

--- a/src_assets/common/assets/web/public/assets/css/sunshine.css
+++ b/src_assets/common/assets/web/public/assets/css/sunshine.css
@@ -685,10 +685,6 @@ body {
     background-color: var(--color-surface-raised) !important;
 }
 
-.modal-header {
-    border-bottom: 2px solid var(--color-primary) !important;
-}
-
 .list-group-item {
     background-color: var(--color-surface) !important;
     border-color: var(--color-border) !important;
@@ -1718,8 +1714,7 @@ p {
 }
 
 .apps-toolbar .input-group {
-    width: 15rem;
-    max-width: 100%;
+    width: 14rem;
 }
 
 .apps-toolbar .btn-outline-secondary {

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -50,6 +50,8 @@
     "covers_found": "Covers Found",
     "cover_search_hint": "Search names should match IGDB naming conventions.",
     "delete": "Delete",
+    "delete_confirm": "Are you sure you want to delete {name}?",
+    "delete_title": "Delete Application",
     "detached_cmds": "Detached Commands",
     "detached_cmds_add": "Add Detached Command",
     "detached_cmds_desc": "A list of commands to be run in the background.",


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
- Moved the `Add New` apps button to the new apps toolbar (left side of the screen)
- Converted the `Add` / `Edit` apps form from the bottom of the screen to a new full-screen modal
  - Allows for nesting of modals as well, so File browser / Cover art modals appear over the `Add` / `Edit` modal
- Added a `Delete app` modal now instead of browser confirm popup
- Added `delete_title` and `delete_confirm` to the `en.json` translation file
- Updated `Add` / `Edit` / `Delete` UI flows to not hard force refresh (now just re-populates via calling the `apps` endpoint)

### Screenshots
<!--- Include screenshots if the changes are UI-related. --->
<img width="492" height="228" alt="image" src="https://github.com/user-attachments/assets/7b525412-7bdd-4f01-aabe-63596297c999" />
<img width="1436" height="1197" alt="image" src="https://github.com/user-attachments/assets/eb5f4649-0534-4906-9e50-951248cdd140" />
<img width="1436" height="1196" alt="image" src="https://github.com/user-attachments/assets/f0164fa8-592f-4694-bb7f-bdc1cd579016" />
<img width="530" height="214" alt="image" src="https://github.com/user-attachments/assets/2d1cf66a-c1d8-44c8-9f8e-d86cff6aab49" />
<img width="416" height="76" alt="image" src="https://github.com/user-attachments/assets/c1b9d8b7-5ed4-47cf-a198-6d7e1ea61428" />
<img width="482" height="89" alt="image" src="https://github.com/user-attachments/assets/e67d5f83-0f88-4a72-bc82-dd3a5f52ae06" />



### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [X] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [X] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [X] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [X] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
