### PR TITLE
fix(graphics): add EGL_BAD_MATCH fallback for incompatible format modifiers

### DIFF
--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -594,7 +594,7 @@ namespace egl {
   }
 
   std::optional<rgb_t> import_source(display_t::pointer egl_display, const surface_descriptor_t &xrgb) {
-    auto attribs = surface_descriptor_to_egl_attribs(xrgb);
+    const auto attribs = surface_descriptor_to_egl_attribs(xrgb);
 
     rgb_t rgb {
       egl_display,
@@ -603,9 +603,29 @@ namespace egl {
     };
 
     if (!rgb->xrgb8) {
-      BOOST_LOG(error) << "Couldn't import RGB Image: "sv << util::hex(eglGetError()).to_string_view();
+      auto err = eglGetError();
 
-      return std::nullopt;
+      // Fallback: retry without modifier if GPU rejects the display's format modifier
+      // Some displays (e.g. USB/DisplayLink) report modifiers the GPU cannot handle
+      if (err == EGL_BAD_MATCH && xrgb.modifier != DRM_FORMAT_MOD_INVALID) {
+        surface_descriptor_t xrgb_linear = xrgb;
+        xrgb_linear.modifier = DRM_FORMAT_MOD_INVALID;
+        auto attribs_linear = surface_descriptor_to_egl_attribs(xrgb_linear);
+
+        rgb = {
+          egl_display,
+          eglCreateImage(egl_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attribs_linear.data()),
+          gl::tex_t::make(1)
+        };
+
+        if (!rgb->xrgb8) {
+          BOOST_LOG(error) << "Couldn't import RGB Image: "sv << util::hex(err).to_string_view();
+          return std::nullopt;
+        }
+      } else {
+        BOOST_LOG(error) << "Couldn't import RGB Image: "sv << util::hex(err).to_string_view();
+        return std::nullopt;
+      }
     }
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);


### PR DESCRIPTION
## Problem

When capturing from displays that report DMA-BUF format modifiers incompatible with the GPU's EGL implementation (e.g. USB/DisplayLink monitors), `eglCreateImage()` fails with `EGL_BAD_MATCH` (0x3009). This causes the error:

```
Couldn't import RGB Image: 00003009
```

The result is that streaming shows only static/interference instead of the actual display content.

## Root Cause

The `surface_descriptor_to_egl_attribs()` function includes the display's DMA-BUF format modifier when creating the EGL image. Some displays (particularly USB-connected ones) report modifiers that the GPU's EGL implementation cannot handle, causing `eglCreateImage()` to fail.

## Fix

In `import_source()`, when the initial `eglCreateImage()` fails with `EGL_BAD_MATCH`, retry the import without the format modifier (`DRM_FORMAT_MOD_INVALID`). This uses a linear import that is universally supported by EGL implementations.

### Code Changes

- `src/platform/linux/graphics.cpp`: Modified `import_source()` to retry DMA-BUF import without modifiers when the initial attempt fails with `EGL_BAD_MATCH`
- Only the modifier is removed from the retry; all other surface parameters (fourcc, fds, pitches, offsets) are preserved

## Testing

- Arch Linux with Sunshine 2026.531.163415  
- GPU: Intel Arc (i9 Ultra, integrated)
- Display: USB-connected tablet/monitor reporting incompatible modifier
- Before fix: continuous `Couldn't import RGB Image: 00003009` errors, stream shows static
- After fix: DMA-BUF import succeeds with fallback, stream works correctly