### PR TITLE
feat(input): forward DS5 player/mic-LED from libvirtualhid to the client

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -117,6 +117,8 @@ namespace platf {
     set_motion_event_state,  ///< Set motion event state
     set_rgb_led,  ///< Set RGB LED
     set_adaptive_triggers,  ///< Set adaptive triggers
+    set_player_led,  ///< Set player-indicator LEDs (DualSense)
+    set_mic_led,  ///< Set mic-mute LED (DualSense)
   };
 
   /**
@@ -208,6 +210,36 @@ namespace platf {
       return msg;
     }
 
+    /**
+     * @brief Create a player-LED (player-indicator) feedback command (DualSense).
+     *
+     * @param id Identifier for the controller.
+     * @param ledValue Raw 5-bit player-indicator bitmask (forwarded verbatim from the game's report).
+     * @return Constructed player-LED object.
+     */
+    static gamepad_feedback_msg_t make_player_led(std::uint16_t id, std::uint8_t ledValue) {
+      gamepad_feedback_msg_t msg;
+      msg.type = gamepad_feedback_e::set_player_led;
+      msg.id = id;
+      msg.data.player_led = {ledValue};
+      return msg;
+    }
+
+    /**
+     * @brief Create a mic-mute-LED feedback command (DualSense).
+     *
+     * @param id Identifier for the controller.
+     * @param ledState Mic-LED state (0 = off, 1 = on, 2 = pulse).
+     * @return Constructed mic-LED object.
+     */
+    static gamepad_feedback_msg_t make_mic_led(std::uint16_t id, std::uint8_t ledState) {
+      gamepad_feedback_msg_t msg;
+      msg.type = gamepad_feedback_e::set_mic_led;
+      msg.id = id;
+      msg.data.mic_led = {ledState};
+      return msg;
+    }
+
     gamepad_feedback_e type;  ///< Feedback command type stored in the union payload.
     std::uint16_t id;  ///< Controller identifier associated with this message.
 
@@ -232,6 +264,14 @@ namespace platf {
         std::uint8_t g;
         std::uint8_t b;
       } rgb_led;
+
+      struct {
+        std::uint8_t value;  ///< Raw 5-bit player-indicator bitmask.
+      } player_led;
+
+      struct {
+        std::uint8_t state;  ///< 0 = off, 1 = on, 2 = pulse.
+      } mic_led;
 
       struct {
         uint16_t controllerNumber;

--- a/src/platform/virtualhid_input.cpp
+++ b/src/platform/virtualhid_input.cpp
@@ -45,6 +45,10 @@ namespace platf::virtualhid {
     std::uint8_t last_red = 0;  ///< Last red LED value.
     std::uint8_t last_green = 0;  ///< Last green LED value.
     std::uint8_t last_blue = 0;  ///< Last blue LED value.
+    bool has_last_player_led = false;  ///< Whether the last player-LED value is valid.
+    std::uint8_t last_player_led = 0;  ///< Last player-indicator LED bitmask.
+    bool has_last_mic_led = false;  ///< Whether the last mic-LED state is valid.
+    std::uint8_t last_mic_led = 0;  ///< Last mic-mute LED state.
   };
 
   namespace {
@@ -389,6 +393,22 @@ namespace platf::virtualhid {
           gamepad->last_green = output.green;
           gamepad->last_blue = output.blue;
           raise_feedback_unlocked(gamepad, gamepad_feedback_msg_t::make_rgb_led(gamepad->client_relative_index, output.red, output.green, output.blue));
+          break;
+        case lvh::GamepadOutputKind::player_led:
+          if (gamepad->has_last_player_led && gamepad->last_player_led == output.player_led) {
+            return;
+          }
+          gamepad->has_last_player_led = true;
+          gamepad->last_player_led = output.player_led;
+          raise_feedback_unlocked(gamepad, gamepad_feedback_msg_t::make_player_led(gamepad->client_relative_index, output.player_led));
+          break;
+        case lvh::GamepadOutputKind::mic_led:
+          if (gamepad->has_last_mic_led && gamepad->last_mic_led == output.mic_led) {
+            return;
+          }
+          gamepad->has_last_mic_led = true;
+          gamepad->last_mic_led = output.mic_led;
+          raise_feedback_unlocked(gamepad, gamepad_feedback_msg_t::make_mic_led(gamepad->client_relative_index, output.mic_led));
           break;
         case lvh::GamepadOutputKind::adaptive_triggers:
           raise_feedback_unlocked(gamepad, gamepad_feedback_msg_t::make_adaptive_triggers(gamepad->client_relative_index, output.adaptive_trigger_flags, output.left_trigger_effect_type, output.right_trigger_effect_type, output.left_trigger_effect, output.right_trigger_effect));

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -49,6 +49,8 @@ constexpr int IDX_RUMBLE_TRIGGER_DATA = 12;  ///< Control-stream message index f
 constexpr int IDX_SET_MOTION_EVENT = 13;  ///< Control-stream message index for set motion event.
 constexpr int IDX_SET_RGB_LED = 14;  ///< Control-stream message index for set rgb led.
 constexpr int IDX_SET_ADAPTIVE_TRIGGERS = 15;  ///< Control-stream message index for set adaptive triggers.
+constexpr int IDX_SET_PLAYER_LED = 16;  ///< Control-stream message index for set player LED (DualSense).
+constexpr int IDX_SET_MIC_LED = 17;  ///< Control-stream message index for set mic LED (DualSense).
 
 static const short packetTypes[] = {
   0x0305,  // Start A
@@ -67,6 +69,8 @@ static const short packetTypes[] = {
   0x5501,  // Set motion event (Sunshine protocol extension)
   0x5502,  // Set RGB LED (Sunshine protocol extension)
   0x5503,  // Set Adaptive triggers (Sunshine protocol extension)
+  0x5504,  // Set Player LED (Sunshine protocol extension, DualSense)
+  0x5505,  // Set Mic LED (Sunshine protocol extension, DualSense)
 };
 
 namespace asio = boost::asio;
@@ -237,6 +241,26 @@ namespace stream {
     std::uint8_t r;  ///< Red LED channel.
     std::uint8_t g;  ///< Green LED channel.
     std::uint8_t b;  ///< Blue LED channel.
+  };
+
+  /**
+   * @brief Control payload that sets the DualSense player-indicator LEDs.
+   */
+  struct control_set_player_led_t {
+    control_header_v2 header;  ///< Control message header preceding this payload.
+
+    std::uint16_t id;  ///< Controller identifier associated with this message.
+    std::uint8_t value;  ///< Raw 5-bit player-indicator bitmask.
+  };
+
+  /**
+   * @brief Control payload that sets the DualSense mic-mute LED.
+   */
+  struct control_set_mic_led_t {
+    control_header_v2 header;  ///< Control message header preceding this payload.
+
+    std::uint16_t id;  ///< Controller identifier associated with this message.
+    std::uint8_t state;  ///< Mic-LED state (0 = off, 1 = on, 2 = pulse).
   };
 
   /**
@@ -1047,6 +1071,32 @@ namespace stream {
       plaintext.type_right = msg.data.adaptive_triggers.type_right;
       std::ranges::copy(msg.data.adaptive_triggers.right, plaintext.right);
 
+      std::array<std::uint8_t, sizeof(control_encrypted_t) + crypto::cipher::round_to_pkcs7_padded(sizeof(plaintext)) + crypto::cipher::tag_size>
+        encrypted_payload;
+
+      payload = encode_control(session, util::view(plaintext), encrypted_payload);
+    } else if (msg.type == platf::gamepad_feedback_e::set_player_led) {
+      control_set_player_led_t plaintext;
+      plaintext.header.type = packetTypes[IDX_SET_PLAYER_LED];
+      plaintext.header.payloadLength = sizeof(plaintext) - sizeof(control_header_v2);
+
+      plaintext.id = util::endian::little(msg.id);
+      plaintext.value = msg.data.player_led.value;
+
+      BOOST_LOG(verbose) << "Player LED: "sv << msg.id << " :: "sv << util::hex(msg.data.player_led.value).to_string_view();
+      std::array<std::uint8_t, sizeof(control_encrypted_t) + crypto::cipher::round_to_pkcs7_padded(sizeof(plaintext)) + crypto::cipher::tag_size>
+        encrypted_payload;
+
+      payload = encode_control(session, util::view(plaintext), encrypted_payload);
+    } else if (msg.type == platf::gamepad_feedback_e::set_mic_led) {
+      control_set_mic_led_t plaintext;
+      plaintext.header.type = packetTypes[IDX_SET_MIC_LED];
+      plaintext.header.payloadLength = sizeof(plaintext) - sizeof(control_header_v2);
+
+      plaintext.id = util::endian::little(msg.id);
+      plaintext.state = msg.data.mic_led.state;
+
+      BOOST_LOG(verbose) << "Mic LED: "sv << msg.id << " :: "sv << util::hex(msg.data.mic_led.state).to_string_view();
       std::array<std::uint8_t, sizeof(control_encrypted_t) + crypto::cipher::round_to_pkcs7_padded(sizeof(plaintext)) + crypto::cipher::tag_size>
         encrypted_payload;
 


### PR DESCRIPTION
## Description
Follow-up to https://github.com/LizardByte/libvirtualhid/pull/97. Now that libvirtualhid reports
the DualSense player and mic LEDs, this forwards them on to the client so the physical
controller's LEDs follow what the game sets.

Adds two control messages, `0x5504` for the player LED and `0x5505` for the mic LED,
and wires the two new output kinds up to them.

- `common.h`: `set_player_led` / `set_mic_led` feedback types and their `make_*` helpers
- `stream.cpp`: the two packet types and their encode paths, same as the existing RGB
  LED one (`0x5502`)
- `virtualhid_input.cpp`: forward the `player_led` / `mic_led` outputs, reusing the same
  per-value dedup as the RGB case
- bumps the `libvirtualhid` submodule to pull in the above

One thing to note: this depends on the libvirtualhid PR, so CI won't pass until that's
merged (the submodule points at its branch). Leaving it a draft until then. Client-side
handling of the two messages is moonlight-common-c#137.

## Type of Change
- [x] **feat**: New feature (non-breaking change which adds functionality)

## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes