### PR TITLE
fix(linux/publish): release the Avahi client when the poll loop stops

### DIFF
--- a/src/platform/linux/publish.cpp
+++ b/src/platform/linux/publish.cpp
@@ -551,6 +551,8 @@ namespace platf::publish {
       if (poll_thread.joinable()) {
         poll_thread.join();
       }
+
+      poll.reset();
     }
   };
 
@@ -581,6 +583,16 @@ namespace platf::publish {
       return nullptr;
     }
 
-    return std::make_unique<deinit_t>(std::jthread {avahi::simple_poll_loop, poll.get()});
+    return std::make_unique<deinit_t>(std::jthread {[]() {
+      avahi::simple_poll_loop(poll.get());
+
+      // simple_poll_loop() returns only once publishing has stopped for good: either at
+      // shutdown, or because a failure path called simple_poll_quit(). Nothing services the
+      // client's D-Bus connection past this point, so release it here rather than leave it
+      // open and subscribed until the process exits. The entry group is owned by the client,
+      // so clear it too, otherwise a later start() would reuse a dangling pointer.
+      client.reset();
+      group = nullptr;
+    }});
   }
 }  // namespace platf::publish


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

Sunshine leaks its Avahi D-Bus connection when mDNS publishing is refused.

`poll` and `client` are namespace-scope, so they live until process exit. When `entry_group_add_service` fails, `create_services()`'s `fail_guard` calls `simple_poll_quit()` and the poll thread exits — but `client` is never reset. Its libdbus connection to the system bus stays open, with its match rules installed and nothing left to read it.

dbus-broker charges that queue to the per-UID quota. After a few days of uptime the quota is exhausted and the broker starts disconnecting unrelated peers owned by the same user. On my machine that killed Steam — exit code 0, no crash dump, no hint it had anything to do with Sunshine.

Reproduced with avahi-daemon running `disable-publishing=yes`:

```
[2026-08-22 17:01:06.262]: Info: Adding avahi service dev
[2026-08-22 17:01:06.262]: Error: Failed to add _nvstream._tcp service: Not permitted
```

Unpatched, 43 minutes later: the bus socket holds `Recv-Q` 32983, byte-identical across probes 10 s apart, and the broker's side sits at 213760 — its write buffer is full (`net.core.wmem_default` is 212992 here). Everything queued past that accumulates inside the broker, which is what the quota counts. Growth ~5.7 KB/min. It ends in:

```
dbus-broker: UID 1000 exceeded its 'bytes' quota on UID 1000.
dbus-broker: Peer :1.127 is being disconnected as it does not have the resources to receive a signal it subscribed to.
```

Patched, same version and same config, same refusal logged: the connection is gone — 4 bus sockets instead of 6, all `Recv-Q` 0, still 0 after 15 minutes.

The fix releases the client once `simple_poll_loop()` returns; that call only returns when publishing has stopped for good. `group` is cleared with it, since the entry group is owned by the client and would dangle on a later `start()`. `poll` is released in `~deinit_t()` after the thread is joined.

Environment: Sunshine 2026.516.143833, NixOS, dbus-broker 37 (`--max-bytes 536870912`).

Testing: verified by the A/B above on a live system. I did not add a unit test — reproducing this needs a running avahi-daemon that refuses publishing and a system bus that accounts queue bytes per UID, which I could not express in the existing suite.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

N/A — not a UI change.

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

None — I did not find an existing issue for this. Happy to open one if you would rather track it separately.

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->

## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [X] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
