### PR TITLE
feat(linux/cuda-gl): Allow YUV4:2:0 HDR and YUV4:4:4 HDR on nvidia cards

### DIFF
--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -361,7 +361,9 @@ namespace cuda {
       auto hw_frames_ctx = (AVHWFramesContext *) hw_frames_ctx_buf->data;
 
       if (hw_frames_ctx->sw_format != AV_PIX_FMT_NV12 &&
-          hw_frames_ctx->sw_format != AV_PIX_FMT_YUV444P) {
+          hw_frames_ctx->sw_format != AV_PIX_FMT_YUV444P &&
+          hw_frames_ctx->sw_format != AV_PIX_FMT_P010LE &&
+          hw_frames_ctx->sw_format != AV_PIX_FMT_YUV444P16LE) {
         BOOST_LOG(error) << "cuda::gl_cuda_vram_t doesn't support any format other than AV_PIX_FMT_NV12 and AV_PIX_FMT_YUV444P"sv;
         return -1;
       }
@@ -374,7 +376,7 @@ namespace cuda {
       }
 
       sw_format = hw_frames_ctx->sw_format;
-      is_yuv444 = (sw_format == AV_PIX_FMT_YUV444P);
+      is_yuv444 = (sw_format == AV_PIX_FMT_YUV444P || sw_format == AV_PIX_FMT_YUV444P16LE);
 
       auto sws_opt = egl::sws_t::make(width, height, frame->width, frame->height, sw_format, is_yuv444);
       if (!sws_opt) {

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -364,7 +364,7 @@ namespace cuda {
           hw_frames_ctx->sw_format != AV_PIX_FMT_YUV444P &&
           hw_frames_ctx->sw_format != AV_PIX_FMT_P010LE &&
           hw_frames_ctx->sw_format != AV_PIX_FMT_YUV444P16LE) {
-        BOOST_LOG(error) << "cuda::gl_cuda_vram_t doesn't support any format other than AV_PIX_FMT_NV12 and AV_PIX_FMT_YUV444P"sv;
+        BOOST_LOG(error) << "cuda::gl_cuda_vram_t doesn't support any format other than AV_PIX_FMT_NV12, AV_PIX_FMT_P010LE, AV_PIX_FMT_YUV444P and AV_PIX_FMT_YUV444P16LE"sv;
         return -1;
       }
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
Allow HDR implementation on Nvidia cards linux, cuda-gl pipeline (wayland).
 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Resolves #5298


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
