### PR TITLE
fix(input): don't send ALT when right-alt is remapped to meta

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1274,10 +1274,10 @@ namespace config {
 
     // This config option will only be used by the UI
     // When editing in the config file itself, use "keybindings"
-    bool map_rightalt_to_win = false;
-    bool_f(vars, "key_rightalt_to_key_win", map_rightalt_to_win);
+    input.key_rightalt_to_key_win = false;
+    bool_f(vars, "key_rightalt_to_key_win", input.key_rightalt_to_key_win);
 
-    if (map_rightalt_to_win) {
+    if (input.key_rightalt_to_key_win) {
       input.keybindings.emplace(0xA5, 0x5B);
     }
 

--- a/src/config.h
+++ b/src/config.h
@@ -217,6 +217,7 @@ namespace config {
     bool ds5_inputtino_randomize_mac;
 
     bool keyboard;
+    bool key_rightalt_to_key_win;
     bool mouse;
     bool controller;
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -178,6 +178,9 @@ namespace input {
     // Keep track of alt+ctrl+shift key combo
     int shortcutFlags;
 
+    bool left_alt_pressed = false;
+    bool right_alt_pressed = false;
+
     std::vector<gamepad_t> gamepads;
     std::unique_ptr<platf::client_input_t> client_context;
 
@@ -760,17 +763,30 @@ namespace input {
     auto release = util::endian::little(packet->header.magic) == KEY_UP_EVENT_MAGIC;
     auto keyCode = packet->keyCode & 0x00FF;
 
+    if (keyCode == VKEY_LMENU) {
+      input->left_alt_pressed = !release;
+    } else if (keyCode == VKEY_RMENU) {
+      input->right_alt_pressed = !release;
+    }
+
+    // Right-alt maps to meta, so it must not also register as ALT
+    int modifiers = packet->modifiers;
+    if (config::input.key_rightalt_to_key_win &&
+        input->right_alt_pressed && !input->left_alt_pressed) {
+      modifiers &= ~MODIFIER_ALT;
+    }
+
     // Set synthetic modifier flags if the keyboard packet is requesting modifier
     // keys that are not current pressed.
     uint8_t synthetic_modifiers = 0;
     if (!release && !is_modifier(keyCode)) {
-      if (!(input->shortcutFlags & input_t::SHIFT) && (packet->modifiers & MODIFIER_SHIFT)) {
+      if (!(input->shortcutFlags & input_t::SHIFT) && (modifiers & MODIFIER_SHIFT)) {
         synthetic_modifiers |= MODIFIER_SHIFT;
       }
-      if (!(input->shortcutFlags & input_t::CTRL) && (packet->modifiers & MODIFIER_CTRL)) {
+      if (!(input->shortcutFlags & input_t::CTRL) && (modifiers & MODIFIER_CTRL)) {
         synthetic_modifiers |= MODIFIER_CTRL;
       }
-      if (!(input->shortcutFlags & input_t::ALT) && (packet->modifiers & MODIFIER_ALT)) {
+      if (!(input->shortcutFlags & input_t::ALT) && (modifiers & MODIFIER_ALT)) {
         synthetic_modifiers |= MODIFIER_ALT;
       }
     }


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

`key_rightalt_to_key_win` only remaps the keycode (`0xA5` -> `0x5B`), not the client's `modifiers` bitmask. On clients where right-alt reports as alt (e.g. macOS right-option), packets sent while it's held still carry `MODIFIER_ALT`, so the synthetic-modifier check injects a real ALT and the host gets `META + ALT + <key>` instead of `META + <key>` (e.g. `Super+1` binds fire as `Super+Alt+1`).

Clearing `MODIFIER_ALT` from that check when right-alt is the only alt held and the remap is active avoids this; a real left-alt still passes through.

Tested on Wayland/Hyprland with a macOS Moonlight client. With the remap on, `Super+<n>` binds reach the compositor as `Super+<n>`.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #4531

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
