### PR TITLE
add non-VK Undo/Cut/Copy/Paste keycodes

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -758,7 +758,13 @@ namespace input {
     }
 
     auto release = util::endian::little(packet->header.magic) == KEY_UP_EVENT_MAGIC;
-    auto keyCode = packet->keyCode & 0x00FF;
+    auto keyCode = util::endian::little(packet->keyCode);
+
+    // Preserve full-width keycodes for Sunshine non-normalized keyboard events.
+    // Normalized keycodes are legacy VK values and only use the low 8 bits.
+    if (!(packet->flags & SS_KBE_FLAG_NON_NORMALIZED)) {
+      keyCode &= 0x00FF;
+    }
 
     // Set synthetic modifier flags if the keyboard packet is requesting modifier
     // keys that are not current pressed.

--- a/src/platform/linux/input/inputtino_keyboard.cpp
+++ b/src/platform/linux/input/inputtino_keyboard.cpp
@@ -157,7 +157,12 @@ namespace platf::keyboard {
     {KEY_BACKSLASH, 0xDC},
     {KEY_RIGHTBRACE, 0xDD},
     {KEY_APOSTROPHE, 0xDE},
-    {KEY_102ND, 0xE2}
+    {KEY_102ND, 0xE2},
+    // Sunshine extension keycodes (sent with SS_KBE_FLAG_NON_NORMALIZED)
+    {KEY_UNDO, 0x100},
+    {KEY_CUT, 0x101},
+    {KEY_COPY, 0x102},
+    {KEY_PASTE, 0x103}
   };
 
   void update(input_raw_t *raw, uint16_t modcode, bool release, uint8_t flags) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Add support for non-VK Undo/Cut/Copy/Paste keycodes (keyboard HID spec usage IDs 0x7A-0x7D). In order to do this I added some ad-hoc/bespoke keycodes outside of the VK range in inputtino.

depends on https://github.com/games-on-whales/inputtino/pull/46

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
n/a

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
