### PR TITLE
fix(linux/pipewire): avoid memory leaks

### DIFF
--- a/src/platform/linux/kwingrab.cpp
+++ b/src/platform/linux/kwingrab.cpp
@@ -248,7 +248,7 @@ namespace kwin {
    * @brief KWin screencast output name and geometry.
    */
   struct output_parameter_t {
-    std::string name = "";  ///< KWin output name.
+    std::string name;  ///< KWin output name.
     int width = 0;  ///< Output width in pixels.
     int height = 0;  ///< Output height in pixels.
     int pos_x = 0;  ///< Output X position in the compositor layout.
@@ -272,6 +272,7 @@ namespace kwin {
     screencast_t &operator=(screencast_t &&) = delete;  // Do not allow to copying
 
     ~screencast_t() {
+      // Release KDE screencast wayland extensions and reset pointers
       if (kde_screencast_stream_v1_) {
         zkde_screencast_stream_unstable_v1_close(kde_screencast_stream_v1_);
         kde_screencast_stream_v1_ = nullptr;
@@ -280,23 +281,30 @@ namespace kwin {
         zkde_screencast_unstable_v1_destroy(kde_screencast_v1_);
         kde_screencast_v1_ = nullptr;
       }
-
       if (kde_output_order) {
         kde_output_order_v1_destroy(kde_output_order);
         kde_output_order = nullptr;
       }
 
+      // Clear output order list
+      output_order.clear();
+      // Clear current output parameters
+      out_params.reset();
+      out_params = nullptr;
+
       // wl_output is owned by the registry, released on disconnect
-      for (const auto &out : outputs | std::views::keys) {
-        wl_output_destroy(out);
+      // also cleanup associated output parameters and clear output list when done
+      for (auto &[output, params] : outputs) {
+        wl_output_destroy(output);
+        params.reset();
       }
       outputs.clear();
 
+      // Release wayland registry, display and reset pointers
       if (wl_registry) {
         wl_registry_destroy(wl_registry);
         wl_registry = nullptr;
       }
-
       if (wl_display) {
         wl_display_disconnect(wl_display);
         wl_display = nullptr;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -136,34 +136,44 @@ namespace pipewire {
 
     ~pipewire_t() {
       BOOST_LOG(debug) << "[pipewire] Destroying pipewire_t"sv;
-      try {
-        cleanup_stream();
-      } catch (const std::exception &e) {
-        BOOST_LOG(error) << "[pipewire] Standard exception caught in ~pipewire_t cleanup_stream: "sv << e.what();
-      } catch (...) {
-        BOOST_LOG(error) << "[pipewire] Unknown exception caught in ~pipewire_t cleanup_stream"sv;
-      }
-
       pw_thread_loop_lock(loop);
 
+      // Lock the frame mutex to stop fill_img
+      BOOST_LOG(debug) << "[pipewire] Stop fill_img"sv;
+      {
+        std::scoped_lock lock(stream_data.frame_mutex);
+        stream_data.frame_ready = false;
+        stream_data.current_buffer = nullptr;
+      }
+
+      // Release pipewire stream
+      if (stream_data.stream) {
+        BOOST_LOG(debug) << "[pipewire] Disconnect stream"sv;
+        pw_stream_disconnect(stream_data.stream);
+        BOOST_LOG(debug) << "[pipewire] Destroy stream"sv;
+        pw_stream_destroy(stream_data.stream);
+        stream_data.stream = nullptr;
+      }
+      // Release pipewire core
       if (core) {
         BOOST_LOG(debug) << "[pipewire] Disconnect PW core"sv;
         pw_core_disconnect(core);
         core = nullptr;
       }
+      // Release pipewire context
       if (context) {
         BOOST_LOG(debug) << "[pipewire] Destroy PW context"sv;
         pw_context_destroy(context);
         context = nullptr;
       }
-
-      pw_thread_loop_unlock(loop);
-
+      // Release pipewire file descriptor
       if (fd >= 0) {
         BOOST_LOG(debug) << "[pipewire] Close pipewire_fd"sv;
         close(fd);
       }
+      // Release pipewire thread loop
       BOOST_LOG(debug) << "[pipewire] Stop PW thread loop"sv;
+      pw_thread_loop_unlock(loop);
       pw_thread_loop_stop(loop);
       BOOST_LOG(debug) << "[pipewire] Destroy PW thread loop"sv;
       pw_thread_loop_destroy(loop);
@@ -243,34 +253,6 @@ namespace pipewire {
 
       pw_thread_loop_unlock(loop);
       return 0;
-    }
-
-    /**
-     * @brief Release the active PipeWire stream and listener.
-     */
-    void cleanup_stream() {
-      BOOST_LOG(debug) << "[pipewire] Cleaning up stream"sv;
-      if (loop && stream_data.stream) {
-        pw_thread_loop_lock(loop);
-
-        // 1. Lock the frame mutex to stop fill_img
-        BOOST_LOG(debug) << "[pipewire] Stop fill_img"sv;
-        {
-          std::scoped_lock lock(stream_data.frame_mutex);
-          stream_data.frame_ready = false;
-          stream_data.current_buffer = nullptr;
-        }
-
-        if (stream_data.stream) {
-          BOOST_LOG(debug) << "[pipewire] Disconnect stream"sv;
-          pw_stream_disconnect(stream_data.stream);
-          BOOST_LOG(debug) << "[pipewire] Destroy stream"sv;
-          pw_stream_destroy(stream_data.stream);
-          stream_data.stream = nullptr;
-        }
-
-        pw_thread_loop_unlock(loop);
-      }
     }
 
     /**

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -124,6 +124,18 @@ namespace pipewire {
   };
 
   /**
+   * @brief Pipewire image assembled for encoding.
+   */
+  struct img_descriptor_t: public egl::img_descriptor_t {
+    ~img_descriptor_t() override {
+      if (data) {
+        delete[] data;
+        data = nullptr;
+      }
+    }
+  };
+
+  /**
    * @brief PipeWire core, context, and stream setup used for screencast capture.
    */
   class pipewire_t {
@@ -916,7 +928,7 @@ namespace pipewire {
      */
     std::shared_ptr<platf::img_t> alloc_img() override {
       // Note: this img_t type is also used for memory buffers
-      auto img = std::make_shared<egl::img_descriptor_t>();
+      auto img = std::make_shared<img_descriptor_t>();
 
       img->width = width;
       img->height = height;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -1049,12 +1049,7 @@ namespace pipewire {
      * @return Capture status reported to the streaming pipeline.
      */
     int dummy_img(platf::img_t *img) override {
-      if (!img) {
-        return -1;
-      }
-
-      img->data = new std::uint8_t[img->height * img->row_pitch];
-      std::fill_n(img->data, img->height * img->row_pitch, 0);
+      // Empty images are recognized as dummies by the zero sequence number
       return 0;
     }
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
In #5346 a memory leak in pipewire-based capture methods (portalgrab, kwingrab) was identified. 

This PR is a fixes (potential) causes in pipewire-based capture by:
- Changing `dummy_img()` to just return 0 without allocating memory as that is enough to mark a dummy image (same logic as kmsgrab/wlgrab)
- Override the destructor of the used `egl::img_descriptor_t` to free allocated memory for the pipewire specific `alloc_image()` override by using a new subclass (also like kmsgrab/wlgrab).
- Explicitly release any memory resources from `kwingrab` by calling `reset()` on any created shared_ptr instances in screencast_t and `clear()` on used lists/maps in screencast_t during destruction.
- Cleanup `pipewire_t` destruction sequence and roll `cleanup_stream` in as is is never used outside of it.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
