### PR TITLE
fix(linux/pipewire): try variable rate for non-KWin compositors

### DIFF
--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -658,8 +658,8 @@ namespace pipewire {
       if (d->format.info.raw.max_framerate.num == 0 && d->format.info.raw.max_framerate.denom == 1) {
         BOOST_LOG(info) << "[pipewire] Framerate (from compositor): 0/1 (variable rate capture)";
       } else {
-        BOOST_LOG(info) << "[pipewire] Framerate (from compositor): "sv << d->format.info.raw.framerate.num << "/"sv << d->format.info.raw.framerate.denom;
-        BOOST_LOG(info) << "[pipewire] Framerate (from compositor, max): "sv << d->format.info.raw.max_framerate.num << "/"sv << d->format.info.raw.max_framerate.denom;
+        BOOST_LOG(info) << "[pipewire] Framerate (from compositor): "sv << d->format.info.raw.framerate.num << "/"sv << d->format.info.raw.framerate.denom
+                        << ", max: "sv << d->format.info.raw.max_framerate.num << "/"sv << d->format.info.raw.max_framerate.denom;
       }
 
       int physical_w = d->format.info.raw.size.width;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -815,10 +815,11 @@ namespace pipewire {
       // calculate frame interval we should capture at
       delay = ::video::capture_frame_interval(config);
 
-      // WORKAROUND: request variable rate (0, 1) capture only if the active compositor is KWin 5.x-6.7.x.
+      // WORKAROUND: if the active compositor is KWin, request variable rate (0, 1) capture only for versions 5.x-6.7.x.
       // Ref: https://bugs.kde.org/show_bug.cgi?id=524129
+      // Also negotiate variable rate for all other compositors. Mutter's variable rate pacing is superior.
       const static std::vector<int> kwin_version = get_running_kwin_version();
-      const static bool negotiate_variable_rate = !kwin_version.empty() && (kwin_version[0] == 5 || (kwin_version[0] == 6 && kwin_version[1] < 8));
+      const static bool negotiate_variable_rate = kwin_version.empty() || (kwin_version[0] == 5 || (kwin_version[0] == 6 && kwin_version[1] < 8));
 
       const AVRational fps = (negotiate_variable_rate ? AVRational {0, 1} : ::video::framerate_to_rational(config));
       if (fps.den != 1) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Variable rate capture works better on mutter, but since GNOME 50
we encountered negotiation failures.

It seems that if we negotiate maxFramerate with a default of variable rate
but relaxed maximum value, the final negotiation phase actually lands on
variable rate (after being constrained to the host refresh rate); mutter
debug included:

[2026-08-29 00:38:43.671]: Info: [pipewire] Framerate (from compositor): 0/1
[2026-08-29 00:38:43.671]: Info: [pipewire] Framerate (from compositor, max): 60/1
SCREEN_CAST: Video format changed to 1920x1080 (framerate: 0/1 (max: 60/1))
SCREEN_CAST: Video format changed to 1920x1080 (framerate: 0/1 (max: 0/1))
[2026-08-29 00:38:43.672]: Info: [pipewire] Framerate (from compositor): 0/1 (variable rate capture)

Pacing does seem to be improved and Sunshine reports variable rate for the
*final* negotiation phase.

Upstream MR has been submitted, but doesn't seem strictly necessary:
https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/5278

With upstream MR applied, output is more uniform:

[2026-08-29 00:35:42.248]: Info: [pipewire] Framerate (from compositor): 0/1 (variable rate capture)
[2026-08-29 00:35:42.248]: Info: [pipewire] Framerate (from compositor): 0/1 (variable rate capture)
[2026-08-29 00:35:42.248]: Info: [pipewire] Framerate (from compositor): 0/1 (variable rate capture)
[2026-08-29 00:35:42.248]: Info: [pipewire] Framerate (from compositor): 0/1 (variable rate capture)
SCREEN_CAST: Video format changed to 1920x1080 (framerate: 0/1 (max: 0/1))

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #5000

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
