### PR TITLE
fix(audio/win): correct WASAPI capture event-wait timeout units (REFERENCE_TIME is 100ns)

### DIFF
--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -663,7 +663,14 @@ namespace platf::audio {
 
       REFERENCE_TIME default_latency;
       audio_client->GetDevicePeriod(&default_latency, nullptr);
-      default_latency_ms = default_latency / 1000;
+      // GetDevicePeriod returns REFERENCE_TIME (100ns units), i.e. 10000 units
+      // per millisecond. Dividing by 1000 yielded tenths of a millisecond, so
+      // the fallback wait during capture silence (and thus default-device-change
+      // / reinit detection) ran ~10x longer than intended. Clamp to a small floor.
+      default_latency_ms = default_latency / 10000;
+      if (default_latency_ms < 3) {
+        default_latency_ms = 3;
+      }
       continuous_audio = continuous;
 
       std::uint32_t frames;
@@ -830,7 +837,7 @@ namespace platf::audio {
     audio_notification_t endpt_notification;  ///< Endpoint notification callback registered with Windows.
     std::optional<std::function<void()>> default_endpt_changed_cb;  ///< Callback invoked when the default endpoint changes.
 
-    REFERENCE_TIME default_latency_ms;  ///< WASAPI default device period used as capture latency.
+    DWORD default_latency_ms;  ///< WASAPI default device period (ms) used as the capture event-wait timeout.
 
     util::buffer_t<float> sample_buf;  ///< Floating-point sample buffer filled from WASAPI packets.
     float *sample_buf_pos;  ///< Current write position in `sample_buf`.


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

`GetDevicePeriod()` returns a `REFERENCE_TIME`, which is measured in 100 ns units (10000 units per millisecond). In `src/platform/windows/audio.cpp` the capture latency is computed as:

```cpp
default_latency_ms = default_latency / 1000;  // -> tenths of a millisecond
```

Dividing by `1000` instead of `10000` yields **tenths of a millisecond**, not milliseconds. That value is then passed straight to `WaitForSingleObjectEx()` as a millisecond timeout:

```cpp
status = WaitForSingleObjectEx(audio_event.get(), default_latency_ms, FALSE);
```

So on a typical 10 ms device period the fallback wait during capture silence runs ~100 ms instead of ~10 ms — about 10x too long. This wait also gates how quickly the capture loop notices a default-endpoint change / needs to reinit, so recovery from a device switch during silence is delayed by the same factor.

**Fix**

- Divide by `10000` (correct 100ns→ms conversion), with a small 3 ms floor.
- Store `default_latency_ms` as `DWORD` to match its only consumer, `WaitForSingleObjectEx` (whose timeout parameter is a `DWORD`).

There is no behavioural change while audio is actively flowing — the event is signalled well before the timeout, so the timeout only matters during silence. The fix tightens silence-period reinit latency and removes the unit mismatch. The floor prevents a 0 ms busy-wait on sub-100µs-period devices.

This is a single-file, three-line change with no new includes. I don't have a repro harness for the device-switch-during-silence path, so I've kept the change minimal and conservative.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A — not UI-related.

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
