### PR TITLE
fix(input): add missing default value for key_rightalt_to_key_win

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -861,6 +861,7 @@ namespace config {
     true,  // virtualhid_randomize_mac
 
     true,  // keyboard enabled
+    false,  // key_rightalt_to_key_win
     true,  // mouse enabled
     true,  // controller enabled
     true,  // always send scancodes

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -124,3 +124,26 @@ TEST_F(ConfigPersistenceTest, SelectsAllDriversOnlyForLicensedUsersWithoutAPrefe
   EXPECT_FALSE(config::select_all_gamepad_drivers_if_licensed(true));
   EXPECT_EQ(file_handler::read_file(config_file().string().c_str()), "gamepad_driver = all\n");
 }
+
+/**
+ * @brief Verify that native_pen_touch defaults to enabled.
+ *
+ * The input_t aggregate initializer previously omitted the key_rightalt_to_key_win
+ * member, which shifted every subsequent field and left native_pen_touch (the
+ * final member) value-initialized to false despite the surrounding comment
+ * suggesting true. This test guards the corrected default.
+ */
+TEST(ConfigInputTest, NativePenTouchDefaultsToEnabled) {
+  EXPECT_TRUE(config::input.native_pen_touch);
+}
+
+/**
+ * @brief Verify that key_rightalt_to_key_win defaults to disabled.
+ *
+ * This member is documented and configured as disabled by default; the
+ * aggregate initializer now explicitly sets it to false. It was previously
+ * omitted, causing the field to shift and native_pen_touch to default to false.
+ */
+TEST(ConfigInputTest, KeyRightAltToKeyWinDefaultsToDisabled) {
+  EXPECT_FALSE(config::input.key_rightalt_to_key_win);
+}


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

Fixes a regression where touch/pen input is disabled when `native_pen_touch` is
omitted from the config file.

Root cause: the `input_t` aggregate initializer in `src/config.cpp` is missing
an entry for `key_rightalt_to_key_win`. This shifts every subsequent field by
one, so `native_pen_touch` (the final member) is value-initialized to `false`
instead of its intended default of `true`. The surrounding comment
`true,  // native pen/touch support` is misleading because that value actually
initializes `high_resolution_scrolling`.

This change adds the missing initializer (`key_rightalt_to_key_win` defaults to
`false`, matching its configured default) and adds unit tests covering both
defaults.

Verified locally: with `native_pen_touch` absent from `sunshine.conf`, I ran the
released build (`2026.808.164219`) and confirmed touch/pen input was broken,
then rebuilt from this branch and confirmed touch/pen input works. The
`ConfigInputTest` cases pass.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

- Closes #5520

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [x] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
