### PR TITLE
fix(macos/packaging): add NSLocalNetworkUsageDescription so Bonjour can register

### DIFF
--- a/src_assets/macos/build/Info.plist.in
+++ b/src_assets/macos/build/Info.plist.in
@@ -28,6 +28,8 @@
   <string>@CMAKE_PROJECT_NAME@ requires access to system audio to capture and stream audio output.</string>
   <key>NSScreenCaptureUsageDescription</key>
   <string>@CMAKE_PROJECT_NAME@ requires access to screen recording to capture and stream your screen content.</string>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>@CMAKE_PROJECT_NAME@ advertises itself on your local network via Bonjour so Moonlight clients can discover this host.</string>
   <key>NSBonjourServices</key>
 	<array>
 		<string>_nvstream._tcp</string>


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

`src_assets/macos/build/Info.plist.in` declares `NSBonjourServices` with `_nvstream._tcp` so the host can advertise itself for Moonlight auto-discovery, but it does not declare `NSLocalNetworkUsageDescription`. On macOS 14+ this combination causes mDNS service registration to fail with error `-65570` (`kDNSServiceErr_PolicyDenied`):

```
[Error: Failed to register DNS service: Error -65570]
```

Apple's Local Network privacy gate treats the missing usage-description key as an implicit opt-out: the OS never prompts the user for permission, and `DNSServiceRegister` returns `PolicyDenied` silently. The Bonjour record is never broadcast, so stock Moonlight clients can't auto-discover the server (users have to add the host by IP manually).

Add a usage description so macOS prompts on first launch and allows the DNS-SD registration to succeed once the user grants Local Network access.

After this change, the startup log shows:

```
[Info: Successfully registered DNS service.]
```

instead of the `-65570` error, and Moonlight on iOS / Apple TV / macOS finds the host automatically over Bonjour.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A — Info.plist key addition.


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->



#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->



## Type of Change
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
