### PR TITLE
feat(apps): add per-app output_name stream-audio override fix .desktop for artix with openrc

### DIFF
--- a/cmake/prep/init.cmake
+++ b/cmake/prep/init.cmake
@@ -12,6 +12,14 @@ elseif (UNIX)
         set(SUNSHINE_EXECUTABLE_PATH "sunshine")
     endif()
 
+    # Auto-detect init system for desktop file
+    find_package(Systemd QUIET)
+    if(SYSTEMD_FOUND)
+        set(SUNSHINE_DESKTOP_EXEC "/usr/bin/env systemctl start --u app-${PROJECT_FQDN}")
+    else()
+        set(SUNSHINE_DESKTOP_EXEC "${CMAKE_INSTALL_FULL_BINDIR}/${SUNSHINE_EXECUTABLE_PATH}")
+    endif()
+
     if(SUNSHINE_BUILD_FLATPAK)
         set(SUNSHINE_SERVICE_START_COMMAND "ExecStart=flatpak run --command=sunshine ${PROJECT_FQDN}")
         set(SUNSHINE_SERVICE_STOP_COMMAND "ExecStop=flatpak kill ${PROJECT_FQDN}")

--- a/packaging/linux/dev.lizardbyte.app.Sunshine.desktop
+++ b/packaging/linux/dev.lizardbyte.app.Sunshine.desktop
@@ -2,7 +2,7 @@
 Actions=RunInTerminal;
 Categories=RemoteAccess;Network;
 Comment=@PROJECT_DESCRIPTION@
-Exec=/usr/bin/env systemctl start --u app-@PROJECT_FQDN@
+Exec=@SUNSHINE_DESKTOP_EXEC@
 Icon=@SUNSHINE_DESKTOP_ICON@
 StartupWMClass=@PROJECT_FQDN@
 Keywords=gamestream;stream;moonlight;remote play;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1037,6 +1037,14 @@ namespace nvhttp {
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     auto launch_session = make_launch_session(host_audio, args);
 
+    // Per-app output_name override
+    for (auto &app : proc::proc.get_apps()) {
+      if (app.id == std::to_string(appid) && !app.output_name.empty()) {
+        config::video.output_name = app.output_name;
+        break;
+      }
+    }
+
     if (rtsp_stream::session_count() == 0) {
       // The display should be restored in case something fails as there are no other sessions.
       revert_display_configuration = true;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -178,8 +178,8 @@ namespace nvhttp {
   std::string last_verified_client_cert;  ///< Last client certificate accepted by the TLS verify callback.  // NOSONAR(cpp:S5421) - intentionally mutable global
 
   // Saved originals for per-app config overrides
-  std::string saved_output_name;  ///< Original config::video.output_name before per-app override.
-  bool saved_stream_audio {true};  ///< Original config::audio.stream before per-app override.
+  std::string saved_output_name;  ///< Original config::video.output_name before per-app override.  // NOSONAR(cpp:S5421) - intentionally mutable global
+  bool saved_stream_audio {true};  ///< Original config::audio.stream before per-app override.  // NOSONAR(cpp:S5421) - intentionally mutable global
 
   /**
    * @brief Case-insensitive map used for HTTP headers and query parameters.

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -177,6 +177,10 @@ namespace nvhttp {
   // Set by TLS verify callback, read by launch/resume handler (single-threaded HTTPS server)
   std::string last_verified_client_cert;  ///< Last client certificate accepted by the TLS verify callback.  // NOSONAR(cpp:S5421) - intentionally mutable global
 
+  // Saved originals for per-app config overrides
+  std::string saved_output_name;  ///< Original config::video.output_name before per-app override.
+  bool saved_stream_audio {true};  ///< Original config::audio.stream before per-app override.
+
   /**
    * @brief Case-insensitive map used for HTTP headers and query parameters.
    */
@@ -1037,10 +1041,18 @@ namespace nvhttp {
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     auto launch_session = make_launch_session(host_audio, args);
 
-    // Per-app output_name override
+    // Save originals before per-app config overrides
+    saved_output_name = config::video.output_name;
+    saved_stream_audio = config::audio.stream;
+
     for (auto &app : proc::proc.get_apps()) {
-      if (app.id == std::to_string(appid) && !app.output_name.empty()) {
-        config::video.output_name = app.output_name;
+      if (app.id == std::to_string(appid)) {
+        if (!app.output_name.empty()) {
+          config::video.output_name = app.output_name;
+        }
+        if (app.stream_audio.has_value()) {
+          config::audio.stream = app.stream_audio.value();
+        }
         break;
       }
     }
@@ -1234,6 +1246,10 @@ namespace nvhttp {
 
     // The config needs to be reverted regardless of whether "proc::proc.terminate()" was called or not.
     display_device::revert_configuration();
+
+    // Restore per-app config overrides to global defaults
+    config::video.output_name = saved_output_name;
+    config::audio.stream = saved_stream_audio;
   }
 
   /**

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -690,6 +690,7 @@ namespace proc {
         auto name = parse_env_val(this_env, app_node.get<std::string>("name"s));
         auto cmd = app_node.get_optional<std::string>("cmd"s);
         auto image_path = app_node.get_optional<std::string>("image-path"s);
+        auto output_name = app_node.get_optional<std::string>("output-name"s);
         auto working_dir = app_node.get_optional<std::string>("working-dir"s);
         auto elevated = app_node.get_optional<bool>("elevated"s);
         auto auto_detach = app_node.get_optional<bool>("auto-detach"s);
@@ -758,6 +759,10 @@ namespace proc {
 
         if (image_path) {
           ctx.image_path = parse_env_val(this_env, *image_path);
+        }
+
+        if (output_name) {
+          ctx.output_name = parse_env_val(this_env, *output_name);
         }
 
         ctx.elevated = elevated.value_or(false);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -696,6 +696,7 @@ namespace proc {
         auto auto_detach = app_node.get_optional<bool>("auto-detach"s);
         auto wait_all = app_node.get_optional<bool>("wait-all"s);
         auto exit_timeout = app_node.get_optional<int>("exit-timeout"s);
+        auto stream_audio = app_node.get_optional<bool>("stream-audio"s);
 
         std::vector<proc::cmd_t> prep_cmds;
         if (!exclude_global_prep.value_or(false)) {
@@ -763,6 +764,10 @@ namespace proc {
 
         if (output_name) {
           ctx.output_name = parse_env_val(this_env, *output_name);
+        }
+
+        if (stream_audio) {
+          ctx.stream_audio = *stream_audio;
         }
 
         ctx.elevated = elevated.value_or(false);

--- a/src/process.h
+++ b/src/process.h
@@ -76,6 +76,7 @@ namespace proc {
     std::string working_dir;  ///< Working dir.
     std::string output;  ///< Captured output from the launched process.
     std::string output_name;  ///< Display output name override for this app.
+    std::optional<bool> stream_audio;  ///< Audio streaming override for this app (std::nullopt = use global config).
     std::string image_path;  ///< Image path.
     std::string id;  ///< Stable identifier for the configured application.
     bool elevated;  ///< Whether the process should be launched elevated.

--- a/src/process.h
+++ b/src/process.h
@@ -75,6 +75,7 @@ namespace proc {
     std::string cmd;  ///< Command line used to launch the application.
     std::string working_dir;  ///< Working dir.
     std::string output;  ///< Captured output from the launched process.
+    std::string output_name;  ///< Display output name override for this app.
     std::string image_path;  ///< Image path.
     std::string id;  ///< Stable identifier for the configured application.
     bool elevated;  ///< Whether the process should be launched elevated.

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -319,6 +319,14 @@
               </div>
               <div id="appImagePathHelp" class="form-text">{{ $t('apps.image_desc') }}</div>
             </div>
+            <!-- output-name -->
+            <div class="mb-3">
+              <label for="appOutputName" class="form-label">{{ $t('apps.output_display') }}</label>
+              <input type="text" class="form-control monospace" id="appOutputName"
+                aria-describedby="appOutputNameHelp" v-model="editForm['output-name']"
+                placeholder="e.g. virtmon" />
+              <div id="appOutputNameHelp" class="form-text">{{ $t('apps.output_display_desc') }}</div>
+            </div>
             <div class="env-hint alert alert-info">
               <div class="form-text">
                 <h4>{{ $t('apps.env_vars_about') }}</h4>
@@ -739,7 +747,8 @@
           "exit-timeout": 5,
           "prep-cmd": [],
           detached: [],
-          "image-path": ""
+          "image-path": "",
+          "output-name": ""
         };
         this.openEditModal();
       },

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -327,6 +327,14 @@
                 placeholder="e.g. virtmon" />
               <div id="appOutputNameHelp" class="form-text">{{ $t('apps.output_display_desc') }}</div>
             </div>
+            <!-- stream-audio -->
+            <Checkbox class="mb-3"
+                      id="streamAudio"
+                      label="apps.stream_audio"
+                      desc="apps.stream_audio_desc"
+                      v-model="editForm['stream-audio']"
+                      default="true"
+            ></Checkbox>
             <div class="env-hint alert alert-info">
               <div class="form-text">
                 <h4>{{ $t('apps.env_vars_about') }}</h4>
@@ -748,7 +756,8 @@
           "prep-cmd": [],
           detached: [],
           "image-path": "",
-          "output-name": ""
+          "output-name": "",
+          "stream-audio": true
         };
         this.openEditModal();
       },
@@ -772,6 +781,9 @@
         }
         if (this.editForm["exit-timeout"] === undefined) {
           this.editForm["exit-timeout"] = 5;
+        }
+        if (this.editForm["stream-audio"] === undefined) {
+          this.editForm["stream-audio"] = true;
         }
         this.openEditModal();
       },

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -97,6 +97,8 @@
     "output_name": "Output",
     "run_as_desc": "This can be necessary for some applications that require administrator permissions to run properly.",
     "search_placeholder": "Search applications...",
+    "stream_audio": "Stream Audio",
+    "stream_audio_desc": "Override audio streaming for this application. When unchecked, audio will not be streamed to the client.",
     "searching_covers": "Searching for covers...",
     "sort_ascending": "Ascending",
     "sort_by_name": "Sort by Name",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -92,6 +92,8 @@
     "no_covers_found": "No covers found",
     "no_search_results": "No applications match your search",
     "output_desc": "The file where the output of the command is stored, if it is not specified, the output is ignored",
+    "output_display": "Display Id",
+    "output_display_desc": "Override the display output for this application. Leave empty to use the global setting.",
     "output_name": "Output",
     "run_as_desc": "This can be necessary for some applications that require administrator permissions to run properly.",
     "search_placeholder": "Search applications...",


### PR DESCRIPTION
Allow each application to specify its own output-name to override the global display capture setting. This enables users to stream different displays per application without restarting Sunshine.
Each application can also override audio streaming with an optional stream-audio checkbox — useful for headless or second-monitor setups where host audio should be muted.
Both fields are optional — when left empty/unset, the global config is used as before.

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
### Per-app Display Id (output-name)
An optional Display Id (output-name) field per application, letting each app capture a different display without restarting Sunshine or running multiple instances.

### Per-app audio streaming (stream-audio)
A new Stream Audio checkbox per application, allowing per-app control of audio streaming. When unchecked, no audio will be streamed for that app.

### Desktop file init auto-detect
The `.desktop` file now auto-detects whether systemd is available. On systems without systemd (e.g. Artix with OpenRC), `Exec` points directly to the sunshine binary instead of `systemctl start ...`.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
<img width="1084" height="1263" alt="image" src="https://github.com/user-attachments/assets/9162a355-627b-4610-8ca9-46e72f3fa6d1" />

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
