### PR TITLE
fix(linux): fallback to wl_output metadata when xdg_output is unavailable

### DIFF
--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -167,11 +167,23 @@ namespace wl {
     viewport.height = height;
 
     BOOST_LOG(info) << "[wayland] Resolution: "sv << width << 'x' << height;
+
+    // Assign these only if xdg_output hasn't done so already
+    if (viewport.logical_width <= 0) {
+        viewport.logical_width = viewport.width;
+    }
+    if (viewport.logical_height <= 0) {
+        viewport.logical_height = viewport.height;
+    }
   }
 
   void monitor_t::listen(zxdg_output_manager_v1 *output_manager) {
     auto xdg_output = zxdg_output_manager_v1_get_xdg_output(output_manager, output);
     zxdg_output_v1_add_listener(xdg_output, &xdg_listener, this);
+    wl_output_add_listener(output, &wl_listener, this);
+  }
+
+  void monitor_t::listen_fallback() {
     wl_output_add_listener(output, &wl_listener, this);
   }
 
@@ -568,13 +580,15 @@ namespace wl {
 
     display.roundtrip();
 
-    if (!interface[interface_t::XDG_OUTPUT]) {
-      BOOST_LOG(error) << "[wayland] Missing Wayland wire XDG_OUTPUT"sv;
-      return {};
-    }
-
-    for (auto &monitor : interface.monitors) {
-      monitor->listen(interface.output_manager);
+    if (interface[interface_t::XDG_OUTPUT]) {
+      for (auto &monitor : interface.monitors) {
+        monitor->listen(interface.output_manager);
+      }
+    } else {
+      BOOST_LOG(warning) << "[wayland] Missing Wayland wire XDG_OUTPUT, falling back to wl_output only"sv;
+      for (auto &monitor : interface.monitors) {
+        monitor->listen_fallback();
+      }
     }
 
     display.roundtrip();

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -171,11 +171,23 @@ namespace wl {
 
     viewport.width = width;
     viewport.height = height;
+
+    // Assign these only if xdg_output hasn't done so already
+    if (viewport.logical_width <= 0) {
+      viewport.logical_width = viewport.width;
+    }
+    if (viewport.logical_height <= 0) {
+      viewport.logical_height = viewport.height;
+    }
   }
 
   void monitor_t::listen(zxdg_output_manager_v1 *output_manager) {
     auto xdg_output = zxdg_output_manager_v1_get_xdg_output(output_manager, output);
     zxdg_output_v1_add_listener(xdg_output, &xdg_listener, this);
+    wl_output_add_listener(output, &wl_listener, this);
+  }
+
+  void monitor_t::listen_fallback() {
     wl_output_add_listener(output, &wl_listener, this);
   }
 
@@ -572,13 +584,15 @@ namespace wl {
 
     display.roundtrip();
 
-    if (!interface[interface_t::XDG_OUTPUT]) {
-      BOOST_LOG(error) << "[wayland] Missing Wayland wire XDG_OUTPUT"sv;
-      return {};
-    }
-
-    for (auto &monitor : interface.monitors) {
-      monitor->listen(interface.output_manager);
+    if (interface[interface_t::XDG_OUTPUT]) {
+      for (auto &monitor : interface.monitors) {
+        monitor->listen(interface.output_manager);
+      }
+    } else {
+      BOOST_LOG(warning) << "[wayland] Missing Wayland wire XDG_OUTPUT, falling back to wl_output only"sv;
+      for (auto &monitor : interface.monitors) {
+        monitor->listen_fallback();
+      }
     }
 
     display.roundtrip();

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -217,6 +217,12 @@ namespace wl {
      * @param output_manager xdg-output manager used to query logical monitor metadata.
      */
     void listen(zxdg_output_manager_v1 *output_manager);
+
+    /**
+     * @brief Attach wl-output listeners for this monitor, without using xdg-output.
+     */
+    void listen_fallback();
+
     /**
      * @brief Store the xdg-output logical monitor name.
      *


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
For compositors that do not have xdg_output, we can fall back to using wl_output by itself. xdg_output is generally only useful for fractional scaling, which a basic compositor won't be doing without this protocol.

Tested against latest gamescope and KDE Plasma 6.7, using portalgrab for both scenarios.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #5406


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [ ] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
