### PR TITLE
fix(build/version): derive date-stamped local version matching CI scheme

### DIFF
--- a/cmake/prep/build_version.cmake
+++ b/cmake/prep/build_version.cmake
@@ -53,15 +53,41 @@ else()
                 RESULT_VARIABLE GIT_IS_DIRTY
                 OUTPUT_STRIP_TRAILING_WHITESPACE
         )
+        # Derive a date-stamped version from the HEAD commit's UTC date so that
+        # local builds use the same YYYY.M[M]DD.H[H]MMSS scheme that CI emits via
+        # BUILD_VERSION. Without this, PROJECT_VERSION stays at the project()
+        # default of 0.0.0 and the web UI mis-classifies the build as ancient,
+        # triggering a spurious "new stable version available" banner.
+        execute_process(
+                COMMAND ${CMAKE_COMMAND} -E env "TZ=UTC"
+                        ${GIT_EXECUTABLE} log -1
+                        --format=%cd --date=format-local:%Y.%-m%d.%-H%M%S HEAD
+                OUTPUT_VARIABLE GIT_COMMIT_DATE_VERSION
+                RESULT_VARIABLE GIT_COMMIT_DATE_ERROR_CODE
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
         if(NOT GIT_DESCRIBE_ERROR_CODE)
             MESSAGE("Sunshine Branch: ${GIT_DESCRIBE_BRANCH}")
-            if(NOT GIT_DESCRIBE_BRANCH STREQUAL "master")
-                set(PROJECT_VERSION ${PROJECT_VERSION}-${GIT_DESCRIBE_VERSION})
-                MESSAGE("Sunshine Version: ${GIT_DESCRIBE_VERSION}")
-            endif()
-            if(GIT_IS_DIRTY)
-                set(PROJECT_VERSION ${PROJECT_VERSION}-dirty)
-                MESSAGE("Git tree is dirty!")
+            if(NOT GIT_COMMIT_DATE_ERROR_CODE AND GIT_COMMIT_DATE_VERSION MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
+                set(PROJECT_VERSION ${GIT_COMMIT_DATE_VERSION})
+                MESSAGE("Sunshine Version (from commit date): ${PROJECT_VERSION}")
+                if(GIT_IS_DIRTY)
+                    # Dot-separated trailing parts keep buildVersionIsDirty()
+                    # in the web UI (which checks split('.').length === 5) accurate.
+                    set(PROJECT_VERSION ${PROJECT_VERSION}.${GIT_DESCRIBE_VERSION}.dirty)
+                    MESSAGE("Git tree is dirty!")
+                endif()
+            else()
+                # Fallback to the historical 0.0.0-sha[-dirty] form if git
+                # couldn't produce a parseable commit date for any reason.
+                if(NOT GIT_DESCRIBE_BRANCH STREQUAL "master")
+                    set(PROJECT_VERSION ${PROJECT_VERSION}-${GIT_DESCRIBE_VERSION})
+                    MESSAGE("Sunshine Version: ${GIT_DESCRIBE_VERSION}")
+                endif()
+                if(GIT_IS_DIRTY)
+                    set(PROJECT_VERSION ${PROJECT_VERSION}-dirty)
+                    MESSAGE("Git tree is dirty!")
+                endif()
             endif()
         else()
             MESSAGE(ERROR ": Got git error while fetching tags: ${GIT_DESCRIBE_ERROR_CODE}")


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

CI builds inject `BUILD_VERSION=YYYY.M[M]DD.H[H]MMSS` from the release-setup reusable action, which produces tags like `v2026.525.22124` that the web UI's `SunshineVersion` parses cleanly. Local builds (no `BRANCH` / `BUILD_VERSION` env vars set) fall into the git fallback path in `cmake/prep/build_version.cmake`, which only ever produces:

```
0.0.0-<short-sha>[-dirty]
```

The web UI then parses this as `[0, 0, NaN]` (because `Number("0-<sha>-dirty") === NaN`), compares it against `https://api.github.com/repos/LizardByte/Sunshine/releases/latest`, and concludes `[2026, ...] > [0, 0, NaN]` — triggering the **"A new Stable Version is Available!"** banner on every local build, even when the local build is on a commit *newer* than the latest published stable.

This change mirrors the CI scheme for non-CI builds: when `BUILD_VERSION` is unset, derive `PROJECT_VERSION` from the HEAD commit's UTC date in the same `YYYY.M[M]DD.H[H]MMSS` format CI emits. CI builds are entirely untouched — the existing `if (BRANCH AND BUILD_VERSION)` branch takes precedence and the new logic only runs in the `else` fallback.

For dirty trees the suffix becomes `.<sha>.dirty` (dot-separated 5 parts) instead of `-<sha>-dirty`, so the web UI's existing `buildVersionIsDirty` check (`split('.').length === 5 && contains 'dirty'`) actually fires and shows the appropriate "thank you for helping" banner rather than the spurious new-stable banner.

If git cannot produce a parseable commit date for any reason, the historical `0.0.0-<sha>[-dirty]` form is used as a fallback so the change can never regress to a worse state than today.

**Behavioural summary**:
| Scenario | Before | After |
|---|---|---|
| CI build (`BUILD_VERSION` set) | `2026.525.22124` | `2026.525.22124` (unchanged) |
| Local clean checkout | `0.0.0-abc1234` → spurious "new stable" banner | `2026.525.103015` → correct "pre-release" banner |
| Local dirty tree | `0.0.0-abc1234-dirty` → spurious banner | `2026.525.103015.abc1234.dirty` → "version_dirty" banner |
| Git unavailable | `0.0.0` | `0.0.0` (fallback retained) |


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A — build script change.


### Issues Fixed or Closed



#### Roadmap Issues



## Type of Change
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
