### PR TITLE
feat(macos): declare LSApplicationCategoryType=games for gamepolicyd treatment

### DIFF
--- a/src_assets/macos/build/Info.plist.in
+++ b/src_assets/macos/build/Info.plist.in
@@ -18,8 +18,17 @@
   <string>@PROJECT_VERSION@</string>
   <key>CFBundleIconFile</key>
   <string>sunshine.icns</string>
+  <!--
+    Categorise as a game so gamepolicyd (macOS 14+) treats this process
+    as game-related and does not deprioritise its encoder/capture threads
+    when the streamed game has Game Mode active. Sunshine itself cannot
+    *trigger* Game Mode because it is LSUIElement (no Dock icon, never
+    frontmost), but being recognised as game-eligible means the OS keeps
+    Sunshine on game-priority scheduling alongside the actual game it is
+    streaming, instead of throttling it as a generic background utility.
+  -->
   <key>LSApplicationCategoryType</key>
-  <string>public.app-category.utilities</string>
+  <string>public.app-category.games</string>
   <key>LSUIElement</key>
   <true/>
   <key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

macOS 14+ uses `gamepolicyd` to decide which processes get game-priority scheduling treatment. The daemon's primary signal is the app's `LSApplicationCategoryType`: anything matching `public.app-category.*games*` is recognised as game-related and kept on game-priority scheduling when other games activate Game Mode. Everything else can be deprioritised to free CPU/GPU resources for the foreground game.

Sunshine was previously declared as a **utility**. When a user streams a game that engages Game Mode (e.g. a native Mac game running fullscreen), the OS treats Sunshine as background noise and throttles its capture and encoder threads — which is exactly backwards for a streaming host whose entire purpose is to maintain realtime encode throughput **while** the streamed game runs hot.

Reclassifying as `public.app-category.games` causes `gamepolicyd` to treat Sunshine as a peer of the running game. Encoder threads keep their scheduling priority, capture queue isn't preempted, and the actual streaming throughput stays consistent under load.

**Important distinction:** Sunshine itself does **not** trigger Game Mode and this PR does not attempt to make it do so. Sunshine is `LSUIElement=true` (background utility, no Dock icon, never frontmost-fullscreen) so it can never meet `gamepolicyd`'s Game Mode activation criteria (frontmost + native-fullscreen). The change is purely about Sunshine **not being throttled** when a separate game-categorised app activates Game Mode.

An inline comment in the plist documents the rationale so future readers don't try to "fix" the seemingly-incorrect category. The `LSApplicationCategoryType` is otherwise informational (no behavioural change outside `gamepolicyd`'s scheduling heuristics and Mac App Store categorisation, the latter being inapplicable here since Sunshine is not App Store distributed).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A — Info.plist key change.


### Issues Fixed or Closed



#### Roadmap Issues



## Type of Change
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [x] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
