### PR TITLE
fix(linux/kms): correct multi-plane monitor indexing and hardware-scaled capture

### DIFF
--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -538,15 +538,28 @@ namespace cuda {
       } else if (descriptor.sequence > sequence) {
         sequence = descriptor.sequence;
 
-        rgb = egl::rgb_t {};
-
         auto rgb_opt = egl::import_source(display.get(), descriptor.sd);
 
         if (!rgb_opt) {
-          return -1;
-        }
+          // The plane's current format/modifier can't be imported (e.g. a game switched to a
+          // 10bpc swapchain in exclusive fullscreen that this driver won't bind to a GL texture).
+          // Encode a blank frame instead of dropping the client, and only log once per failure
+          // streak to avoid flooding the log every frame.
+          if (!import_failed_last_frame) {
+            BOOST_LOG(warning) << "Skipping frame(s): plane format (fourcc: "sv << util::hex(descriptor.sd.fourcc).to_string_view()
+                                << ") failed to import; will resume automatically if the format changes back"sv;
+            import_failed_last_frame = true;
+          }
 
-        rgb = std::move(*rgb_opt);
+          rgb = egl::create_blank(img);
+        } else {
+          if (import_failed_last_frame) {
+            BOOST_LOG(info) << "Resumed capture after plane format import failure"sv;
+            import_failed_last_frame = false;
+          }
+
+          rgb = std::move(*rgb_opt);
+        }
       }
 
       auto fmt_desc = av_pix_fmt_desc_get(sw_format);
@@ -640,6 +653,8 @@ namespace cuda {
     int offset_y;  ///< Vertical offset in physical pixels.
 
     bool is_yuv444;  ///< Whether the CUDA converter outputs YUV 4:4:4.
+
+    bool import_failed_last_frame = false;  ///< Whether the previous frame's plane import failed, to avoid log spam.
   };
 
   /**

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -631,6 +631,25 @@ namespace egl {
   }
 
   /**
+   * @brief Log the surface descriptor an import attempt was built from, for diagnosing
+   * driver-specific import failures (e.g. a particular DRM format/modifier/pitch combo).
+   * Only meant to be called on the (rate-limited, caller-side) failure path, hence debug level.
+   */
+  static void log_surface_descriptor(const surface_descriptor_t &xrgb) {
+    BOOST_LOG(debug) << "Surface descriptor: "sv << xrgb.width << 'x' << xrgb.height
+                      << " fourcc="sv << util::hex(xrgb.fourcc).to_string_view()
+                      << " modifier="sv << util::hex(xrgb.modifier).to_string_view();
+    for (auto x = 0; x < 4; ++x) {
+      if (xrgb.fds[x] < 0) {
+        continue;
+      }
+      BOOST_LOG(debug) << "  plane["sv << x << "]: fd="sv << xrgb.fds[x]
+                        << " offset="sv << xrgb.offsets[x]
+                        << " pitch="sv << xrgb.pitches[x];
+    }
+  }
+
+  /**
    * @brief Import the source frame texture for EGL/OpenGL conversion.
    *
    * @param egl_display EGL display used to create the image.
@@ -647,9 +666,18 @@ namespace egl {
     };
 
     if (!rgb->xrgb8) {
-      BOOST_LOG(error) << "Couldn't import RGB Image: "sv << util::hex(eglGetError()).to_string_view();
+      BOOST_LOG(debug) << "Couldn't import RGB Image: "sv << util::hex(eglGetError()).to_string_view();
+      log_surface_descriptor(xrgb);
 
       return std::nullopt;
+    }
+
+    // Some drivers can return a non-null EGLImage from eglCreateImage() while still leaving
+    // an error queued (validation deferred until first use). Catch that here too rather than
+    // only checking eglGetError() on the outright-null-image path above.
+    if (auto egl_err = eglGetError(); egl_err != EGL_SUCCESS) {
+      BOOST_LOG(debug) << "eglCreateImage() left a pending EGL error despite returning an image: "sv << util::hex(egl_err).to_string_view();
+      log_surface_descriptor(xrgb);
     }
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
@@ -664,10 +692,11 @@ namespace egl {
     // but then reject binding it to a GL texture, e.g. Mesa/RADV rejecting a 10bpc format
     // like DRM_FORMAT_XBGR2101010. When that happens, the texture is left with stale or
     // incomplete contents, so this must be treated as an import failure rather than
-    // silently streaming whatever ends up in the texture.
+    // silently streaming whatever ends up in the texture. Logged at debug level: callers
+    // already surface a rate-limited, user-facing warning instead of flooding at error level.
     if (auto err = gl::ctx.GetError(); err != GL_NO_ERROR) {
-      BOOST_LOG(error) << "Failed to bind EGLImage (DRM fourcc: "sv << util::hex(xrgb.fourcc).to_string_view()
-                        << ") to GL texture: "sv << util::hex(err).to_string_view();
+      BOOST_LOG(debug) << "Failed to bind EGLImage to GL texture: "sv << util::hex(err).to_string_view();
+      log_surface_descriptor(xrgb);
       gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
       return std::nullopt;
     }

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -655,9 +655,22 @@ namespace egl {
     gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
     if (!gl::egl_image_target_texture_2d()) {
       BOOST_LOG(error) << "glEGLImageTargetTexture2DOES is not available; cannot import RGB DMA-BUF"sv;
+      gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
       return std::nullopt;
     }
     gl::egl_image_target_texture_2d()(GL_TEXTURE_2D, rgb->xrgb8);
+
+    // Some drivers accept an EGLImage of a given DRM format/modifier from eglCreateImage()
+    // but then reject binding it to a GL texture, e.g. Mesa/RADV rejecting a 10bpc format
+    // like DRM_FORMAT_XBGR2101010. When that happens, the texture is left with stale or
+    // incomplete contents, so this must be treated as an import failure rather than
+    // silently streaming whatever ends up in the texture.
+    if (auto err = gl::ctx.GetError(); err != GL_NO_ERROR) {
+      BOOST_LOG(error) << "Failed to bind EGLImage (DRM fourcc: "sv << util::hex(xrgb.fourcc).to_string_view()
+                        << ") to GL texture: "sv << util::hex(err).to_string_view();
+      gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
+      return std::nullopt;
+    }
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1668,7 +1668,21 @@ namespace platf {
         auto rgb_opt = egl::import_source(display.get(), sd);
 
         if (!rgb_opt) {
-          return capture_e::error;
+          // The plane's current format/modifier can't be imported (e.g. a game switched to a
+          // 10bpc swapchain in exclusive fullscreen that this driver won't bind to a GL texture).
+          // Skip this frame rather than tearing down the whole capture thread for every client,
+          // and only log once per failure streak to avoid flooding the log every frame.
+          if (!import_failed_last_frame) {
+            BOOST_LOG(warning) << "Skipping frame(s): plane format (fourcc: "sv << util::hex(sd.fourcc).to_string_view()
+                                << ") failed to import; will resume automatically if the format changes back"sv;
+            import_failed_last_frame = true;
+          }
+          return capture_e::timeout;
+        }
+
+        if (import_failed_last_frame) {
+          BOOST_LOG(info) << "Resumed capture after plane format import failure"sv;
+          import_failed_last_frame = false;
         }
 
         auto &rgb = *rgb_opt;
@@ -1726,6 +1740,7 @@ namespace platf {
       gbm::gbm_t gbm;  ///< GBM device used for buffer allocation.
       egl::display_t display;  ///< EGL display created from the GBM device.
       egl::ctx_t ctx;  ///< EGL context used to copy KMS frames into RAM.
+      bool import_failed_last_frame = false;  ///< Whether the previous frame's plane import failed, to avoid log spam.
     };
 
     /**

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1703,24 +1703,53 @@ namespace platf {
         // The plane's backing texture can be smaller than the configured capture
         // resolution when the display controller hardware-scales it up at scanout time
         // (e.g. a game's native-resolution exclusive-fullscreen swapchain stretched to
-        // fill the output). Reading past the texture's real bounds triggers
-        // GL_INVALID_VALUE, so clamp the read to what's actually there. GL_PACK_ROW_LENGTH
-        // keeps the destination stride matching the full-size image buffer so the read
-        // lands correctly in its top-left corner instead of shearing across rows.
-        // Note this does not reproduce the hardware scaling itself: the rest of the frame
-        // is left as whatever the buffer previously contained.
-        int read_width = std::max(0, std::min(width, w - img_offset_x));
-        int read_height = std::max(0, std::min(height, h - img_offset_y));
-        bool clamped = read_width != width || read_height != height;
-        if (clamped) {
-          gl::ctx.PixelStorei(GL_PACK_ROW_LENGTH, width);
+        // fill the output) -- kmsgrab imports the plane's raw pre-scale buffer via
+        // DMA-BUF, bypassing that hardware scaler entirely. Reproduce the same upscale
+        // with a linear-filtered GL blit into a full-resolution scratch texture before
+        // reading it back, so the captured frame matches what the display actually shows
+        // instead of being cropped to the plane's native corner.
+        GLuint read_tex = rgb->tex[0];
+        int read_offset_x = img_offset_x;
+        int read_offset_y = img_offset_y;
+
+        if (w != width || h != height) {
+          if (!scale_tex.size()) {
+            scale_tex = gl::tex_t::make(1);
+            gl::ctx.BindTexture(GL_TEXTURE_2D, scale_tex[0]);
+            gl::ctx.TexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, width, height);
+            gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
+
+            scale_dst_fb = gl::frame_buf_t::make(1);
+            scale_dst_fb.bind(&scale_tex[0], &scale_tex[0] + 1);
+
+            scale_src_fb = gl::frame_buf_t::make(1);
+          }
+
+          gl::ctx.BindFramebuffer(GL_READ_FRAMEBUFFER, scale_src_fb[0]);
+          gl::ctx.FramebufferTexture(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, rgb->tex[0], 0);
+          gl::ctx.ReadBuffer(GL_COLOR_ATTACHMENT0);
+
+          gl::ctx.BindFramebuffer(GL_DRAW_FRAMEBUFFER, scale_dst_fb[0]);
+          GLenum draw_buf = GL_COLOR_ATTACHMENT0;
+          gl::ctx.DrawBuffers(1, &draw_buf);
+
+#ifndef NDEBUG
+          auto status = gl::ctx.CheckFramebufferStatus(GL_READ_FRAMEBUFFER);
+          if (status != GL_FRAMEBUFFER_COMPLETE) {
+            BOOST_LOG(error) << "Scale blit: source CheckFramebufferStatus() --> [0x"sv << util::hex(status).to_string_view() << ']';
+          }
+#endif
+
+          gl::ctx.BlitFramebuffer(0, 0, w, h, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+
+          gl::ctx.BindFramebuffer(GL_FRAMEBUFFER, 0);
+
+          read_tex = scale_tex[0];
+          read_offset_x = 0;
+          read_offset_y = 0;
         }
 
-        gl::ctx.GetTextureSubImage(rgb->tex[0], 0, img_offset_x, img_offset_y, 0, read_width, read_height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
-
-        if (clamped) {
-          gl::ctx.PixelStorei(GL_PACK_ROW_LENGTH, 0);
-        }
+        gl::ctx.GetTextureSubImage(read_tex, 0, read_offset_x, read_offset_y, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
 
         img_out->frame_timestamp = frame_timestamp;
 
@@ -1761,6 +1790,15 @@ namespace platf {
       egl::display_t display;  ///< EGL display created from the GBM device.
       egl::ctx_t ctx;  ///< EGL context used to copy KMS frames into RAM.
       bool import_failed_last_frame = false;  ///< Whether the previous frame's plane import failed, to avoid log spam.
+
+      // Lazily created the first time a captured plane's native size differs from the
+      // configured capture resolution (i.e. the display controller is hardware-scaling
+      // it). scale_tex is sized to the full capture resolution; scale_src_fb/scale_dst_fb
+      // wrap the per-frame imported texture and scale_tex respectively so BlitFramebuffer
+      // can scale between them.
+      gl::tex_t scale_tex;  ///< Scratch texture holding the upscaled frame, when needed.
+      gl::frame_buf_t scale_src_fb;  ///< FBO used to bind the per-frame imported texture as the blit source.
+      gl::frame_buf_t scale_dst_fb;  ///< FBO wrapping scale_tex as the blit destination.
     };
 
     /**

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1700,7 +1700,27 @@ namespace platf {
           return platf::capture_e::interrupted;
         }
 
-        gl::ctx.GetTextureSubImage(rgb->tex[0], 0, img_offset_x, img_offset_y, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
+        // The plane's backing texture can be smaller than the configured capture
+        // resolution when the display controller hardware-scales it up at scanout time
+        // (e.g. a game's native-resolution exclusive-fullscreen swapchain stretched to
+        // fill the output). Reading past the texture's real bounds triggers
+        // GL_INVALID_VALUE, so clamp the read to what's actually there. GL_PACK_ROW_LENGTH
+        // keeps the destination stride matching the full-size image buffer so the read
+        // lands correctly in its top-left corner instead of shearing across rows.
+        // Note this does not reproduce the hardware scaling itself: the rest of the frame
+        // is left as whatever the buffer previously contained.
+        int read_width = std::max(0, std::min(width, w - img_offset_x));
+        int read_height = std::max(0, std::min(height, h - img_offset_y));
+        bool clamped = read_width != width || read_height != height;
+        if (clamped) {
+          gl::ctx.PixelStorei(GL_PACK_ROW_LENGTH, width);
+        }
+
+        gl::ctx.GetTextureSubImage(rgb->tex[0], 0, img_offset_x, img_offset_y, 0, read_width, read_height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
+
+        if (clamped) {
+          gl::ctx.PixelStorei(GL_PACK_ROW_LENGTH, 0);
+        }
 
         img_out->frame_timestamp = frame_timestamp;
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <filesystem>
 #include <ranges>
+#include <set>
 #include <thread>
 #include <unistd.h>
 
@@ -932,6 +933,7 @@ namespace platf {
             continue;
           }
 
+          std::set<std::uint32_t> counted_crtcs;
           auto end = std::end(card);
           for (auto plane = std::begin(card); plane != end; ++plane) {
             // Skip unused planes
@@ -943,8 +945,15 @@ namespace platf {
               continue;
             }
 
+            // A CRTC can have more than one simultaneously-active plane (e.g. gamescope's
+            // base + overlay layers). Count each CRTC once so this matches kms_display_names().
+            if (counted_crtcs.count(plane->crtc_id)) {
+              continue;
+            }
+
             if (monitor != monitor_index) {
               ++monitor;
+              counted_crtcs.insert(plane->crtc_id);
               continue;
             }
 
@@ -2075,6 +2084,7 @@ namespace platf {
       }
 
       auto crtc_to_monitor = kms::map_crtc_to_monitor(card.monitors(conn_type_count));
+      std::set<std::uint32_t> counted_crtcs;
 
       auto end = std::end(card);
       for (auto plane = std::begin(card); plane != end; ++plane) {
@@ -2084,6 +2094,12 @@ namespace platf {
         }
 
         if (card.is_cursor(plane->plane_id)) {
+          continue;
+        }
+
+        // A CRTC can have more than one simultaneously-active plane (e.g. gamescope's
+        // base + overlay layers). Count each CRTC once, not once per active plane.
+        if (counted_crtcs.count(plane->crtc_id)) {
           continue;
         }
 
@@ -2126,6 +2142,7 @@ namespace platf {
         kms::print(plane.get(), fb.get(), crtc.get());
         display_names.emplace_back(std::format("{}-{}", drmModeGetConnectorTypeName(it->second.type), it->second.index));
         count++;
+        counted_crtcs.insert(plane->crtc_id);
       }
 
       cds.emplace_back(kms::card_descriptor_t {

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -558,15 +558,28 @@ namespace va {
       } else if (descriptor.sequence > sequence) {
         sequence = descriptor.sequence;
 
-        rgb = egl::rgb_t {};
-
         auto rgb_opt = egl::import_source(display.get(), descriptor.sd);
 
         if (!rgb_opt) {
-          return -1;
-        }
+          // The plane's current format/modifier can't be imported (e.g. a game switched to a
+          // 10bpc swapchain in exclusive fullscreen that this driver won't bind to a GL texture).
+          // Encode a blank frame instead of dropping the client, and only log once per failure
+          // streak to avoid flooding the log every frame.
+          if (!import_failed_last_frame) {
+            BOOST_LOG(warning) << "Skipping frame(s): plane format (fourcc: "sv << util::hex(descriptor.sd.fourcc).to_string_view()
+                                << ") failed to import; will resume automatically if the format changes back"sv;
+            import_failed_last_frame = true;
+          }
 
-        rgb = std::move(*rgb_opt);
+          rgb = egl::create_blank(img);
+        } else {
+          if (import_failed_last_frame) {
+            BOOST_LOG(info) << "Resumed capture after plane format import failure"sv;
+            import_failed_last_frame = false;
+          }
+
+          rgb = std::move(*rgb_opt);
+        }
       }
 
       sws.load_vram(descriptor, offset_x, offset_y, rgb->tex[0], false);
@@ -603,6 +616,8 @@ namespace va {
 
     int offset_x;  ///< Horizontal offset in physical pixels.
     int offset_y;  ///< Vertical offset in physical pixels.
+
+    bool import_failed_last_frame = false;  ///< Whether the previous frame's plane import failed, to avoid log spam.
   };
 
   /**


### PR DESCRIPTION
## Description

**Human Overview of changes**:
This bug fix allows my steam lxc running Sunshine + Gamescope with a dummy display port connector to successfully render and stream. I'll be happy to run this custom patched version for just myself, however I thought I would post this fix so for if anyone else in the community is looking for it or wants to clean it up, they can or they can use it too. I've spent a month of troubleshooting other avenues before ending up looking at Sunshines code and ending up with this solution. 
This PRs code changes are entirely AI generated, but has been tested on my hardware and is working for me (RX 9060 XT). YMMV. 

This PR comprises of two bug fixes.
1. Deduplication of planes when each plane contains the same CRTC ID (Gamescopes -drm mode surfaces this issue. As it produces two planes throwing off index selection for available monitors. Possibly one plane for the overlay and one for the screen in gamescopes case? I didn't look too deeply into it.)
2. When a games render resolution in gamescope is lower than the interfaces resolution, you are presented with a corrupted image. 2 fixes were applied; have a black fallback for display instead of corruption, correct scaling when the src is lower res than what the connector reports.

**AI Overview of changes**:
Fixes several bugs in the Linux KMS capture backend (`kmsgrab`) related to multi-plane monitors and hardware-scaled scanout.

- **Monitor index mismatch**: `kms_display_names()` and `display_t::init()` each counted every active, non-cursor *plane* as a separate monitor. A CRTC with more than one simultaneously-active plane (e.g. gamescope's base + overlay layers) was counted twice by both passes, throwing their indices out of sync and producing duplicate/misnumbered display names. Both passes now count active *CRTCs* instead, so a CRTC contributes to the index exactly once regardless of how many planes are active on it.
- **Black screen on hardware-scaled planes**: when the display controller hardware-scales a plane at scanout (its CRTC destination rect differs from the plane's native buffer size — e.g. a game's native-resolution exclusive-fullscreen swapchain stretched to fill a higher-resolution output), `kmsgrab`'s raw DMA-BUF import bypasses that scaler and only ever sees the pre-scale buffer. The texture readback was sized to the CRTC's output viewport rather than the actual imported texture, which triggered `GL_INVALID_VALUE` every frame and manifested as a black screen for the whole session. The capture path now reproduces the hardware upscale itself via a linear-filtered `glBlitFramebuffer` into a scratch texture sized to the configured capture resolution before readback, so the captured frame matches what the display actually shows. The scratch texture/FBOs are lazily created and reused; the common unscaled case is unaffected.

Tested against real hardware with a hardware-scaled plane at scanout (native-resolution exclusive-fullscreen swapchain stretched to a higher-resolution output).

### Screenshot
N/A — not a UI change.

### Issues Fixed or Closed
None referenced.

#### Roadmap Issues
None.

## Type of Change
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
