### PR TITLE
build(macos): quote SHOULD_SIGN env expansion in install script

### DIFF
--- a/cmake/packaging/macos.cmake
+++ b/cmake/packaging/macos.cmake
@@ -60,7 +60,7 @@ else()
         endif()
 
         # SHOULD_SIGN is set only when publish_release is true or when manually building
-        if(\$ENV{SHOULD_SIGN} STREQUAL \"true\")
+        if(\"\$ENV{SHOULD_SIGN}\" STREQUAL \"true\")
           # Sign anything inside Contents/Frameworks
           set(_fw_dir \"\${_app}/Contents/Frameworks\")
           if(EXISTS \"\${_fw_dir}\")


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

The macOS `install(CODE ...)` block in `cmake/packaging/macos.cmake` contains:

```cmake
if($ENV{SHOULD_SIGN} STREQUAL "true")
```

When `SHOULD_SIGN` is unset (the common case for local manual builds — the env var is only set by CI on publish-release runs), the unquoted expansion collapses to nothing and CMake sees:

```
if( STREQUAL "true")
```

…which fails with `Unknown arguments specified` at install time. The bundle is fully assembled by that point (fixup_bundle runs first), but the error makes `cmake --install` exit non-zero and breaks scripts that chain `install` with `cpack` or downstream packaging steps.

Quote the expansion so the comparison is safe whether the env var is set, empty, or unset:

```cmake
if("$ENV{SHOULD_SIGN}" STREQUAL "true")
```

CI builds (where `SHOULD_SIGN=true`) keep working identically because quoting a non-empty string is a no-op.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A — build script change.


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->



#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->



## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
