### PR TITLE
fix(linux/cuda-gl): gl:[00000501] error regression

### DIFF
--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -504,7 +504,7 @@ namespace cuda {
      * @brief Configures shader parameters for the specified colorspace.
      */
     void apply_colorspace() override {
-      sws.apply_colorspace(colorspace);
+      sws.apply_colorspace(colorspace, is_yuv444);
     }
 
     file_t file;

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -856,7 +856,7 @@ namespace egl {
     return yuv444;
   }
 
-  void sws_t::apply_colorspace(const video::sunshine_colorspace_t &colorspace) {
+  void sws_t::apply_colorspace(const video::sunshine_colorspace_t &colorspace, bool is_yuv444) {
     auto color_p = video::color_vectors_from_colorspace(colorspace, true);
 
     std::string_view members[] {
@@ -869,9 +869,11 @@ namespace egl {
 
     color_matrix.update(members, sizeof(members) / sizeof(decltype(members[0])));
 
-    program[0].bind(color_matrix);
-    program[1].bind(color_matrix);
-    program[2].bind(color_matrix);
+    int planesCount = is_yuv444 ? 3 : 2;
+
+    for (int i = 0; i < planesCount; i++) {
+      program[i].bind(color_matrix);
+    }
   }
 
   int configure_sws_pipeline(sws_t &sws, const video::color_t *color_p, gl::tex_t &&tex, bool is_yuv444) {

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -375,7 +375,7 @@ namespace egl {
     void load_ram(platf::img_t &img);
     void load_vram(img_descriptor_t &img, int offset_x, int offset_y, int texture, bool is_yuv444);
 
-    void apply_colorspace(const video::sunshine_colorspace_t &colorspace);
+    void apply_colorspace(const video::sunshine_colorspace_t &colorspace, bool is_yuv444);
 
     // The first texture is the monitor image.
     // The second texture is the cursor image

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -381,7 +381,7 @@ namespace va {
     }
 
     void apply_colorspace() override {
-      sws.apply_colorspace(colorspace);
+      sws.apply_colorspace(colorspace, false);
     }
 
     va::display_t::pointer va_display;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
Mismatch count of programs in apply_color causing error gl:[00000501] (GL_INVALID_VALUE) in create_blank at start of probing NV12(yuv420) at encoders, that using egl (cuda-gl, vaapi)

```
[2026-06-18 09:02:50.313]: Info: Creating encoder [h264_nvenc]
[2026-06-18 09:02:50.313]: Info: Color coding: SDR (Rec. 601)
[2026-06-18 09:02:50.313]: Info: Color depth: 8-bit
[2026-06-18 09:02:50.313]: Info: Color range: JPEG
[2026-06-18 09:02:50.336]: Info: EGL: context priority set to HIGH
[2026-06-18 09:02:50.427]: Info: Streaming bitrate is 1000000
[2026-06-18 09:02:50.460]: Error: GL: /src/platform/linux/graphics.cpp:649: [00000501]
[2026-06-18 09:02:50.477]: Info: Creating encoder [hevc_nvenc]
[2026-06-18 09:02:50.477]: Info: Color coding: SDR (Rec. 601)
[2026-06-18 09:02:50.477]: Info: Color depth: 8-bit
[2026-06-18 09:02:50.477]: Info: Color range: JPEG
[2026-06-18 09:02:50.478]: Info: EGL: context priority set to HIGH
[2026-06-18 09:02:50.479]: Info: Streaming bitrate is 1000000
[2026-06-18 09:02:50.499]: Error: GL: /src/platform/linux/graphics.cpp:649: [00000501]
[2026-06-18 09:02:50.513]: Info: Creating encoder [av1_nvenc]
[2026-06-18 09:02:50.513]: Info: Color coding: SDR (Rec. 601)
[2026-06-18 09:02:50.513]: Info: Color depth: 8-bit
[2026-06-18 09:02:50.513]: Info: Color range: JPEG
[2026-06-18 09:02:50.514]: Info: EGL: context priority set to HIGH
[2026-06-18 09:02:50.515]: Info: Streaming bitrate is 1000000
[2026-06-18 09:02:50.536]: Error: GL: /src/platform/linux/graphics.cpp:649: [00000501]
[2026-06-18 09:02:50.551]: Info: Screencasting with KMS
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
