### PR TITLE
fix(keyboard): Japanese mapping

### DIFF
--- a/src/platform/virtualhid_input.cpp
+++ b/src/platform/virtualhid_input.cpp
@@ -311,7 +311,7 @@ namespace platf::virtualhid {
       event.uses_normalized_key_code = (static_cast<std::byte>(flags) & static_cast<std::byte>(SS_KBE_FLAG_NON_NORMALIZED)) == std::byte {};
       event.prefer_native_scan_code = config::input.always_send_scancodes;
 #else
-      (void) flags;
+      event.uses_normalized_key_code = (static_cast<std::byte>(flags) & static_cast<std::byte>(SS_KBE_FLAG_NON_NORMALIZED)) == std::byte {};
 #endif
       return event;
     }

--- a/tests/unit/platform/test_virtualhid_input.cpp
+++ b/tests/unit/platform/test_virtualhid_input.cpp
@@ -629,10 +629,11 @@ TEST_F(VirtualHidDeviceTest, TranslatesMouseAndKeyboardInput) {
   keyboard_event = context()->keyboard->last_submitted_event();
   EXPECT_FALSE(keyboard_event.uses_normalized_key_code);
 #else
-  EXPECT_FALSE(keyboard_event.uses_normalized_key_code);
+  EXPECT_TRUE(keyboard_event.uses_normalized_key_code);
   EXPECT_FALSE(keyboard_event.prefer_native_scan_code);
-  platf::virtualhid::keyboard_update(*context(), 0x41, true, 0xFF);
+  platf::virtualhid::keyboard_update(*context(), 0x41, true, SS_KBE_FLAG_NON_NORMALIZED);
   keyboard_event = context()->keyboard->last_submitted_event();
+  EXPECT_FALSE(keyboard_event.uses_normalized_key_code);
 #endif
   EXPECT_FALSE(keyboard_event.pressed);
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Fix Japanese keyboard mapping

To be fixed, Need to merge all these PRs
https://github.com/moonlight-stream/moonlight-qt/pull/1984 
https://github.com/LizardByte/Sunshine/pull/5542
https://github.com/LizardByte/libvirtualhid/pull/101

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Fixes https://github.com/moonlight-stream/moonlight-qt/issues/1962



#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
