### PR TITLE
fix(linux): add a lock to PipeWire DMA-BUFs to avoid unexpected buffer overwrite and flicker

### DIFF
--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -604,6 +604,11 @@ namespace cuda {
         CU_CHECK(cdf->cuGraphicsUnmapResources(resources.size(), resources.data(), stream.get()), "Couldn't unmap GL textures from CUDA");
       }
 
+      // Mapping the GL conversion targets into CUDA synchronizes the preceding
+      // GL draw that consumed the source DMA-BUF. It is now safe for PipeWire
+      // to return that producer-owned buffer to KWin for reuse.
+      descriptor.mark_capture_buffer_consumed();
+
       return 0;
     }
 

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -5,9 +5,11 @@
 #pragma once
 
 // standard includes
+#include <exception>
 #include <functional>
 #include <optional>
 #include <string_view>
+#include <utility>
 
 // lib includes
 #include <glad/egl.h>
@@ -603,14 +605,14 @@ namespace egl {
    */
   class img_descriptor_t: public cursor_t {
   public:
-    ~img_descriptor_t() {
+    ~img_descriptor_t() noexcept {
       reset();
     }
 
     /**
      * @brief Reset the object to its initial empty state.
      */
-    void reset() {
+    void reset() noexcept {
       mark_capture_buffer_consumed();
 
       for (auto x = 0; x < 4; ++x) {
@@ -626,10 +628,16 @@ namespace egl {
      * @brief Notify the capture backend that the imported source buffer is no
      * longer needed by conversion and can be returned to its producer.
      */
-    void mark_capture_buffer_consumed() {
-      if (capture_buffer_consumed_cb) {
-        auto callback = std::move(capture_buffer_consumed_cb);
-        callback();
+    void mark_capture_buffer_consumed() noexcept {
+      auto callback = std::exchange(capture_buffer_consumed_cb, {});
+      if (callback) {
+        try {
+          callback();
+        } catch (const std::exception &e) {
+          BOOST_LOG(error) << "Failed to release capture buffer: " << e.what();
+        } catch (...) {
+          BOOST_LOG(error) << "Failed to release capture buffer: unknown exception";
+        }
       }
     }
 

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -5,6 +5,7 @@
 #pragma once
 
 // standard includes
+#include <functional>
 #include <optional>
 #include <string_view>
 
@@ -610,12 +611,25 @@ namespace egl {
      * @brief Reset the object to its initial empty state.
      */
     void reset() {
+      mark_capture_buffer_consumed();
+
       for (auto x = 0; x < 4; ++x) {
         if (sd.fds[x] >= 0) {
           close(sd.fds[x]);
 
           sd.fds[x] = -1;
         }
+      }
+    }
+
+    /**
+     * @brief Notify the capture backend that the imported source buffer is no
+     * longer needed by conversion and can be returned to its producer.
+     */
+    void mark_capture_buffer_consumed() {
+      if (capture_buffer_consumed_cb) {
+        auto callback = std::move(capture_buffer_consumed_cb);
+        callback();
       }
     }
 
@@ -632,6 +646,7 @@ namespace egl {
     std::optional<uint64_t> seq;  ///< PipeWire frame sequence number.
     std::optional<bool> pw_damage;  ///< Whether PipeWire damage tracking should be used.
     std::optional<uint32_t> pw_flags;  ///< PipeWire frame flags reported with the buffer.
+    std::function<void()> capture_buffer_consumed_cb;  ///< Releases a producer-owned capture buffer after import/conversion.
   };
 
   /**

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -88,6 +88,53 @@ namespace pipewire {
   };
 
   /**
+   * @brief Safely returns retained PipeWire buffers from Sunshine's conversion
+   * thread while preventing use after stream teardown.
+   */
+  struct buffer_release_state_t {
+    /**
+     * @brief Make buffer releases target the active PipeWire stream.
+     *
+     * @param new_loop PipeWire thread loop that owns the stream.
+     * @param new_stream PipeWire stream that owns captured buffers.
+     */
+    void activate(struct pw_thread_loop *new_loop, struct pw_stream *new_stream) {
+      std::scoped_lock lock(mutex);
+      loop = new_loop;
+      stream = new_stream;
+    }
+
+    /**
+     * @brief Ignore future buffer releases before stream teardown.
+     */
+    void deactivate() {
+      std::scoped_lock lock(mutex);
+      loop = nullptr;
+      stream = nullptr;
+    }
+
+    /**
+     * @brief Return a retained buffer to the active PipeWire stream.
+     *
+     * @param buffer PipeWire buffer whose capture contents are no longer used.
+     */
+    void release(struct pw_buffer *buffer) {
+      std::scoped_lock lock(mutex);
+      if (!loop || !stream || !buffer) {
+        return;
+      }
+
+      pw_thread_loop_lock(loop);
+      pw_stream_queue_buffer(stream, buffer);
+      pw_thread_loop_unlock(loop);
+    }
+
+    std::mutex mutex;  ///< Protects stream lifetime and serialized buffer release.
+    struct pw_thread_loop *loop = nullptr;  ///< Thread loop that owns `stream`.
+    struct pw_stream *stream = nullptr;  ///< Active stream that owns retained buffers.
+  };
+
+  /**
    * @brief PipeWire stream handle, format, and shared state pointer.
    */
   struct stream_data_t {
@@ -148,6 +195,7 @@ namespace pipewire {
 
     ~pipewire_t() {
       BOOST_LOG(debug) << "[pipewire] Destroying pipewire_t"sv;
+      buffer_release_state->deactivate();
       pw_thread_loop_lock(loop);
 
       // Lock the frame mutex to stop fill_img
@@ -293,6 +341,7 @@ namespace pipewire {
 
         BOOST_LOG(debug) << "[pipewire] Create PW stream"sv;
         stream_data.stream = pw_stream_new(core, "Sunshine Video Capture", props);
+        buffer_release_state->activate(loop, stream_data.stream);
         pw_stream_add_listener(stream_data.stream, &stream_data.stream_listener, &stream_events, &stream_data);
 
         std::array<uint8_t, SPA_POD_BUFFER_SIZE> buffer;
@@ -308,6 +357,7 @@ namespace pipewire {
         bool use_dmabuf = n_dmabuf_infos > 0 && (mem_type == platf::mem_type_e::vaapi ||
                                                  mem_type == platf::mem_type_e::vulkan ||
                                                  (mem_type == platf::mem_type_e::cuda && display_is_nvidia));
+        retain_dmabuf_for_cuda_ = use_dmabuf && mem_type == platf::mem_type_e::cuda;
         if (use_dmabuf) {
           for (int i = 0; i < n_dmabuf_infos; i++) {
             auto format_param = build_format_parameter(&pod_builder, width, height, refresh_rate, dmabuf_infos[i].format, dmabuf_infos[i].modifiers, dmabuf_infos[i].n_modifiers);
@@ -434,6 +484,20 @@ namespace pipewire {
         fill_img_metadata(img_descriptor, buf);
         if (buf->datas[0].type == SPA_DATA_DmaBuf) {
           fill_img_dmabuf(img_descriptor, buf, stream_data);
+
+          if (retain_dmabuf_for_cuda_) {
+            // Transfer ownership of this PipeWire buffer to the captured image.
+            // The GL/CUDA conversion path returns it only after it has finished
+            // reading the imported DMA-BUF.
+            const auto retained_buffer = stream_data.current_buffer;
+            std::weak_ptr<buffer_release_state_t> weak_release_state = buffer_release_state;
+            img_descriptor->capture_buffer_consumed_cb = [weak_release_state, retained_buffer]() {
+              if (auto release_state = weak_release_state.lock()) {
+                release_state->release(retained_buffer);
+              }
+            };
+            stream_data.current_buffer = nullptr;
+          }
         } else {
           img->data = stream_data.front_buffer->data();
           img->row_pitch = stream_data.local_stride;
@@ -458,10 +522,12 @@ namespace pipewire {
     struct pw_core *core;
     struct spa_hook core_listener;
     struct stream_data_t stream_data;
+    std::shared_ptr<buffer_release_state_t> buffer_release_state = std::make_shared<buffer_release_state_t>();
     int fd;
     uint32_t node;
     uint64_t object_serial;
     bool negotiate_maxframerate_ = true;
+    bool retain_dmabuf_for_cuda_ = false;  ///< Retain producer buffers until GL/CUDA conversion consumes them.
 
     struct spa_pod *build_format_parameter(struct spa_pod_builder *b, uint32_t width, uint32_t height, uint32_t refresh_rate, int32_t format, uint64_t *modifiers, int n_modifiers) {
       struct spa_pod_frame object_frame;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -4,6 +4,7 @@
  */
 // standard includes
 #include <fstream>
+#include <utility>
 
 // lib includes
 #include <gio/gio.h>
@@ -486,17 +487,7 @@ namespace pipewire {
           fill_img_dmabuf(img_descriptor, buf, stream_data);
 
           if (retain_dmabuf_for_cuda_) {
-            // Transfer ownership of this PipeWire buffer to the captured image.
-            // The GL/CUDA conversion path returns it only after it has finished
-            // reading the imported DMA-BUF.
-            const auto retained_buffer = stream_data.current_buffer;
-            std::weak_ptr<buffer_release_state_t> weak_release_state = buffer_release_state;
-            img_descriptor->capture_buffer_consumed_cb = [weak_release_state, retained_buffer]() {
-              if (auto release_state = weak_release_state.lock()) {
-                release_state->release(retained_buffer);
-              }
-            };
-            stream_data.current_buffer = nullptr;
+            retain_current_buffer_until_conversion(img_descriptor);
           }
         } else {
           img->data = stream_data.front_buffer->data();
@@ -517,6 +508,24 @@ namespace pipewire {
     }
 
   private:
+    /**
+     * @brief Transfer the current PipeWire buffer to an image until conversion completes.
+     *
+     * @param img_descriptor Captured image that will release the buffer after conversion.
+     */
+    void retain_current_buffer_until_conversion(egl::img_descriptor_t *img_descriptor) {
+      const auto retained_buffer = std::exchange(stream_data.current_buffer, nullptr);
+      const std::weak_ptr<buffer_release_state_t> weak_release_state = buffer_release_state;
+      img_descriptor->capture_buffer_consumed_cb = [weak_release_state, retained_buffer]() {
+        const auto release_state = weak_release_state.lock();
+        if (!release_state) {
+          return;
+        }
+
+        release_state->release(retained_buffer);
+      };
+    }
+
     struct pw_thread_loop *loop;
     struct pw_context *context;
     struct pw_core *core;

--- a/tests/unit/platform/linux/test_graphics.cpp
+++ b/tests/unit/platform/linux/test_graphics.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file tests/unit/platform/linux/test_graphics.cpp
+ * @brief Test src/platform/linux/graphics.h image descriptor behavior.
+ */
+#include "../../../tests_common.h"
+
+#if defined(__linux__)
+  #include <algorithm>
+  #include <iterator>
+
+  #include <src/platform/linux/graphics.h>
+
+TEST(EglImageDescriptorTest, ReleasesCaptureBufferOnlyOnce) {
+  egl::img_descriptor_t descriptor;
+  std::fill(std::begin(descriptor.sd.fds), std::end(descriptor.sd.fds), -1);
+
+  int release_count = 0;
+  descriptor.capture_buffer_consumed_cb = [&release_count]() {
+    ++release_count;
+  };
+
+  descriptor.mark_capture_buffer_consumed();
+  descriptor.mark_capture_buffer_consumed();
+  descriptor.reset();
+
+  EXPECT_EQ(release_count, 1);
+}
+
+TEST(EglImageDescriptorTest, ResetReleasesCaptureBuffer) {
+  egl::img_descriptor_t descriptor;
+  std::fill(std::begin(descriptor.sd.fds), std::end(descriptor.sd.fds), -1);
+
+  bool released = false;
+  descriptor.capture_buffer_consumed_cb = [&released]() {
+    released = true;
+  };
+
+  descriptor.reset();
+
+  EXPECT_TRUE(released);
+}
+#endif

--- a/tests/unit/platform/linux/test_graphics.cpp
+++ b/tests/unit/platform/linux/test_graphics.cpp
@@ -6,13 +6,13 @@
 
 #if defined(__linux__)
   #include <algorithm>
-  #include <iterator>
+  #include <stdexcept>
 
   #include <src/platform/linux/graphics.h>
 
 TEST(EglImageDescriptorTest, ReleasesCaptureBufferOnlyOnce) {
   egl::img_descriptor_t descriptor;
-  std::fill(std::begin(descriptor.sd.fds), std::end(descriptor.sd.fds), -1);
+  std::ranges::fill(descriptor.sd.fds, -1);
 
   int release_count = 0;
   descriptor.capture_buffer_consumed_cb = [&release_count]() {
@@ -28,7 +28,7 @@ TEST(EglImageDescriptorTest, ReleasesCaptureBufferOnlyOnce) {
 
 TEST(EglImageDescriptorTest, ResetReleasesCaptureBuffer) {
   egl::img_descriptor_t descriptor;
-  std::fill(std::begin(descriptor.sd.fds), std::end(descriptor.sd.fds), -1);
+  std::ranges::fill(descriptor.sd.fds, -1);
 
   bool released = false;
   descriptor.capture_buffer_consumed_cb = [&released]() {
@@ -38,5 +38,17 @@ TEST(EglImageDescriptorTest, ResetReleasesCaptureBuffer) {
   descriptor.reset();
 
   EXPECT_TRUE(released);
+}
+
+TEST(EglImageDescriptorTest, ContainsCaptureBufferReleaseExceptions) {
+  egl::img_descriptor_t descriptor;
+  std::ranges::fill(descriptor.sd.fds, -1);
+
+  descriptor.capture_buffer_consumed_cb = []() {
+    throw std::runtime_error("release failed");
+  };
+
+  EXPECT_NO_THROW(descriptor.mark_capture_buffer_consumed());
+  EXPECT_FALSE(descriptor.capture_buffer_consumed_cb);
 }
 #endif

--- a/tests/unit/platform/linux/test_graphics.cpp
+++ b/tests/unit/platform/linux/test_graphics.cpp
@@ -6,9 +6,16 @@
 
 #if defined(__linux__)
   #include <algorithm>
-  #include <stdexcept>
+  #include <exception>
 
   #include <src/platform/linux/graphics.h>
+
+namespace {
+  /**
+   * @brief Test-only failure raised by a capture-buffer release callback.
+   */
+  class capture_buffer_release_error: public std::exception {};
+}  // namespace
 
 TEST(EglImageDescriptorTest, ReleasesCaptureBufferOnlyOnce) {
   egl::img_descriptor_t descriptor;
@@ -45,7 +52,7 @@ TEST(EglImageDescriptorTest, ContainsCaptureBufferReleaseExceptions) {
   std::ranges::fill(descriptor.sd.fds, -1);
 
   descriptor.capture_buffer_consumed_cb = []() {
-    throw std::runtime_error("release failed");
+    throw capture_buffer_release_error {};
   };
 
   EXPECT_NO_THROW(descriptor.mark_capture_buffer_consumed());


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

- Added a lock to the pipewire capture buffer, to avoid Kwin overwriting the content of this buffer when we are reading it, causing the video stream to flicker intermittently.
- The lock is correctly released after we made a copy of its content or on error.
- Only implemented for CUDA/NVENC, since this is the only device I have.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Might be a workaround for https://github.com/LizardByte/Sunshine/issues/3235

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [x] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
