### PR TITLE
fix(config): handle malformed prep_cmd and dd_mode_remapping JSON in config

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -693,13 +693,19 @@ namespace config {
       std::stringstream json_stream;
       json_stream << "{\"dd_mode_remapping\":" << value << "}";
 
-      boost::property_tree::ptree json_tree;
-      boost::property_tree::read_json(json_stream, json_tree);
-
       video_t::dd_t::mode_remapping_t output;
-      parse_entry_list(json_tree.get_child("dd_mode_remapping.mixed"), output.mixed);
-      parse_entry_list(json_tree.get_child("dd_mode_remapping.resolution_only"), output.resolution_only);
-      parse_entry_list(json_tree.get_child("dd_mode_remapping.refresh_rate_only"), output.refresh_rate_only);
+      try {
+        boost::property_tree::ptree json_tree;
+        boost::property_tree::read_json(json_stream, json_tree);
+
+        parse_entry_list(json_tree.get_child("dd_mode_remapping.mixed"), output.mixed);
+        parse_entry_list(json_tree.get_child("dd_mode_remapping.resolution_only"), output.resolution_only);
+        parse_entry_list(json_tree.get_child("dd_mode_remapping.refresh_rate_only"), output.refresh_rate_only);
+      } catch (const boost::property_tree::ptree_error &err) {
+        // don't let bad json kill startup, skip remapping
+        BOOST_LOG(warning) << "Ignoring invalid dd_mode_remapping configuration: "sv << err.what();
+        return {};
+      }
 
       return output;
     }
@@ -1426,15 +1432,21 @@ namespace config {
     // We need to add a wrapping object to make it valid JSON, otherwise ptree cannot parse it.
     jsonStream << "{\"prep_cmd\":" << string << "}";
 
-    boost::property_tree::ptree jsonTree;
-    boost::property_tree::read_json(jsonStream, jsonTree);
+    try {
+      boost::property_tree::ptree jsonTree;
+      boost::property_tree::read_json(jsonStream, jsonTree);
 
-    for (auto &[_, prep_cmd] : jsonTree.get_child("prep_cmd"s)) {
-      auto do_cmd = prep_cmd.get_optional<std::string>("do"s);
-      auto undo_cmd = prep_cmd.get_optional<std::string>("undo"s);
-      auto elevated = prep_cmd.get_optional<bool>("elevated"s);
+      for (auto &[_, prep_cmd] : jsonTree.get_child("prep_cmd"s)) {
+        auto do_cmd = prep_cmd.get_optional<std::string>("do"s);
+        auto undo_cmd = prep_cmd.get_optional<std::string>("undo"s);
+        auto elevated = prep_cmd.get_optional<bool>("elevated"s);
 
-      input.emplace_back(do_cmd.value_or(""), undo_cmd.value_or(""), elevated.value_or(false));
+        input.emplace_back(do_cmd.value_or(""), undo_cmd.value_or(""), elevated.value_or(false));
+      }
+    } catch (const boost::property_tree::ptree_error &err) {
+      // don't let bad json kill startup, skip this setting
+      BOOST_LOG(warning) << "Ignoring invalid "sv << name << " configuration: "sv << err.what();
+      input.clear();
     }
   }
 

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -1,0 +1,81 @@
+/**
+ * @file tests/unit/test_config.cpp
+ * @brief Test src/config.* configuration parsing helpers.
+ */
+// test imports
+#include "../tests_common.h"
+
+// standard imports
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+// local imports
+#include <src/config.h>
+
+// internal helpers, not exposed in config.h
+namespace config {
+  void list_prep_cmd_f(std::unordered_map<std::string, std::string> &vars, const std::string &name, std::vector<prep_cmd_t> &input);
+
+  namespace dd {
+    video_t::dd_t::mode_remapping_t mode_remapping_from_view(std::string_view value);
+  }  // namespace dd
+}  // namespace config
+
+struct ConfigParsingTest: BaseTest {};
+
+TEST_F(ConfigParsingTest, PrepCmdMalformedJsonDoesNotThrow) {
+  // bad json here must not kill startup
+  std::unordered_map<std::string, std::string> vars {{"global_prep_cmd", "["}};
+  std::vector<config::prep_cmd_t> input;
+
+  EXPECT_NO_THROW(config::list_prep_cmd_f(vars, "global_prep_cmd", input));
+  EXPECT_TRUE(input.empty());
+}
+
+TEST_F(ConfigParsingTest, PrepCmdValidJsonIsParsed) {
+  std::unordered_map<std::string, std::string> vars {
+    {"global_prep_cmd", R"([{"do":"echo start","undo":"echo stop","elevated":false}])"}
+  };
+  std::vector<config::prep_cmd_t> input;
+
+  ASSERT_NO_THROW(config::list_prep_cmd_f(vars, "global_prep_cmd", input));
+  ASSERT_EQ(input.size(), 1u);
+  EXPECT_EQ(input[0].do_cmd, "echo start");
+  EXPECT_EQ(input[0].undo_cmd, "echo stop");
+  EXPECT_FALSE(input[0].elevated);
+}
+
+TEST_F(ConfigParsingTest, ModeRemappingMalformedJsonReturnsEmpty) {
+  config::video_t::dd_t::mode_remapping_t result;
+  EXPECT_NO_THROW(result = config::dd::mode_remapping_from_view("{ not valid json"));
+  EXPECT_TRUE(result.mixed.empty());
+  EXPECT_TRUE(result.resolution_only.empty());
+  EXPECT_TRUE(result.refresh_rate_only.empty());
+}
+
+TEST_F(ConfigParsingTest, ModeRemappingValidJsonMissingChildKeysReturnsEmpty) {
+  // valid json but missing keys also throws (ptree_bad_path)
+  config::video_t::dd_t::mode_remapping_t result;
+  EXPECT_NO_THROW(result = config::dd::mode_remapping_from_view("[]"));
+  EXPECT_TRUE(result.mixed.empty());
+  EXPECT_TRUE(result.resolution_only.empty());
+  EXPECT_TRUE(result.refresh_rate_only.empty());
+}
+
+TEST_F(ConfigParsingTest, ModeRemappingValidJsonIsParsed) {
+  constexpr std::string_view value = R"({
+    "mixed": [{"requested_resolution":"1920x1080","requested_fps":"60","final_resolution":"2560x1440","final_refresh_rate":"120"}],
+    "resolution_only": [],
+    "refresh_rate_only": []
+  })";
+
+  config::video_t::dd_t::mode_remapping_t result;
+  ASSERT_NO_THROW(result = config::dd::mode_remapping_from_view(value));
+  ASSERT_EQ(result.mixed.size(), 1u);
+  EXPECT_EQ(result.mixed[0].requested_resolution, "1920x1080");
+  EXPECT_EQ(result.mixed[0].requested_fps, "60");
+  EXPECT_EQ(result.mixed[0].final_resolution, "2560x1440");
+  EXPECT_EQ(result.mixed[0].final_refresh_rate, "120");
+}


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->


## Description
<!--- Please include a summary of the changes. --->

The existing try/catch for loading the config file (`apply_config()`) only catches filesystem-level errors, not JSON schema errors. If either of the two JSON blobs (stored as strings) in the config file (`global_prep_cmd`, `dd_mode_remapping`) is malformed, they are not caught by the catch clauses, and Sunshine never starts up until the typo/error is fixed. Because the web UI does not currently have input validation, this error is likely to occur. The fix catches JSON parsing issues specifically either in `global_prep_cmd` or `dd_mode_remapping` and returns the default for either config if malformed, letting Sunshine start with a malformed config (which can be reported in logging).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes