### PR TITLE
build(linux): avoid network for appstream cli & add missing deps

### DIFF
--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -31,6 +31,9 @@ fi
 depends=(
   'avahi'
   'curl'
+  'gtk3'
+  'hicolor-icon-theme'
+  'libayatana-appindicator'
   'libcap'
   'libdrm'
   'libevdev'
@@ -168,9 +171,13 @@ build() {
       _cmake_options+=(-DBUILD_TESTS=OFF)
     fi
 
+    if [[ -z "${GITHUB_ACTIONS}" ]]; then
+	    _appstreamcli_arguments=(--no-net)
+    fi
+
     cmake "${_cmake_options[@]}"
 
-    appstreamcli validate "build/dev.lizardbyte.app.Sunshine.metainfo.xml"
+    appstreamcli validate "${_appstreamcli_arguments[@]}" "build/dev.lizardbyte.app.Sunshine.metainfo.xml"
     appstream-util validate "build/dev.lizardbyte.app.Sunshine.metainfo.xml"
     desktop-file-validate "build/dev.lizardbyte.app.Sunshine.desktop"
     desktop-file-validate "build/dev.lizardbyte.app.Sunshine.terminal.desktop"


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
As of right now, the PKGBUILD fails to build on Arch Linux due to AppStream throwing warnings when validating a file. Therefore, I have created a pull request to add `--no-net` to `appstreamcli validate`. Furthermore, when checking the ensuing package with `namcap` (a tool used by Arch maintainers), the package was missing `gtk3`, `hicolor-icon-theme`, and `libayatana-appindicator`. This is with building sunshine against the latest pre-release (2026.619.155209).

I believe appstream fails to validate due to these pages being behind Cloudflare, but that's just my guess.

Here is CLI output of the build failing without this commit:
```
W: dev.lizardbyte.app.Sunshine:20: url-not-reachable
     https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2troubleshooting.html -
     Unexpected status code: 429
W: dev.lizardbyte.app.Sunshine:21: url-not-reachable
     https://docs.lizardbyte.dev/projects/sunshine - Unexpected status code: 429
I: dev.lizardbyte.app.Sunshine:26: description-first-word-not-capitalized

✘ Validation failed: warnings: 2, infos: 1, pedantic: 1
==> ERROR: A failure occurred in build().
    Aborting...
hurricane@TheCloutPC ~/sunshine/packaging/linux/Arch $ 
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [X] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [ ] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
