### PR TITLE
fix(linux/kwin): retry init with fully dropped elevated privileges in case KWin is missing CAP_SYS_NICE on linux

### DIFF
--- a/src/platform/linux/kwingrab.cpp
+++ b/src/platform/linux/kwingrab.cpp
@@ -326,6 +326,14 @@ namespace kwin {
     }
 
     /**
+     * @brief Check if kwin screencasting is currently available
+     * @return true if screencast can be started, false otherwise
+     */
+    bool is_kwin_screencasting_available() const {
+      return kde_screencast_v1_ != nullptr;
+    }
+
+    /**
      * @brief Generate a sorted list of known output names.
      * @return List of strings with output names to pass to start()
      */
@@ -642,6 +650,20 @@ namespace kwin {
       if (screencast->init(true) < 0) {
         return -1;
       }
+#if !defined(__FreeBSD__)
+      // Check if KWin screencasting extension is accessible after first init attempt
+      if (!screencast->is_kwin_screencasting_available()) {
+        // KWin screencasting extension was not found. Drop ALL elevated privileges in case KWin is missing CAP_SYS_NICE
+        BOOST_LOG(warning) << "[kwingrab] KWin screencasting unavailable after init. Trying again after dropping ALL elevated privileges."sv;
+        platf::drop_elevated_privileges(true);
+        // Retry screencast session init after privilege drop
+        screencast.reset();  // Cleanup current screencast instance
+        screencast = std::make_unique<screencast_t>();  // Create new screencast instance
+        if (screencast->init(true) < 0) {
+          return -1;
+        }
+      }
+#endif
       if (screencast->start(display_name) < 0) {
         return -1;
       }


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Archlinux/CachyOS packaged `kwin-6.6.5-3` is not assigning `CAP_SYS_NICE` to KWin therefore breaking `kwingrab` which was allowed to retain the capability to improve streaming performance as part of #5075. Although this is likely a bug on the packaging end it should be properly handled in Sunshine.

This PR adds handling for KWin missing CAP_SYS_NICE by checking if init succeeded in binding the screencast extension. Should that not be the case it's logging a warning, dropping *ALL* elevated capabilities and doing a full reinit of the screencast instance on the display object before continuing with starting the stream. 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
