### PR TITLE
feat(session): add SUNSHINE_CLIENT_NAME environment variable

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1258,7 +1258,7 @@ namespace nvhttp {
    * @brief Check whether a paired client certificate is allowed to connect and retrieve its friendly name.
    *
    * @param cert_pem PEM-encoded client certificate to look up.
-   * @return Pair of (bool enabled, string name) where "enabled" is True when the client certificate belongs to an 
+   * @return Pair of (bool enabled, string name) where "enabled" is True when the client certificate belongs to an
              enabled device and "name" is the friendly client name set during pairing.
    */
   std::pair<bool, std::string> get_client_status(const std::string_view cert_pem);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -176,6 +176,7 @@ namespace nvhttp {
 
   // Set by TLS verify callback, read by launch/resume handler (single-threaded HTTPS server)
   std::string last_verified_client_cert;  ///< Last client certificate accepted by the TLS verify callback.  // NOSONAR(cpp:S5421): intentionally mutable global
+  std::string last_verified_client_name;  ///< Friendly name of last client certificate accepted by the TLS verify callback.
 
   /**
    * @brief Case-insensitive map used for HTTP headers and query parameters.
@@ -405,6 +406,7 @@ namespace nvhttp {
     }
     launch_session->rtsp_url_scheme = launch_session->rtsp_cipher ? "rtspenc://"s : "rtsp://"s;
     launch_session->client_cert = last_verified_client_cert;
+    launch_session->client_name = last_verified_client_name;
 
     // Generate the unique identifiers for this connection that we will send later during RTSP handshake
     unsigned char raw_payload[8];
@@ -1253,12 +1255,13 @@ namespace nvhttp {
   }
 
   /**
-   * @brief Check whether a paired client certificate is allowed to connect.
+   * @brief Check whether a paired client certificate is allowed to connect and retrieve its friendly name.
    *
    * @param cert_pem PEM-encoded client certificate to look up.
-   * @return True when the client certificate belongs to an enabled device.
+   * @return Pair of (bool enabled, string name) where "enabled" is True when the client certificate belongs to an 
+             enabled device and "name" is the friendly client name set during pairing.
    */
-  bool is_client_enabled(const std::string_view cert_pem);
+  std::pair<bool, std::string> get_client_status(const std::string_view cert_pem);
 
   void start() {
     platf::set_thread_name("nvhttp");
@@ -1330,12 +1333,14 @@ namespace nvhttp {
 
       // Check if this client is enabled
       auto pem = crypto::pem(x509);
-      if (!is_client_enabled(pem)) {
+      auto [enabled, client_name] = get_client_status(pem);
+      if (!enabled) {
         BOOST_LOG(info) << "Client is disabled -- denied"sv;
         return verified;
       }
 
       last_verified_client_cert = pem;
+      last_verified_client_name = client_name;
       verified = 1;
 
       return verified;
@@ -1463,15 +1468,15 @@ namespace nvhttp {
   }
 
   /**
-   * @brief Check whether a paired client certificate is allowed to connect.
+   * @brief Check whether a paired client certificate is allowed to connect and return its friendly name.
    */
-  bool is_client_enabled(const std::string_view cert_pem) {
+  std::pair<bool, std::string> get_client_status(const std::string_view cert_pem) {
     const client_t &client = client_root;
     for (const auto &named_cert : client.named_devices) {
       if (named_cert.cert == cert_pem) {
-        return named_cert.enabled;
+        return {named_cert.enabled, named_cert.name};
       }
     }
-    return true;
+    return {true, {}};
   }
 }  // namespace nvhttp

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -176,7 +176,7 @@ namespace nvhttp {
 
   // Set by TLS verify callback, read by launch/resume handler (single-threaded HTTPS server)
   std::string last_verified_client_cert;  ///< Last client certificate accepted by the TLS verify callback.  // NOSONAR(cpp:S5421): intentionally mutable global
-  std::string last_verified_client_name;  ///< Friendly name of last client certificate accepted by the TLS verify callback.
+  std::string last_verified_client_name;  ///< Friendly name of last client certificate accepted by the TLS verify callback. // NOSONAR(cpp:S5421): intentionally mutable global
 
   /**
    * @brief Case-insensitive map used for HTTP headers and query parameters.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -169,6 +169,7 @@ namespace proc {
     // Add Stream-specific environment variables
     _env["SUNSHINE_APP_ID"] = std::to_string(_app_id);
     _env["SUNSHINE_APP_NAME"] = _app.name;
+    _env["SUNSHINE_CLIENT_NAME"] = launch_session->client_name;
     _env["SUNSHINE_CLIENT_WIDTH"] = std::to_string(launch_session->width);
     _env["SUNSHINE_CLIENT_HEIGHT"] = std::to_string(launch_session->height);
     _env["SUNSHINE_CLIENT_FPS"] = std::to_string(launch_session->fps);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -170,6 +170,7 @@ namespace proc {
     // Add Stream-specific environment variables
     _env["SUNSHINE_APP_ID"] = std::to_string(_app_id);
     _env["SUNSHINE_APP_NAME"] = _app.name;
+    _env["SUNSHINE_CLIENT_NAME"] = launch_session->client_name;
     _env["SUNSHINE_CLIENT_WIDTH"] = std::to_string(launch_session->width);
     _env["SUNSHINE_CLIENT_HEIGHT"] = std::to_string(launch_session->height);
     _env["SUNSHINE_CLIENT_FPS"] = std::to_string(launch_session->fps);

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -38,6 +38,7 @@ namespace rtsp_stream {
     bool continuous_audio;  ///< Whether audio packets continue during silence.
     bool enable_hdr;  ///< Whether HDR streaming is requested.
     bool enable_sops;  ///< Whether sequence output protection is requested.
+    std::string client_name;  ///< Friendly client name from initial pairing.
 
     std::optional<crypto::cipher::gcm_t> rtsp_cipher;  ///< AES-GCM cipher used once encrypted RTSP is negotiated.
     std::string rtsp_url_scheme;  ///< URL scheme selected by the RTSP SETUP flow.

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -338,6 +338,10 @@
                   <td>{{ $t('apps.env_app_name') }}</td>
                 </tr>
                 <tr>
+                  <td style="font-family: monospace">SUNSHINE_CLIENT_NAME</td>
+                  <td>{{ $t('apps.env_client_name') }}</td>
+                </tr>
+                <tr>
                   <td style="font-family: monospace">SUNSHINE_CLIENT_WIDTH</td>
                   <td>{{ $t('apps.env_client_width') }}</td>
                 </tr>

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -71,6 +71,7 @@
     "env_client_hdr": "HDR is enabled by the client (true/false)",
     "env_client_height": "The Height requested by the client (int)",
     "env_client_host_audio": "The client has requested host audio (true/false)",
+    "env_client_name": "The Name of the client assigned during pairing (str)",
     "env_client_width": "The Width requested by the client (int)",
     "env_displayplacer_example": "Example - displayplacer for Resolution Automation:",
     "env_qres_example": "Example - QRes for Resolution Automation:",


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This PR populates a new environment variable, "SUNSHINE_CLIENT_NAME", with the friendly name given for the client cert during the PIN pairing process. 

The use case for this is being able to reference specific clients in host scripts. For example, if "Justin-TV" should get a different HDR calibration setting in KDE Plasma than "Justin-Macbook" I can match on the client name to set it instead of the requested height/width (which works until you have more than one device requesting the same resolution).   

I've tested this on my own devices:

```
SUNSHINE_CLIENT_NAME=Justin-MacbookPro
SUNSHINE_CLIENT_AUDIO_CONFIGURATION=2.0
SUNSHINE_CLIENT_GCMAP=0
SUNSHINE_CLIENT_WIDTH=3456
SUNSHINE_APP_ID=881448767
SUNSHINE_CLIENT_AUDIO_SURROUND_PARAMS=
SUNSHINE_CLIENT_ENABLE_SOPS=true
SUNSHINE_CLIENT_FPS=120
SUNSHINE_APP_NAME=Desktop
SUNSHINE_CLIENT_HDR=true
SUNSHINE_CLIENT_HOST_AUDIO=false
SUNSHINE_CLIENT_HEIGHT=2160
```

```
SUNSHINE_CLIENT_NAME=Justin-iPhone
SUNSHINE_CLIENT_AUDIO_CONFIGURATION=2.0
SUNSHINE_CLIENT_GCMAP=1
SUNSHINE_CLIENT_WIDTH=2796
SUNSHINE_APP_ID=881448767
SUNSHINE_CLIENT_AUDIO_SURROUND_PARAMS=
SUNSHINE_CLIENT_ENABLE_SOPS=true
SUNSHINE_CLIENT_FPS=120
SUNSHINE_APP_NAME=Desktop
SUNSHINE_CLIENT_HDR=true
SUNSHINE_CLIENT_HOST_AUDIO=false
SUNSHINE_CLIENT_HEIGHT=1290
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Closes https://github.com/orgs/LizardByte/discussions/837

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

Unit tests were run and reviewed for potential updates but I couldn't think of a reasonable way to cover this change.

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes

Web-based AI helped with brainstorming where to implement the change and then I promptly ignored its recommendations and came up with a solution I liked better. No AI ever touched the coding environment. 