### PR TITLE
fix(linux): avoid memory leak from unnecessary encoder re-probing

### DIFF
--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1247,7 +1247,15 @@ namespace platf {
    * @return Always `true` because Linux GPU changes are not tracked by this backend.
    */
   bool needs_encoder_reenumeration() {
-    // We don't track GPU state, so we will always reenumerate. Fortunately, it is fast on Linux.
+    // Only re-probe if the GPU render device changed (hotplug, driver reload).
+    // Full re-probing on every reconnect leaks ~20 MB due to FFmpeg CBS
+    // allocations during HEVC/AV1 codec validation.
+    static std::string last_render_device;
+    auto current = platf::resolve_render_device();
+    if (current == last_render_device) {
+      return false;
+    }
+    last_render_device = current;
     return true;
   }
 


### PR DESCRIPTION
## Description
On Linux, `needs_encoder_reenumeration()` unconditionally returns `true`, causing full encoder re-probing (h264, hevc, av1) on every client reconnect. Each probe cycle triggers FFmpeg CBS (Coded Bitstream) operations that allocate ~7.9 MB per HEVC VPS clone for validation. With 2 HEVC + 2 AV1 probes per reconnect, this leaks ~20 MB per cycle that is never fully reclaimed.

Fix by caching the render device path and only returning `true` when the GPU actually changes (hotplug, driver reload). This reduces per-reconnect memory growth from ~20 MB to <1 MB.

### Measured results (AMD RX 9070 XT, RADV, Vulkan encoder):
| Reconnect | Before | After |
|-----------|--------|-------|
| 1st | +18 MB | +0.6 MB |
| 2nd | +18 MB | +0.4 MB |
| 3rd | +18 MB | +0.4 MB |
| 4th | +18 MB | +0.4 MB |
| 5th | +18 MB | +0.4 MB |

The residual ~0.4-0.6 MB is malloc arena fragmentation (confirmed reclaimable via `malloc_trim`).

### Root cause analysis
- `needs_encoder_reenumeration()` always returned `true` on Linux
- `probe_encoders()` is called from `nvhttp.cpp` on every launch/resume
- Each probe creates codec contexts for h264/hevc/av1, triggering CBS `cbs_h265_replace_vps` which clones `H265RawVPS` (7.9 MB struct) via `av_refstruct`
- Confirmed via heaptrack: 43 MB of CBS allocations marked as leaked at process exit, growing with each reconnect cycle

### Issues Fixed or Closed

### Screenshot

## Type of Change
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [x] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change

## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
