### PR TITLE
fix(linux/freebsd): truncate thread names to 15 characters

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -949,7 +949,7 @@ namespace platf {
    *
    * @param name Human-readable name to assign.
    */
-  void set_thread_name(const std::string &name);
+  void set_thread_name(std::string_view name);
 
   void enable_mouse_keys();
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -521,9 +521,10 @@ namespace platf {
     }
   }
 
-  void set_thread_name(const std::string &name) {
+  void set_thread_name(std::string_view name) {
     // Truncate name to fit in Linux/FreeBSD kernel's 16 byte limit
-    pthread_setname_np(pthread_self(), name.substr(0, 15).c_str());
+    std::string tr_name {name.substr(0, 15)};
+    pthread_setname_np(pthread_self(), tr_name.c_str());
   }
 
   /**

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -522,7 +522,8 @@ namespace platf {
   }
 
   void set_thread_name(const std::string &name) {
-    pthread_setname_np(pthread_self(), name.c_str());
+    // Truncate name to fit in Linux/FreeBSD kernel's 16 byte limit
+    pthread_setname_np(pthread_self(), name.substr(0, 15).c_str());
   }
 
   /**

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -252,8 +252,9 @@ namespace platf {
     pthread_set_qos_class_self_np(mac_priority, 0);
   }
 
-  void set_thread_name(const std::string &name) {
-    pthread_setname_np(name.c_str());
+  void set_thread_name(std::string_view name) {
+    std::string thread_name {name};
+    pthread_setname_np(thread_name.c_str());
   }
 
   void enable_mouse_keys() {

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1130,8 +1130,8 @@ namespace platf {
     }
   }
 
-  void set_thread_name(const std::string &name) {
-    std::wstring wname = utf_utils::from_utf8(name);
+  void set_thread_name(std::string_view name) {
+    std::wstring wname = utf_utils::from_utf8(std::string {name});
     HRESULT hr = SetThreadDescription(GetCurrentThread(), wname.c_str());
     if (FAILED(hr)) {
       BOOST_LOG(error) << "SetThreadDescription failed: " << hr;


### PR DESCRIPTION
The Linux and FreeBSD kernels impose a strict 16 character limit (including null terminator), so truncate thread names on these platforms.

Although it might be simpler to manually truncate the thread names, we don't have the same naming length limitation on Windows and MacOS.

Fixes the following threads being left as the fallback "rtsp::handler", "session::audio" or "sunshine":

  audio::pulseaudio
  stream::controlBroadcast
  stream::audioBroadcast
  stream::videoBroadcast
  TaskPool::worker

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
