### PR TITLE
feat(web): add file extension validation to file browser modal

### DIFF
--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -309,7 +309,7 @@
                 <input type="text" class="form-control monospace" id="appImagePath" aria-describedby="appImagePathHelp"
                   v-model="editForm['image-path']" />
                 <button class="btn btn-secondary" type="button"
-                  @click="browseFor('file', 'file_browser.select_file', editForm['image-path'], v => editForm['image-path'] = v)">
+                  @click="browseFor('file', 'file_browser.select_file', editForm['image-path'], v => editForm['image-path'] = v, ['.png'])">
                   <folder-open :size="18" class="icon"></folder-open>
                 </button>
                 <button class="btn btn-secondary" type="button" @click="showCoverFinder">
@@ -630,6 +630,7 @@
         fileBrowserType: "any",
         fileBrowserTitle: "",
         fileBrowserCallback: null,
+        fileBrowserAcceptedExtensions: null,
         fileBrowserCurrentPath: "",
         fileBrowserParentPath: "",
         fileBrowserEntries: [],
@@ -907,10 +908,11 @@
         })
           .finally(() => this.coverFinderBusy = false);
       },
-      browseFor(type, titleKey, startPath, callback) {
+      browseFor(type, titleKey, startPath, callback, acceptedExtensions = null) {
         this.fileBrowserType = type;
         this.fileBrowserTitle = this.$t(titleKey);
         this.fileBrowserCallback = callback;
+        this.fileBrowserAcceptedExtensions = acceptedExtensions;
         this.fileBrowserSelectedPath = startPath || '';
         this.fileBrowserTypedPath = startPath || '';
         this.fileBrowserError = '';
@@ -924,6 +926,14 @@
       fileBrowserConfirm() {
         const path = this.fileBrowserSelectedPath || this.fileBrowserTypedPath;
         if (path) {
+          if (this.fileBrowserAcceptedExtensions && this.fileBrowserType !== 'directory') {
+            const lowerPath = path.toLowerCase();
+            const isValid = this.fileBrowserAcceptedExtensions.some(ext => lowerPath.endsWith(ext.toLowerCase()));
+            if (!isValid) {
+              this.fileBrowserError = this.$t('file_browser.error_invalid_extension', { extensions: this.fileBrowserAcceptedExtensions.join(', ') });
+              return;
+            }
+          }
           if (this.fileBrowserCallback) {
             this.fileBrowserCallback(path);
             this.fileBrowserCallback = null;

--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -124,6 +124,8 @@
               :aria-label="$t('_common.close')"></button>
           </div>
           <div class="modal-body">
+            <!-- Error -->
+            <div v-if="editFormError" class="alert alert-danger py-2 small">{{ editFormError }}</div>
             <!-- Application Name -->
             <div class="mb-3">
               <label for="appName" class="form-label">{{ $t('apps.app_name') }}</label>
@@ -621,6 +623,7 @@
       return {
         apps: [],
         editForm: null,
+        editFormError: "",
         detachedCmd: "",
         coverSearching: false,
         coverFinderBusy: false,
@@ -742,6 +745,7 @@
           detached: [],
           "image-path": ""
         };
+        this.editFormError = "";
         this.openEditModal();
       },
       editApp(id) {
@@ -765,6 +769,7 @@
         if (this.editForm["exit-timeout"] === undefined) {
           this.editForm["exit-timeout"] = 5;
         }
+        this.editFormError = "";
         this.openEditModal();
       },
       showDeleteModal(id) {
@@ -994,7 +999,17 @@
         });
       },
       save() {
+        this.editFormError = "";
         this.editForm["image-path"] = this.editForm["image-path"].toString().replace(/"/g, '');
+        
+        const imagePath = this.editForm["image-path"];
+        if (imagePath && !imagePath.toLowerCase().endsWith('.png')) {
+          this.editFormError = this.$t('file_browser.error_invalid_extension', { extensions: '.png' });
+          const modalBody = this.$refs.editModal.querySelector('.modal-body');
+          if (modalBody) modalBody.scrollTop = 0;
+          return;
+        }
+
         apiFetch("./api/apps", {
           method: "POST",
           headers: {

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -634,6 +634,7 @@
   },
   "file_browser": {
     "empty": "No items to display",
+    "error_invalid_extension": "Selected file must have one of the following extensions: {extensions}",
     "root": "Root",
     "select": "Select",
     "select_directory": "Select Directory",


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This PR adds frontend file extension validation to the shared "Select File" file browser modal in the Sunshine Web UI.
Previously, the file browser would accept any selected file (e.g. `.md`) without providing any feedback, even when opening the modal to select an application cover image.

This change ensures the file extension is validated directly in the modal right when the user clicks "Select", aligning the frontend behavior with the existing backend enforcement in `validate_app_image_path` (in `process.cpp`).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->
Updated `fileBrowserConfirm` to validate the selected file against the accepted extensions and display an error message inside the modal if it fails.

https://github.com/user-attachments/assets/be19f312-13e9-44c2-b08f-0ca55400ac9f

Updated the `save` method to validate manually typed image paths, displaying the new error banner and preventing the API request if the extension is invalid.

<img width="912" height="639" alt="image" src="https://github.com/user-attachments/assets/552f7c40-7f65-4140-b22e-aae503ce1595" />

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Closes #5523 

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [X] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [X] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [X] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [X] **Heavy**: AI generated most or all of the code changes
