### PR TITLE
feat(linux): pace capture at exact fractional NTSC framerates

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -226,13 +226,9 @@ namespace nvenc {
     init_params.darWidth = encoder_params.width;
     init_params.encodeHeight = encoder_params.height;
     init_params.darHeight = encoder_params.height;
-    init_params.frameRateNum = client_config.framerate;
-    init_params.frameRateDen = 1;
-    if (client_config.framerateX100 > 0) {
-      AVRational fps = video::framerateX100_to_rational(client_config.framerateX100);
-      init_params.frameRateNum = fps.num;
-      init_params.frameRateDen = fps.den;
-    }
+    const AVRational fps = video::framerate_to_rational(client_config);
+    init_params.frameRateNum = fps.num;
+    init_params.frameRateDen = fps.den;
 
     if (client_config.videoFormat > 0 && get_encoder_cap(NV_ENC_CAPS_NUM_ENCODER_ENGINES) > 1) {
       // SFE supports HEVC/AV1 if you have more than 1 nvenc block

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -993,6 +993,11 @@ namespace cuda {
         }
 
         delay = std::chrono::nanoseconds {1s} / config.framerate;
+        if (config.framerateX100 > 0) {
+          // Use exactly the requested rate if the client sent an X100 value
+          AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
+          delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
+        }
 
         capture_params = NVFBC_CREATE_CAPTURE_SESSION_PARAMS {NVFBC_CREATE_CAPTURE_SESSION_PARAMS_VER};
 

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -992,12 +992,7 @@ namespace cuda {
           }
         }
 
-        delay = std::chrono::nanoseconds {1s} / config.framerate;
-        if (config.framerateX100 > 0) {
-          // Use exactly the requested rate if the client sent an X100 value
-          AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
-          delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
-        }
+        delay = ::video::capture_frame_interval(config);
 
         capture_params = NVFBC_CREATE_CAPTURE_SESSION_PARAMS {NVFBC_CREATE_CAPTURE_SESSION_PARAMS_VER};
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -873,12 +873,7 @@ namespace platf {
        * @return 0 on success; nonzero or negative platform status on failure.
        */
       int init(const std::string &display_name, const ::video::config_t &config) {
-        delay = std::chrono::nanoseconds {1s} / config.framerate;
-        if (config.framerateX100 > 0) {
-          // Use exactly the requested rate if the client sent an X100 value
-          AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
-          delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
-        }
+        delay = ::video::capture_frame_interval(config);
 
         int monitor_index = util::from_view(display_name);
         int monitor = 0;

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -874,6 +874,11 @@ namespace platf {
        */
       int init(const std::string &display_name, const ::video::config_t &config) {
         delay = std::chrono::nanoseconds {1s} / config.framerate;
+        if (config.framerateX100 > 0) {
+          // Use exactly the requested rate if the client sent an X100 value
+          AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
+          delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
+        }
 
         int monitor_index = util::from_view(display_name);
         int monitor = 0;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -806,14 +806,11 @@ namespace pipewire {
     int init(platf::mem_type_e hwdevice_type, const std::string &display_name, const ::video::config_t &config) {
       // calculate frame interval we should capture at
       framerate = config.framerate;
+      delay = ::video::capture_frame_interval(config);
       if (config.framerateX100 > 0) {
         AVRational fps_strict = ::video::framerateX100_to_rational(config.framerateX100);
-        delay = std::chrono::nanoseconds(
-          (static_cast<int64_t>(fps_strict.den) * 1'000'000'000LL) / fps_strict.num
-        );
         BOOST_LOG(info) << "[pipewire] Requested frame rate [" << fps_strict.num << "/" << fps_strict.den << ", approx. " << av_q2d(fps_strict) << " fps]";
       } else {
-        delay = std::chrono::nanoseconds {1s} / framerate;
         BOOST_LOG(info) << "[pipewire] Requested frame rate [" << framerate << "fps]";
       }
       mem_type = hwdevice_type;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -807,11 +807,11 @@ namespace pipewire {
       // calculate frame interval we should capture at
       framerate = config.framerate;
       delay = ::video::capture_frame_interval(config);
-      if (config.framerateX100 > 0) {
-        AVRational fps_strict = ::video::framerateX100_to_rational(config.framerateX100);
-        BOOST_LOG(info) << "[pipewire] Requested frame rate [" << fps_strict.num << "/" << fps_strict.den << ", approx. " << av_q2d(fps_strict) << " fps]";
+      const AVRational fps = ::video::framerate_to_rational(config);
+      if (fps.den != 1) {
+        BOOST_LOG(info) << "[pipewire] Requested frame rate [" << fps.num << "/" << fps.den << ", approx. " << av_q2d(fps) << " fps]";
       } else {
-        BOOST_LOG(info) << "[pipewire] Requested frame rate [" << framerate << "fps]";
+        BOOST_LOG(info) << "[pipewire] Requested frame rate [" << fps.num << "fps]";
       }
       mem_type = hwdevice_type;
 

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -54,12 +54,7 @@ namespace wl {
         );
         BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << fps_strict.num << "/" << fps_strict.den << ", approx. " << av_q2d(fps_strict) << " fps]";
       } else {
-        delay = std::chrono::nanoseconds {1s} / config.framerate;
-        if (config.framerateX100 > 0) {
-          // Use exactly the requested rate if the client sent an X100 value
-          AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
-          delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
-        }
+        delay = ::video::capture_frame_interval(config);
         BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << config.framerate << "fps]";
       }
 

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -55,6 +55,11 @@ namespace wl {
         BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << fps_strict.num << "/" << fps_strict.den << ", approx. " << av_q2d(fps_strict) << " fps]";
       } else {
         delay = std::chrono::nanoseconds {1s} / config.framerate;
+        if (config.framerateX100 > 0) {
+          // Use exactly the requested rate if the client sent an X100 value
+          AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
+          delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
+        }
         BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << config.framerate << "fps]";
       }
 

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -47,15 +47,12 @@ namespace wl {
      */
     int init(platf::mem_type_e hwdevice_type, const std::string &display_name, const ::video::config_t &config) {
       // calculate frame interval we should capture at
-      if (config.framerateX100 > 0) {
-        AVRational fps_strict = ::video::framerateX100_to_rational(config.framerateX100);
-        delay = std::chrono::nanoseconds(
-          (static_cast<int64_t>(fps_strict.den) * 1'000'000'000LL) / fps_strict.num
-        );
-        BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << fps_strict.num << "/" << fps_strict.den << ", approx. " << av_q2d(fps_strict) << " fps]";
+      delay = ::video::capture_frame_interval(config);
+      const AVRational fps = ::video::framerate_to_rational(config);
+      if (fps.den != 1) {
+        BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << fps.num << "/" << fps.den << ", approx. " << av_q2d(fps) << " fps]";
       } else {
-        delay = ::video::capture_frame_interval(config);
-        BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << config.framerate << "fps]";
+        BOOST_LOG(info) << "[wlgrab] Requested frame rate [" << fps.num << "fps]";
       }
 
       mem_type = hwdevice_type;

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -499,12 +499,7 @@ namespace platf {
         return -1;
       }
 
-      delay = std::chrono::nanoseconds {1s} / config.framerate;
-      if (config.framerateX100 > 0) {
-        // Use exactly the requested rate if the client sent an X100 value
-        AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
-        delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
-      }
+      delay = ::video::capture_frame_interval(config);
 
       xwindow = DefaultRootWindow(xdisplay.get());
 

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -500,6 +500,11 @@ namespace platf {
       }
 
       delay = std::chrono::nanoseconds {1s} / config.framerate;
+      if (config.framerateX100 > 0) {
+        // Use exactly the requested rate if the client sent an X100 value
+        AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
+        delay = std::chrono::nanoseconds {std::chrono::nanoseconds {1s}.count() * fps.den / fps.num};
+      }
 
       xwindow = DefaultRootWindow(xdisplay.get());
 

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -728,7 +728,7 @@ namespace platf::dxgi {
     client_frame_rate = config.framerate;
     client_frame_rate_strict = {0, 0};
     if (config.framerateX100 > 0) {
-      AVRational fps = ::video::framerateX100_to_rational(config.framerateX100);
+      const AVRational fps = ::video::framerate_to_rational(config);
       client_frame_rate_strict = DXGI_RATIONAL {static_cast<UINT>(fps.num), static_cast<UINT>(fps.den)};
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1954,13 +1954,9 @@ namespace video {
       ctx.reset(avcodec_alloc_context3(codec));
       ctx->width = config.width;
       ctx->height = config.height;
-      ctx->time_base = AVRational {1, config.framerate};
-      ctx->framerate = AVRational {config.framerate, 1};
-      if (config.framerateX100 > 0) {
-        AVRational fps = video::framerateX100_to_rational(config.framerateX100);
-        ctx->framerate = fps;
-        ctx->time_base = AVRational {fps.den, fps.num};
-      }
+      const AVRational fps = video::framerate_to_rational(config);
+      ctx->framerate = fps;
+      ctx->time_base = AVRational {fps.den, fps.num};
 
       switch (config.videoFormat) {
         case 0:

--- a/src/video.h
+++ b/src/video.h
@@ -645,14 +645,23 @@ namespace video {
   }
 
   /**
+   * @brief Requested framerate as an exact rational.
+   * Uses the exact fractional rate when the client provided an X100 value,
+   * otherwise the integer framerate over 1.
+   */
+  inline AVRational framerate_to_rational(const config_t &config) {
+    if (config.framerateX100 > 0) {
+      return framerateX100_to_rational(config.framerateX100);
+    }
+    return AVRational {config.framerate, 1};
+  }
+
+  /**
    * @brief Capture frame interval for the requested framerate.
    * Uses the exact fractional rate when the client provided an X100 value.
    */
   inline std::chrono::nanoseconds capture_frame_interval(const config_t &config) {
-    if (config.framerateX100 > 0) {
-      AVRational fps = framerateX100_to_rational(config.framerateX100);
-      return std::chrono::nanoseconds {(static_cast<int64_t>(fps.den) * 1'000'000'000LL) / fps.num};
-    }
-    return std::chrono::nanoseconds {std::chrono::seconds {1}} / config.framerate;
+    const AVRational fps = framerate_to_rational(config);
+    return std::chrono::nanoseconds {(static_cast<int64_t>(fps.den) * 1'000'000'000LL) / fps.num};
   }
 }  // namespace video

--- a/src/video.h
+++ b/src/video.h
@@ -4,6 +4,9 @@
  */
 #pragma once
 
+// standard includes
+#include <chrono>
+
 // local includes
 #include "input.h"
 #include "platform/common.h"
@@ -639,5 +642,17 @@ namespace video {
         // "rational numbers with |num| <= 1<<26 && |den| <= 1<<26 can be recovered exactly from their double representation"
         return av_d2q((double) framerateX100 / 100.0f, 1 << 26);
     }
+  }
+
+  /**
+   * @brief Capture frame interval for the requested framerate.
+   * Uses the exact fractional rate when the client provided an X100 value.
+   */
+  inline std::chrono::nanoseconds capture_frame_interval(const config_t &config) {
+    if (config.framerateX100 > 0) {
+      AVRational fps = framerateX100_to_rational(config.framerateX100);
+      return std::chrono::nanoseconds {(static_cast<int64_t>(fps.den) * 1'000'000'000LL) / fps.num};
+    }
+    return std::chrono::nanoseconds {std::chrono::seconds {1}} / config.framerate;
   }
 }  // namespace video

--- a/src/video.h
+++ b/src/video.h
@@ -648,6 +648,9 @@ namespace video {
    * @brief Requested framerate as an exact rational.
    * Uses the exact fractional rate when the client provided an X100 value,
    * otherwise the integer framerate over 1.
+   *
+   * @param config Stream configuration carrying the requested framerate.
+   * @return Requested frame rate as a rational.
    */
   inline AVRational framerate_to_rational(const config_t &config) {
     if (config.framerateX100 > 0) {
@@ -659,6 +662,9 @@ namespace video {
   /**
    * @brief Capture frame interval for the requested framerate.
    * Uses the exact fractional rate when the client provided an X100 value.
+   *
+   * @param config Stream configuration carrying the requested framerate.
+   * @return Duration of a single frame interval in nanoseconds.
    */
   inline std::chrono::nanoseconds capture_frame_interval(const config_t &config) {
     const AVRational fps = framerate_to_rational(config);

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -76,3 +76,48 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_tuple(9498, AVRational {4749, 50})  // from my LG 27GN950
   )
 );
+
+struct FramerateToRationalTest: testing::TestWithParam<std::tuple<int, int, AVRational>> {};
+
+TEST_P(FramerateToRationalTest, Run) {
+  const auto &[framerate, framerateX100, expected] = GetParam();
+  video::config_t config {};
+  config.framerate = framerate;
+  config.framerateX100 = framerateX100;
+  auto res = video::framerate_to_rational(config);
+  ASSERT_EQ(0, av_cmp_q(res, expected)) << "expected "
+                                        << expected.num << "/" << expected.den
+                                        << ", got "
+                                        << res.num << "/" << res.den;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  FramerateToRationalTests,
+  FramerateToRationalTest,
+  testing::Values(
+    std::make_tuple(60, 0, AVRational {60, 1}),  // no X100 value, fall back to integer framerate
+    std::make_tuple(60, 5994, AVRational {60000, 1001}),
+    std::make_tuple(120, 11988, AVRational {120000, 1001}),
+    std::make_tuple(24, 2398, AVRational {24000, 1001})
+  )
+);
+
+struct CaptureFrameIntervalTest: testing::TestWithParam<std::tuple<int, int, std::chrono::nanoseconds>> {};
+
+TEST_P(CaptureFrameIntervalTest, Run) {
+  const auto &[framerate, framerateX100, expected] = GetParam();
+  video::config_t config {};
+  config.framerate = framerate;
+  config.framerateX100 = framerateX100;
+  ASSERT_EQ(expected, video::capture_frame_interval(config));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  CaptureFrameIntervalTests,
+  CaptureFrameIntervalTest,
+  testing::Values(
+    std::make_tuple(60, 0, std::chrono::nanoseconds {16666666}),
+    std::make_tuple(60, 5994, std::chrono::nanoseconds {16683333}),  // 1e9 * 1001 / 60000
+    std::make_tuple(120, 11988, std::chrono::nanoseconds {8341666})  // 1e9 * 1001 / 120000
+  )
+);


### PR DESCRIPTION
## Description

#4019 added support for the `x-nv-video[0].clientRefreshRateX100` RTSP parameter, but
implemented the capture-side handling only for the Windows backend
(`platform/windows/display_base.cpp`); on Linux only the encoder time base got the exact
rational. The Linux capture loops still pace at the integer `maxFPS`, so for a client that
requests e.g. 11988 (Xbox, whose display pipeline runs at 120/1.001 Hz) the host delivers
120.00 fps while the client drains 119.88 fps. The 0.1% surplus accumulates one extra frame
every ~8 s, which the client-side pacer keeps correcting — visible as a periodic frame-queue
oscillation / micro-judder that no client setting can remove.

This PR mirrors the Windows handling in the four Linux capture pacers (kmsgrab, wlgrab,
x11grab, CUDA): when `framerateX100` is present, the frame interval is derived from the
exact rational returned by `video::framerateX100_to_rational()`.

Tested on an AMD RDNA4 + KDE Wayland host (KMS capture, Vulkan encoder) against a
moonlight-xbox client at 4K 119.88 Hz:  the standing frame-queue oscillation on
the client disappears (queue settles flat instead of breathing by one frame every ~8 s).

### Issues Fixed or Closed

Completes the Linux side of #4019.

## Type of Change

- [x] **feat**: New feature (non-breaking change which adds functionality)

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas

### AI Usage

- [x] **Heavy**: AI generated most or all of the code changes