### PR TITLE
build(homebrew): normalize remapped LCOV source paths

### DIFF
--- a/packaging/sunshine.rb
+++ b/packaging/sunshine.rb
@@ -367,11 +367,20 @@ class Sunshine < Formula
     source_index = lines.index { |line| line.start_with?("SF:") }
     return unless source_index
 
-    source_path = lines[source_index].delete_prefix("SF:").strip
-    source_prefix = source_prefixes.find { |prefix| source_path.start_with?(prefix) }
-    return unless source_prefix
+    source_path = Pathname.new(lines[source_index].delete_prefix("SF:").strip).cleanpath.to_s
+    # Homebrew remaps the formula build path to ".". LLVM may then resolve that
+    # relative path from CMake's compilation directory at "build/tests".
+    relative_source_path = if source_path.start_with?("build/tests/src/")
+      source_path.delete_prefix("build/tests/")
+    elsif source_path.start_with?("src/")
+      source_path
+    else
+      source_prefix = source_prefixes.find { |prefix| source_path.start_with?(prefix) }
+      "src/#{source_path.delete_prefix(source_prefix)}" if source_prefix
+    end
+    return unless relative_source_path
 
-    lines[source_index] = "SF:src/#{source_path.delete_prefix(source_prefix)}\n"
+    lines[source_index] = "SF:#{relative_source_path}\n"
     "#{lines.join}end_of_record\n"
   end
 
@@ -476,6 +485,42 @@ class Sunshine < Formula
         run_test_suite testpath
         generate_coverage_report testpath, ENV.fetch("HOMEBREW_BUILDPATH", "")
       end
+
+      lcov = <<~LCOV
+        SF:./src/remapped.cpp
+        DA:1,1
+        end_of_record
+        SF:build/tests/src/remapped_from_compile_dir.cpp
+        DA:1,1
+        end_of_record
+        SF:src/relative.cpp
+        DA:1,1
+        end_of_record
+        SF:#{testpath}/src/absolute.cpp
+        DA:1,1
+        end_of_record
+        SF:./tests/excluded.cpp
+        DA:1,1
+        end_of_record
+        SF:build/tests/tests/excluded_from_compile_dir.cpp
+        DA:1,1
+        end_of_record
+      LCOV
+      expected_lcov = <<~LCOV
+        SF:src/remapped.cpp
+        DA:1,1
+        end_of_record
+        SF:src/remapped_from_compile_dir.cpp
+        DA:1,1
+        end_of_record
+        SF:src/relative.cpp
+        DA:1,1
+        end_of_record
+        SF:src/absolute.cpp
+        DA:1,1
+        end_of_record
+      LCOV
+      assert_equal expected_lcov, lcov_for_source_files(lcov, testpath)
     end
   end
 end


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Updates `lcov_for_source_files` in `packaging/sunshine.rb` to handle Homebrew shim-rewritten paths (`./src/...`) and already-relative `src/...` entries, while still supporting absolute paths via known source prefixes. Adds a test case to verify all three path forms are normalized to `src/...` and that non-source entries (like `./tests/...`) are excluded.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
