### PR TITLE
fix(wayland): export all DMA-BUF planes for wlroots capture

### DIFF
--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -2,6 +2,11 @@
  * @file src/platform/linux/wayland.cpp
  * @brief Definitions for Wayland capture.
  */
+// standard includes
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
 // platform includes
 #include <drm_fourcc.h>
 #include <fcntl.h>
@@ -382,7 +387,19 @@ namespace wl {
     if (supported_modifiers) {
       auto it = supported_modifiers->find(dmabuf_info.format);
       if (it != supported_modifiers->end() && !it->second.empty()) {
-        current_bo = gbm_bo_create_with_modifiers(gbm_device, dmabuf_info.width, dmabuf_info.height, dmabuf_info.format, it->second.data(), it->second.size());
+        // DRM_FORMAT_MOD_INVALID requests an implicit-modifier allocation and is not a valid
+        // entry in an explicit modifier list, so drop it before handing the list to GBM.
+        std::vector<std::uint64_t> modifiers;
+        modifiers.reserve(it->second.size());
+        std::copy_if(it->second.begin(), it->second.end(), std::back_inserter(modifiers), [](std::uint64_t modifier) {
+          return modifier != DRM_FORMAT_MOD_INVALID;
+        });
+
+        if (!modifiers.empty()) {
+          // Use the flag-taking variant, otherwise the GBM_BO_USE_RENDERING usage hint passed
+          // by the implicit-modifier path below would be silently dropped.
+          current_bo = gbm_bo_create_with_modifiers2(gbm_device, dmabuf_info.width, dmabuf_info.height, dmabuf_info.format, modifiers.data(), modifiers.size(), GBM_BO_USE_RENDERING);
+        }
       }
     }
 
@@ -397,10 +414,17 @@ namespace wl {
       return;
     }
 
-    // Get buffer info
-    int fd = gbm_bo_get_fd(current_bo);
-    if (fd < 0) {
-      BOOST_LOG(error) << "Failed to get buffer FD"sv;
+    // Get buffer info. An explicit modifier may describe a multi-planar layout (for example
+    // AMD DCC, where a second plane holds the compression metadata). Every plane has to be
+    // exported, otherwise the compositor rejects the import with EGL_BAD_MATCH.
+    uint64_t modifier = gbm_bo_get_modifier(current_bo);
+    int planes = gbm_bo_get_plane_count(current_bo);
+
+    auto next_frame = get_next_frame();
+    next_frame->sd.modifier = modifier;
+
+    if (planes < 1 || planes > 4) {
+      BOOST_LOG(error) << "Unsupported DMA-BUF plane count: "sv << planes;
       gbm_bo_destroy(current_bo);
       current_bo = nullptr;
       zwlr_screencopy_frame_v1_destroy(frame);
@@ -408,19 +432,32 @@ namespace wl {
       return;
     }
 
-    uint32_t stride = gbm_bo_get_stride(current_bo);
-    uint64_t modifier = gbm_bo_get_modifier(current_bo);
-
-    // Store in surface descriptor for later use
-    auto next_frame = get_next_frame();
-    next_frame->sd.fds[0] = fd;
-    next_frame->sd.pitches[0] = stride;
-    next_frame->sd.offsets[0] = 0;
-    next_frame->sd.modifier = modifier;
-
     // Create linux-dmabuf buffer
     auto params = zwp_linux_dmabuf_v1_create_params(dmabuf_interface);
-    zwp_linux_buffer_params_v1_add(params, fd, 0, 0, stride, modifier >> 32, modifier & 0xffffffff);
+
+    for (int plane = 0; plane < planes; ++plane) {
+      int fd = gbm_bo_get_fd_for_plane(current_bo, plane);
+      if (fd < 0) {
+        BOOST_LOG(error) << "Failed to get buffer FD for plane "sv << plane;
+        zwp_linux_buffer_params_v1_destroy(params);
+        next_frame->destroy();  // Closes the FDs exported so far
+        gbm_bo_destroy(current_bo);
+        current_bo = nullptr;
+        zwlr_screencopy_frame_v1_destroy(frame);
+        status = REINIT;
+        return;
+      }
+
+      uint32_t stride = gbm_bo_get_stride_for_plane(current_bo, plane);
+      uint32_t offset = gbm_bo_get_offset(current_bo, plane);
+
+      // Store in surface descriptor for later use
+      next_frame->sd.fds[plane] = fd;
+      next_frame->sd.pitches[plane] = stride;
+      next_frame->sd.offsets[plane] = offset;
+
+      zwp_linux_buffer_params_v1_add(params, fd, plane, offset, stride, modifier >> 32, modifier & 0xffffffff);
+    }
 
     // Add listener for buffer creation
     zwp_linux_buffer_params_v1_add_listener(params, &params_listener, frame);


### PR DESCRIPTION
In comments to #5132 I pointed out a regression on my setup. On my Proxmox LXC with Headless Sway and 8060s GPU WLR capture just stopped working completely https://gist.github.com/ninele7/15a83db0104c94ddcbb26dbca7fa6340.. 

I honestly have no understanding of the situation, but given that initial regression was introduced by fully AI driven PR, I decided to try to fix it the same way. 

Claude identified the issue based on the logs. And created small test script to check used formats: https://gist.github.com/ninele7/0ea3d852ff6d0d0da6bfe6f70a4cdff5. 

Script output:

```
/tmp/modprobe_test 
compositor-advertised modifiers for XRGB8888: 8
chosen modifier : 0x02000000186abb04
plane count     : 2
  plane 0: stride=10240 offset=0
  plane 1: stride=2560 offset=15728640

Sunshine submits only plane 0 with this modifier -> MISMATCH (compositor import will fail)
pre-5132 gbm_bo_create: modifier=0x00ffffffffffffff planes=1
```

After that it produced a fix, which I've tested with and without `WLR_RENDERER=vulkan`. It works on my hardware in both cases. 

Working logs: https://gist.github.com/ninele7/e07621f3c6042ff5647fb529095cbc23

Probably would need testing from someone else. Also claude says, that it might fix problem that #5288 tries to fix. 

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed (I'm not really competent in this kind of C++)
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes

I don't understand the code, so it contradicts AI usage guidelines. But PR which introduced the regression also doesn't follow that specific guideline. 