### PR TITLE
fix(linux/kms): use same methodology for display name matching and list generation

### DIFF
--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -860,19 +860,11 @@ namespace platf {
       if (display_name.empty() || std::ranges::all_of(display_name, ::isdigit)) {
         return util::from_view(display_name);
       }
-      // display_name is a connector name (not empty and containing non-digits) try to resolve correct monitor index like correlate_wayland does
-      auto index_begin = display_name.find_last_of('-');
-      std::int64_t index;
-      if (index_begin == std::string_view::npos) {
-        index = 1;
-      } else {
-        index = std::max<int64_t>(1, util::from_view(display_name.substr(index_begin + 1)));
-      }
-      auto type = kms::from_view(display_name.substr(0, index_begin));
+      // display_name is a connector name (not empty and containing non-digits)
       for (auto &card_descriptor : kms::card_descriptors) {
         for (const auto &monitor_descriptor : card_descriptor.crtc_to_monitor | std::views::values) {
-          if (monitor_descriptor.type == type && monitor_descriptor.index == index) {
-            BOOST_LOG(debug) << "Mapped '"sv << display_name << "' to a monitor index " << monitor_descriptor.monitor_index;
+          if (display_name == std::format("{}-{}", drmModeGetConnectorTypeName(monitor_descriptor.type), monitor_descriptor.index)) {
+            BOOST_LOG(info) << "Mapped '"sv << display_name << "' to kmsgrab monitor index " << monitor_descriptor.monitor_index;
             return monitor_descriptor.monitor_index;
           }
         }
@@ -2171,6 +2163,7 @@ namespace platf {
 
     kms::card_descriptors = std::move(cds);
 
+    BOOST_LOG(debug) << "Final KMS display_names return list: " << (display_names | std::views::join_with(' ') | std::ranges::to<std::string>());
     return display_names;
   }
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This is a small addendum to #5423 to ensure there is never a mismatch between the KMS display list generation and display matching code by changing the latter to use the same methodology for matching to kmsgrab monitor index.

Both cases now generate a string using `std::format("{}-{}", drmModeGetConnectorTypeName(type), index)` and either add it to the display_name list or check if it string matches the value given during kmsgrab display init.

Also adds a log of the final display_names list returned to simplify debugging available display_names.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
