### PR TITLE
fix(video): fix video stream freezing on capture re-init (e.g. pipewire display switch)

### DIFF
--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -1010,14 +1010,12 @@ namespace pipewire {
             }
             if (!push_captured_image_cb(std::move(img_out), false)) {
               BOOST_LOG(debug) << "[pipewire] PipeWire: timeout -> !push_captured_image_cb -> ok";
-              std::this_thread::sleep_for(10us);  // Workaround: delay OK to avoid video stream freezing
               return platf::capture_e::ok;
             }
             break;
           case platf::capture_e::ok:
             if (!push_captured_image_cb(std::move(img_out), true)) {
               BOOST_LOG(debug) << "[pipewire] PipeWire: ok -> !push_captured_image_cb -> ok";
-              std::this_thread::sleep_for(10us);  // Workaround: delay OK to avoid video stream freezing
               return platf::capture_e::ok;
             }
             break;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -136,16 +136,12 @@ namespace pipewire {
 
     ~pipewire_t() {
       BOOST_LOG(debug) << "[pipewire] Destroying pipewire_t"sv;
-      if (loop) {
-        BOOST_LOG(debug) << "[pipewire] Stop PW thread loop"sv;
-        pw_thread_loop_stop(loop);
-      }
       try {
         cleanup_stream();
       } catch (const std::exception &e) {
-        BOOST_LOG(error) << "[pipewire] Standard exception caught in ~pipewire_t: "sv << e.what();
+        BOOST_LOG(error) << "[pipewire] Standard exception caught in ~pipewire_t cleanup_stream: "sv << e.what();
       } catch (...) {
-        BOOST_LOG(error) << "[pipewire] Unknown exception caught in ~pipewire_t"sv;
+        BOOST_LOG(error) << "[pipewire] Unknown exception caught in ~pipewire_t cleanup_stream"sv;
       }
 
       pw_thread_loop_lock(loop);

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -529,8 +529,13 @@ namespace pipewire {
     };
 
     static void on_stream_state_changed(void *user_data, enum pw_stream_state old, enum pw_stream_state state, const char *err_msg) {
-      BOOST_LOG(debug) << "[pipewire] PipeWire stream state: " << pw_stream_state_as_string(old)
-                       << " -> " << pw_stream_state_as_string(state);
+      if (err_msg != nullptr) {
+        BOOST_LOG(info) << "[pipewire] PipeWire stream error '" << err_msg << "' on state: " << pw_stream_state_as_string(old)
+                        << " -> " << pw_stream_state_as_string(state);
+      } else {
+        BOOST_LOG(info) << "[pipewire] PipeWire stream state: " << pw_stream_state_as_string(old)
+                        << " -> " << pw_stream_state_as_string(state);
+      }
 
       auto *d = static_cast<stream_data_t *>(user_data);
 
@@ -999,18 +1004,20 @@ namespace pipewire {
           case platf::capture_e::timeout:
             if (!pull_free_image_cb(img_out)) {
               // Detect if shutdown is pending
-              BOOST_LOG(debug) << "[pipewire] PipeWire: timeout -> interrupt nudge";
+              BOOST_LOG(debug) << "[pipewire] PipeWire: timeout -> shutdown pending -> interrupt nudge";
               pipewire.frame_cv().notify_all();
               return platf::capture_e::interrupted;
             }
             if (!push_captured_image_cb(std::move(img_out), false)) {
-              BOOST_LOG(debug) << "[pipewire] PipeWire: !push_captured_image_cb -> ok";
+              BOOST_LOG(debug) << "[pipewire] PipeWire: timeout -> !push_captured_image_cb -> ok";
+              std::this_thread::sleep_for(10us);  // Workaround: delay OK to avoid video stream freezing
               return platf::capture_e::ok;
             }
             break;
           case platf::capture_e::ok:
             if (!push_captured_image_cb(std::move(img_out), true)) {
-              BOOST_LOG(debug) << "[pipewire] PipeWire: !push_captured_image_cb -> ok";
+              BOOST_LOG(debug) << "[pipewire] PipeWire: ok -> !push_captured_image_cb -> ok";
+              std::this_thread::sleep_for(10us);  // Workaround: delay OK to avoid video stream freezing
               return platf::capture_e::ok;
             }
             break;

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -49,6 +49,21 @@ namespace safe {
       _cv.notify_all();
     }
 
+    /**
+     * @brief Try to remove and return the next queued item without any further wait
+     *
+     * @return Removed queue item, or empty result when the queue is stopped or empty.
+     */
+    status_t try_pop() {
+      std::lock_guard lg {_lock};
+      if (!_status) {
+        return util::false_v<status_t>;
+      }
+      auto val = std::move(_status);
+      _status = util::false_v<status_t>;
+      return val;
+    }
+
     // pop and view should not be used interchangeably
     /**
      * @brief Remove and return the next queued item, waiting when requested.
@@ -94,7 +109,7 @@ namespace safe {
       }
 
       auto val = std::move(_status);
-      _status.reset();
+      _status = util::false_v<status_t>;
       return val;
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1697,8 +1697,7 @@ namespace video {
                   continue;
                 }
 
-                while (capture_ctx->images->peek()) {
-                  capture_ctx->images->pop();
+                while (capture_ctx->images->try_pop()) {
                 }
 
                 ++capture_ctx;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This is a trial-and-error workaround to avoid video stream freezing when display switching that somehow happens when not using the added thread sleeps due to a racecondition that needs to be further diagnosed and might even be outside Sunshine's control. Adding a 0.01ms sleep at the relevant codepoints (see changes) seems to fix the issue reliably without creating unwanted behaviour/other issues.

Also the log level for pipewire state changes to ease initial analysis of future issues without having debug logging enabled.

This issue was identified after working around the FFmpeg segfault in #4943 but might occur independently from that. Unsure if this can also help with #5241 but should be tested as it might be the same root cause.

__Note:__ This issue is almost impossible to pinpoint as it is only occurring when running as a systemd user service without having debug logging enabled (so `BOOST_LOG(debug)` does noop). If run with debug logging enabled, the added runtime by BOOST_LOG is sufficient to allievate the issue. Same is true if running with a debugger attached. The only way to figure out the relevant code segment was by changing the loglevel for each log statement in `pipewire.cpp` and trying to trigger the issue. After doing that the following codesegment was found to fix the issue when using log level info:
https://github.com/LizardByte/Sunshine/blob/1f0455cc0c06487ca9141b6b76e612580f9574e4/src/platform/linux/pipewire.cpp#L866-L869
That is why the workaround now adds a sleep right before the return (and does so also for the timeout case).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
