### PR TITLE
fix(video): avoid UAF crashes during video reinit (reproducible on Vulkan)

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2389,17 +2389,6 @@ namespace video {
     }
 
     while (true) {
-      // Break out of the encoding loop if any of the following are true:
-      // a) The stream is ending
-      // b) Sunshine is quitting
-      // c) The capture side is waiting to reinit and we've encoded at least one frame
-      //
-      // If we have to reinit before we have received any captured frames, we will encode
-      // the blank dummy frame just to let Moonlight know that we're alive.
-      if (shutdown_event->peek() || !images->running() || (reinit_event.peek() && frame_nr > 1)) {
-        break;
-      }
-
       bool requested_idr_frame = false;
 
       while (invalidate_ref_frames_events->peek()) {
@@ -2430,6 +2419,20 @@ namespace video {
         } else if (!images->running()) {
           break;
         }
+      }
+
+      // Break out of the encoding loop if any of the following are true:
+      // a) The stream is ending
+      // b) Sunshine is quitting
+      // c) The capture side is waiting to reinit and we've encoded at least one frame
+      //
+      // If we have to reinit before we have received any captured frames, we will encode
+      // the blank dummy frame just to let Moonlight know that we're alive.
+      //
+      // Ensure that this check occurs as close as possible to the encode call to prevent packets
+      // in flight after encoder teardown.
+      if (shutdown_event->peek() || !images->running() || (reinit_event.peek() && frame_nr > 1)) {
+        break;
       }
 
       if (encode(frame_nr++, *session, packets, channel_data, frame_timestamp)) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
On Linux with the Vulkan encoder, reinit triggered by display switching or mode changes can crash Sunshine due to packets in flight after encoder teardown.

With extra debug logging, this pattern was occurring:

```
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.625]: Warning: [crash] encode_avcodec session=0x7fd8c89ad480 thread=140569594554048 avctx=0x7fd8c8c7f980 hw_frames=0x7fd8c883a940 FFmpeg frames ctx=0x7fd8c8a6b200
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.628]: Warning: PACKET DESTROY 0x7fd8c8b76d00
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.628]: Warning: [crash] SESSION DESTROY START 0x7fd8c89ad480
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.628]: Warning: PACKET DESTROY 0x7fd8e8bfd490
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.628]: Warning: [crash] Calling avcodec_ctx.reset()
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.628]: Warning: [crash] SESSION DESTROY AFTER RESET 0x7fd8c89ad480
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.628]: Warning: [crash] Calling device.reset()
    Jun 26 23:57:21 archlinux sunshine[263621]: [2026-06-26 23:57:21.629]: Warning: PACKET DESTROY 0x7fd8c882de40
    Jun 26 23:57:21 archlinux kernel: rtsp::handler[263877]: segfault at 7fd8a0af7e20 ip 00007fd8a0af7e20 sp 00007fd8ebffd638 error 14 likely on CPU 11 (core 3, socket 0)
    Jun 26 23:57:21 archlinux kernel: Code: Unable to access opcode bytes at 0x7fd8a0af7df6.
    Jun 26 23:57:21 archlinux systemd-coredump[263973]: Process 263621 (sunshine) of user 1000 terminated abnormally with signal 11/SEGV, processing...
    Jun 26 23:57:21 archlinux systemd[1]: Started Process Core Dump (PID 263973/UID 0).
    Jun 26 23:57:21 archlinux systemd[1]: Started Pass systemd-coredump journal entries to relevant user for potential DrKonqi handling.
    Jun 26 23:57:22 archlinux systemd-coredump[263974]: [🡕] Process 263621 (sunshine) of user 1000 dumped core.
    
                                                        Stack trace of thread 263877:
                                                        #0  0x00007fd8a0af7e20 n/a (libvulkan_radeon.so + 0xf7e20)
                                                        #1  0x00007fd8a0bcd8cf n/a (libvulkan_radeon.so + 0x1cd8cf)
                                                        #2  0x00005636d70c0ea4 ff_vk_unmap_buffers (sunshine + 0x45dea4)
                                                        #3  0x00005636d70c100b ff_vk_unmap_buffer (sunshine + 0x45e00b)
                                                        #4  0x00005636d70c102d free_data_buf (sunshine + 0x45e02d)
                                                        #5  0x00005636d7198a17 buffer_pool_flush (sunshine + 0x535a17)
                                                        #6  0x00005636d7198c26 buffer_replace (sunshine + 0x535c26)
                                                        #7  0x00005636d704596e av_packet_unref (sunshine + 0x3e296e)
                                                        #8  0x00005636d70459da av_packet_free (sunshine + 0x3e29da)
                                                        #9  0x00005636d6eb51a8 _ZNSt10unique_ptrIN5video12packet_raw_tESt14default_deleteIS1_EED2Ev.lto_priv.0 (sunshine + 0x2521a8)
                                                        #10 0x00005636d6ea6b69 _ZN6stream20videoBroadcastThreadERN5boost4asio21basic_datagram_socketINS1_2ip3udpENS1_15any_io_executorEEE (sunshine + 0x243b69)
                                                        #11 0x00005636d7f4f749 execute_native_thread_routine (sunshine + 0x12ec749)
                                                        #12 0x00007fd938a97739 n/a (libc.so.6 + 0x97739)
                                                        #13 0x00007fd938b1bedc n/a (libc.so.6 + 0x11bedc)
```

Since an in-flight packet's `packet_raw_avcodec` destructor was calling `av_packet_free(..)` after `device.reset()`, a UAF-type SEGFAULT would manifest. Moving the breakout check of the encoding loop to check immediately before `encode()` resolves the issue on my system via repeated stress testing. It may be possible that in-flight packets can still be active, which may necessitate future refcounting of packets in flight and waiting for it to drop to zero before breaking out of the encode loop, but for now, this minimal change fully resolves the issue on my system.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
