### PR TITLE
fix(macos): drop max_ref_frames=1 for h264_videotoolbox

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1134,12 +1134,16 @@ namespace video {
     },
     {
       // Common options
+      // Note: max_ref_frames is intentionally omitted for H.264 because
+      // VideoToolbox on Apple Silicon produces all-IDR output when
+      // ReferenceBufferCount=1 is set for H.264, causing massive bandwidth
+      // inflation (~3x) and frame drops. HEVC and AV1 are unaffected and
+      // retain max_ref_frames=1. See LizardByte/Sunshine#5013.
       {
         {"allow_sw"s, &config::video.vt.vt_allow_sw},
         {"require_sw"s, &config::video.vt.vt_require_sw},
         {"realtime"s, &config::video.vt.vt_realtime},
         {"prio_speed"s, 1},
-        {"max_ref_frames"s, 1},
       },
       {},  // SDR-specific options
       {},  // HDR-specific options


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

VideoToolbox on Apple Silicon emits an IDR keyframe on **every** frame when `ReferenceBufferCount=1` is set for H.264 — P-frames are never produced, and bandwidth inflates by roughly 3× while frame drops become severe under any sustained load. The hardware encoder's H.264 path interprets the minimum-ref-frames=1 constraint as "you have nothing to reference back to," so it cannot legally emit a P-frame and falls back to IDR-everything.

HEVC and AV1 on the same Apple Silicon hardware are **not affected** by this quirk — they continue to honor `max_ref_frames=1` correctly and produce normal P-frames for reference-frame invalidation, so the constraint is correctly retained for those codecs.

This change removes `{"max_ref_frames"s, 1}` from the **common options** block of the `h264_videotoolbox` encoder entry only. The encoder still goes through Sunshine's `max_ref_frames` capability probe (`config_max_ref_frames` test), but without forcing the AVCodecContext option upfront — VideoToolbox is left to pick a sensible default reference count for H.264 (which it does correctly: 1-2 reference frames, producing real P-frames).

Validated on Apple Silicon (M4 Max): H.264 stream bitrate at 1080p60 drops from ~14 Mbps (all-IDR) to ~4.5 Mbps (normal P-frame mix) at identical quality, matching expected behavior for H.264 streaming. HEVC and AV1 paths are bitwise unchanged.

The diagnosis and original fix are from the **Lumen** fork ([github.com/trollzem/Lumen](https://github.com/trollzem/Lumen)); this PR brings the fix upstream with an inline comment explaining the rationale so future readers don't try to "re-add" the constraint thinking it was an oversight.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A — encoder option change.


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->

- Fixes #5013


#### Roadmap Issues



## Type of Change
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
