### PR TITLE
fix(input): preserve aux gamepad data and bump libvirtualhid

### DIFF
--- a/src/platform/virtualhid_input.cpp
+++ b/src/platform/virtualhid_input.cpp
@@ -613,7 +613,13 @@ namespace platf::virtualhid {
     }
 
     auto &gamepad = context.gamepads[nr];
-    log_failure("submit libvirtualhid gamepad state"sv, gamepad->adapter->set_state(make_gamepad_state(state, gamepad->adapter->support())));
+    auto updated_state = make_gamepad_state(state, gamepad->adapter->support());
+    const auto &cached_state = gamepad->adapter->state();
+    updated_state.acceleration = cached_state.acceleration;
+    updated_state.gyroscope = cached_state.gyroscope;
+    updated_state.battery = cached_state.battery;
+    updated_state.touchpad_contacts = cached_state.touchpad_contacts;
+    log_failure("submit libvirtualhid gamepad state"sv, gamepad->adapter->set_state(updated_state));
   }
 
   void gamepad_touch(input_context_t &context, const gamepad_touch_t &touch) {

--- a/tests/unit/platform/test_virtualhid_input.cpp
+++ b/tests/unit/platform/test_virtualhid_input.cpp
@@ -540,6 +540,38 @@ TEST_F(VirtualHidDeviceTest, TranslatesGamepadTouchMotionAndBattery) {
   EXPECT_EQ(unsupported->gamepad()->submit_count(), unsupported_count);
 }
 
+TEST_F(VirtualHidDeviceTest, PreservesAuxiliaryGamepadStateAcrossControlUpdates) {
+  const auto capabilities = static_cast<std::uint16_t>(LI_CCAP_ACCEL | LI_CCAP_GYRO | LI_CCAP_TOUCHPAD | LI_CCAP_BATTERY_STATE);
+  auto *adapter = allocate_gamepad("ds5"sv, LI_CTYPE_PS, capabilities);
+  ASSERT_NE(adapter, nullptr);
+  EXPECT_TRUE(feedback_queue()->pop(10ms));
+  EXPECT_TRUE(feedback_queue()->pop(10ms));
+
+  platf::virtualhid::gamepad_motion(*context(), {{0, 3}, LI_MOTION_TYPE_ACCEL, 0.0F, 9.80665F, 0.0F});
+  platf::virtualhid::gamepad_motion(*context(), {{0, 3}, LI_MOTION_TYPE_GYRO, -0.2F, -0.5F, 0.0F});
+  platf::virtualhid::gamepad_touch(*context(), {{0, 3}, LI_TOUCH_EVENT_DOWN, 10, 0.25F, 0.75F, 1.0F});
+  platf::virtualhid::gamepad_battery(*context(), {{0, 3}, LI_BATTERY_STATE_DISCHARGING, 75});
+
+  platf::virtualhid::gamepad_update(*context(), 0, {platf::A, 255, 0, 0, 0, 0, 0});
+
+  const auto &state = adapter->state();
+  EXPECT_TRUE(state.buttons.test(lvh::GamepadButton::a));
+  ASSERT_TRUE(state.acceleration);
+  EXPECT_FLOAT_EQ(state.acceleration->x, 0.0F);
+  EXPECT_FLOAT_EQ(state.acceleration->y, 9.80665F);
+  EXPECT_FLOAT_EQ(state.acceleration->z, 0.0F);
+  ASSERT_TRUE(state.gyroscope);
+  EXPECT_FLOAT_EQ(state.gyroscope->x, -0.2F);
+  EXPECT_FLOAT_EQ(state.gyroscope->y, -0.5F);
+  EXPECT_FLOAT_EQ(state.gyroscope->z, 0.0F);
+  EXPECT_TRUE(state.touchpad_contacts[0].active);
+  EXPECT_FLOAT_EQ(state.touchpad_contacts[0].x, 0.25F);
+  EXPECT_FLOAT_EQ(state.touchpad_contacts[0].y, 0.75F);
+  ASSERT_TRUE(state.battery);
+  EXPECT_EQ(state.battery->state, lvh::GamepadBatteryState::discharging);
+  EXPECT_EQ(state.battery->percentage, 75);
+}
+
 TEST_F(VirtualHidDeviceTest, TranslatesMouseAndKeyboardInput) {
   platf::virtualhid::move_mouse(*context(), -4, 7);
   auto mouse_event = context()->mouse->last_submitted_event();


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Avoid overwriting motion, battery, and touchpad fields when submitting regular gamepad control updates. `gamepad_update` now starts from the translated control state and carries forward cached acceleration, gyroscope, battery, and touch contacts before calling `set_state`. Added a unit test to verify these auxiliary values persist across control updates, and bumped the `libvirtualhid` submodule to the required revision.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
