### PR TITLE
feat(linux/wlgrab): report HDR from the output's image description

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -216,6 +216,7 @@ if(WAYLAND_FOUND)
     GEN_WAYLAND("${WAYLAND_PROTOCOLS_DIR}" "unstable/xdg-output" xdg-output-unstable-v1)
     GEN_WAYLAND("${WAYLAND_PROTOCOLS_DIR}" "unstable/linux-dmabuf" linux-dmabuf-unstable-v1)
     GEN_WAYLAND("${CMAKE_SOURCE_DIR}/third-party/wlr-protocols" "unstable" wlr-screencopy-unstable-v1)
+    GEN_WAYLAND("${WAYLAND_PROTOCOLS_DIR}" "staging/color-management" color-management-v1)
 
     include_directories(
             SYSTEM

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -191,6 +191,13 @@ namespace wl {
       dmabuf_listener {
         &CLASS_CALL(interface_t, dmabuf_format),
         &CLASS_CALL(interface_t, dmabuf_modifier)
+      },
+      color_listener {
+        &CLASS_CALL(interface_t, color_supported_intent),
+        &CLASS_CALL(interface_t, color_supported_feature),
+        &CLASS_CALL(interface_t, color_supported_tf_named),
+        &CLASS_CALL(interface_t, color_supported_primaries_named),
+        &CLASS_CALL(interface_t, color_done)
       } {
   }
 
@@ -237,6 +244,17 @@ namespace wl {
       zwp_linux_dmabuf_v1_add_listener(dmabuf_interface, &dmabuf_listener, this);
 
       this->interface[LINUX_DMABUF] = true;
+    } else if (!std::strcmp(interface, wp_color_manager_v1_interface.name)) {
+      BOOST_LOG(info) << "[wayland] Found interface: "sv << interface << '(' << id << ") version "sv << version;
+
+      // Bound at version 1 on purpose. Everything wlgrab asks of this global -
+      // the output's image description and the values inside it - is in the
+      // first version, and a higher one only adds events this code would have
+      // to carry a handler for.
+      color_manager = (wp_color_manager_v1 *) wl_registry_bind(registry, id, &wp_color_manager_v1_interface, 1);
+      wp_color_manager_v1_add_listener(color_manager, &color_listener, this);
+
+      this->interface[COLOR_MANAGER] = true;
     }
   }
 

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #ifdef SUNSHINE_BUILD_WAYLAND
+  #include <color-management-v1.h>
   #include <linux-dmabuf-unstable-v1.h>
   #include <wlr-screencopy-unstable-v1.h>
   #include <xdg-output-unstable-v1.h>
@@ -315,6 +316,7 @@ namespace wl {
       XDG_OUTPUT,  ///< xdg-output
       WLR_EXPORT_DMABUF,  ///< screencopy manager
       LINUX_DMABUF,  ///< linux-dmabuf protocol
+      COLOR_MANAGER,  ///< color-management-v1, which is how an output says it is in HDR
       MAX_INTERFACES,  ///< Maximum number of interfaces
     };
 
@@ -359,11 +361,81 @@ namespace wl {
      */
     void dmabuf_modifier(zwp_linux_dmabuf_v1 *zwp_linux_dmabuf, uint32_t format, uint32_t modifier_hi, uint32_t modifier_lo);
 
+    /**
+     * @brief Absorb the rendering intents wp_color_manager_v1 supports.
+     *
+     * The capability events are not read. They cannot be ignored either:
+     * libwayland dispatches straight into the listener table, so a null entry
+     * for an event the compositor does send is a crash rather than a no-op.
+     *
+     * @param manager Colour management global that emitted the event.
+     * @param render_intent Rendering intent the compositor supports.
+     */
+    void color_supported_intent(wp_color_manager_v1 *manager, std::uint32_t render_intent) {
+      // Deliberately empty; present so the listener entry is not null.
+    }
+
+    /**
+     * @brief Absorb the features wp_color_manager_v1 supports.
+     *
+     * The capability events are not read. They cannot be ignored either:
+     * libwayland dispatches straight into the listener table, so a null entry
+     * for an event the compositor does send is a crash rather than a no-op.
+     *
+     * @param manager Colour management global that emitted the event.
+     * @param feature Feature the compositor supports.
+     */
+    void color_supported_feature(wp_color_manager_v1 *manager, std::uint32_t feature) {
+      // Deliberately empty; present so the listener entry is not null.
+    }
+
+    /**
+     * @brief Absorb the named transfer functions wp_color_manager_v1 supports.
+     *
+     * The capability events are not read. They cannot be ignored either:
+     * libwayland dispatches straight into the listener table, so a null entry
+     * for an event the compositor does send is a crash rather than a no-op.
+     *
+     * @param manager Colour management global that emitted the event.
+     * @param tf Named transfer function the compositor supports.
+     */
+    void color_supported_tf_named(wp_color_manager_v1 *manager, std::uint32_t tf) {
+      // Deliberately empty; present so the listener entry is not null.
+    }
+
+    /**
+     * @brief Absorb the named primaries wp_color_manager_v1 supports.
+     *
+     * The capability events are not read. They cannot be ignored either:
+     * libwayland dispatches straight into the listener table, so a null entry
+     * for an event the compositor does send is a crash rather than a no-op.
+     *
+     * @param manager Colour management global that emitted the event.
+     * @param primaries Named primaries the compositor supports.
+     */
+    void color_supported_primaries_named(wp_color_manager_v1 *manager, std::uint32_t primaries) {
+      // Deliberately empty; present so the listener entry is not null.
+    }
+
+    /**
+     * @brief Acknowledge the end of wp_color_manager_v1's capability events.
+     *
+     * The capability events are not read. They cannot be ignored either:
+     * libwayland dispatches straight into the listener table, so a null entry
+     * for an event the compositor does send is a crash rather than a no-op.
+     *
+     * @param manager Colour management global that emitted the event.
+     */
+    void color_done(wp_color_manager_v1 *manager) {
+      // Deliberately empty; present so the listener entry is not null.
+    }
+
     std::vector<std::unique_ptr<monitor_t>> monitors;  ///< Outputs discovered from the Wayland registry.
     std::map<std::uint32_t, std::vector<std::uint64_t>> supported_modifiers;  ///< DRM format modifiers grouped by format.
     zwlr_screencopy_manager_v1 *screencopy_manager {nullptr};  ///< WLR screencopy global used to request frames.
     zwp_linux_dmabuf_v1 *dmabuf_interface {nullptr};  ///< Linux DMA-BUF global used to allocate frame buffers.
     zxdg_output_manager_v1 *output_manager {nullptr};  ///< xdg-output global used to query monitor names and sizes.
+    wp_color_manager_v1 *color_manager {nullptr};  ///< color-management-v1 global used to read the output's image description.
 
   private:
     void add_interface(wl_registry *registry, std::uint32_t id, const char *interface, std::uint32_t version);
@@ -372,6 +444,7 @@ namespace wl {
     std::bitset<MAX_INTERFACES> interface;
     wl_registry_listener listener;
     zwp_linux_dmabuf_v1_listener dmabuf_listener;
+    wp_color_manager_v1_listener color_listener;
   };
 
   /**

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -3,7 +3,10 @@
  * @brief Definitions for wlgrab capture.
  */
 // standard includes
+#include <algorithm>
+#include <array>
 #include <thread>
+#include <unistd.h>
 
 // local includes
 #include "cuda.h"
@@ -31,6 +34,199 @@ namespace wl {
       data = nullptr;
     }
   };
+
+  /**
+   * @brief What colour an output is presenting in, as the compositor describes it.
+   *
+   * Sunshine only sends HDR to a client when the display it captured says it is
+   * in HDR; see colorspace_from_client_config(), which falls back to Rec.709 for
+   * every capture backend whose is_hdr() is false. Until now that was every
+   * backend on Wayland: kmsgrab reads the connector's HDR_OUTPUT_METADATA
+   * property and the PipeWire path reads the SPA colorimetry, and screencopy
+   * carries neither.
+   *
+   * It does not have to. color-management-v1 hands the output's whole image
+   * description to any client that asks, which is more than the DRM property
+   * carries and is available on a virtual output as readily as on a physical
+   * one. That is the point for a headless seat: there is no connector to read,
+   * and there does not need to be.
+   *
+   * Values are kept in the protocol's own units and converted where they are
+   * handed to Moonlight, so that the conversion sits next to the structure that
+   * defines it rather than being spread over eleven callbacks.
+   */
+  struct output_color_t {
+    bool known {false};  ///< True once the compositor finished describing the output.
+
+    std::uint32_t primaries {0};  ///< wp_color_manager_v1 primaries enum.
+    std::uint32_t transfer_function {0};  ///< wp_color_manager_v1 transfer function enum.
+
+    std::array<std::int32_t, 8> target_primaries {};  ///< Mastering display, r_x r_y g_x g_y b_x b_y w_x w_y, CIE 1931 xy * 1000000.
+
+    std::uint32_t target_min_luminance {0};  ///< cd/m² * 10000.
+    std::uint32_t target_max_luminance {0};  ///< cd/m².
+    std::uint32_t target_max_cll {0};  ///< cd/m².
+    std::uint32_t target_max_fall {0};  ///< cd/m².
+  };
+
+  /**
+   * @brief State carried through one image description query.
+   */
+  struct color_query_t {
+    output_color_t color;  ///< Values collected from the information events.
+    bool ready {false};  ///< True once the image description resolved.
+    bool failed {false};  ///< True when the compositor refused to describe it.
+    bool done {false};  ///< True once every information event has arrived.
+  };
+
+  static void color_desc_failed(void *data, wp_image_description_v1 *, std::uint32_t cause, const char *msg) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    auto query = (color_query_t *) data;
+    query->failed = true;
+    BOOST_LOG(debug) << "[wlgrab] The compositor would not describe the output's colour: "sv << (msg ? msg : "no reason given");
+  }
+
+  static void color_desc_ready(void *data, wp_image_description_v1 *, std::uint32_t identity) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    ((color_query_t *) data)->ready = true;
+  }
+
+  static void color_info_done(void *data, wp_image_description_info_v1 *) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    auto query = (color_query_t *) data;
+    query->done = true;
+    query->color.known = true;
+  }
+
+  static void color_info_icc_file(void *data, wp_image_description_info_v1 *, std::int32_t fd, std::uint32_t size) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    // An ICC profile describes an SDR output. Nothing to read, but the file
+    // descriptor is ours now and leaking one per stream would be a slow leak
+    // rather than no leak at all.
+    if (fd >= 0) {
+      close(fd);
+    }
+  }
+
+  static void color_info_primaries(void *data, wp_image_description_info_v1 *, std::int32_t r_x, std::int32_t r_y, std::int32_t g_x, std::int32_t g_y, std::int32_t b_x, std::int32_t b_y, std::int32_t w_x, std::int32_t w_y) {  // NOSONAR: the event's shape is fixed by the Wayland C protocol - eight coordinates, the proxy and the user pointer (cpp:S107, cpp:S5008)
+    // The primary colour volume, which is not what Moonlight's structure wants:
+    // that is mastering display metadata, and it arrives in target_primaries.
+  }
+
+  static void color_info_primaries_named(void *data, wp_image_description_info_v1 *, std::uint32_t primaries) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    ((color_query_t *) data)->color.primaries = primaries;
+  }
+
+  static void color_info_tf_power(void *data, wp_image_description_info_v1 *, std::uint32_t eexp) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    // A power-function transfer characteristic, so not PQ and not HDR.
+  }
+
+  static void color_info_tf_named(void *data, wp_image_description_info_v1 *, std::uint32_t tf) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    ((color_query_t *) data)->color.transfer_function = tf;
+  }
+
+  static void color_info_luminances(void *data, wp_image_description_info_v1 *, std::uint32_t min_lum, std::uint32_t max_lum, std::uint32_t reference_lum) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    // The primary colour volume's luminances. target_luminance carries the ones
+    // that correspond to SMPTE ST 2086 and therefore to SS_HDR_METADATA.
+  }
+
+  static void color_info_target_primaries(void *data, wp_image_description_info_v1 *, std::int32_t r_x, std::int32_t r_y, std::int32_t g_x, std::int32_t g_y, std::int32_t b_x, std::int32_t b_y, std::int32_t w_x, std::int32_t w_y) {  // NOSONAR: the event's shape is fixed by the Wayland C protocol - eight coordinates, the proxy and the user pointer (cpp:S107, cpp:S5008)
+    auto &color = ((color_query_t *) data)->color;
+    color.target_primaries = {r_x, r_y, g_x, g_y, b_x, b_y, w_x, w_y};
+  }
+
+  static void color_info_target_luminance(void *data, wp_image_description_info_v1 *, std::uint32_t min_lum, std::uint32_t max_lum) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    auto &color = ((color_query_t *) data)->color;
+    color.target_min_luminance = min_lum;
+    color.target_max_luminance = max_lum;
+  }
+
+  static void color_info_target_max_cll(void *data, wp_image_description_info_v1 *, std::uint32_t max_cll) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    ((color_query_t *) data)->color.target_max_cll = max_cll;
+  }
+
+  static void color_info_target_max_fall(void *data, wp_image_description_info_v1 *, std::uint32_t max_fall) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    ((color_query_t *) data)->color.target_max_fall = max_fall;
+  }
+
+  static const wp_image_description_v1_listener color_desc_listener = {
+    .failed = color_desc_failed,
+    .ready = color_desc_ready,
+  };
+
+  static const wp_image_description_info_v1_listener color_info_listener = {
+    .done = color_info_done,
+    .icc_file = color_info_icc_file,
+    .primaries = color_info_primaries,
+    .primaries_named = color_info_primaries_named,
+    .tf_power = color_info_tf_power,
+    .tf_named = color_info_tf_named,
+    .luminances = color_info_luminances,
+    .target_primaries = color_info_target_primaries,
+    .target_luminance = color_info_target_luminance,
+    .target_max_cll = color_info_target_max_cll,
+    .target_max_fall = color_info_target_max_fall,
+  };
+
+  static void color_output_changed(void *data, wp_color_management_output_v1 *) {  // NOSONAR(cpp:S5008): the listener signature is fixed by the Wayland C protocol
+    // The output's colour can change while a stream runs, when the compositor
+    // is told to turn HDR on or off. Nothing is read here: Sunshine settles the
+    // colourspace when the encode session is built, so a change mid stream only
+    // takes effect on the next one. Present because libwayland dispatches into
+    // this table and a null entry would be a crash.
+  }
+
+  static const wp_color_management_output_v1_listener color_output_listener = {
+    .image_description_changed = color_output_changed,
+  };
+
+  /**
+   * @brief Ask the compositor what colour an output is presenting in.
+   *
+   * Never fails loudly. A compositor without color-management-v1, or one that
+   * refuses to describe the output, leaves the result unknown, which reads as
+   * SDR everywhere it is used. That is what every wlroots compositor did before
+   * this existed, so the fallback is the old behaviour rather than a new one.
+   *
+   * @param display Wayland connection used to round-trip.
+   * @param manager color-management-v1 global, or nullptr when absent.
+   * @param output The output being captured.
+   * @return What the compositor said, or an unknown colour.
+   */
+  static output_color_t query_output_color(wl::display_t &display, wp_color_manager_v1 *manager, wl_output *output) {
+    color_query_t query;
+
+    if (!manager || !output) {
+      return query.color;
+    }
+
+    auto cm_output = wp_color_manager_v1_get_output(manager, output);
+    if (!cm_output) {
+      return query.color;
+    }
+
+    wp_color_management_output_v1_add_listener(cm_output, &color_output_listener, &query);
+
+    auto desc = wp_color_management_output_v1_get_image_description(cm_output);
+    if (!desc) {
+      wp_color_management_output_v1_destroy(cm_output);
+      return query.color;
+    }
+
+    wp_image_description_v1_add_listener(desc, &color_desc_listener, &query);
+    display.roundtrip();
+
+    if (query.ready && !query.failed) {
+      // The information object is destroyed by the compositor when it sends
+      // done, so it must not be destroyed here as well.
+      auto info = wp_image_description_v1_get_information(desc);
+      if (info) {
+        wp_image_description_info_v1_add_listener(info, &color_info_listener, &query);
+        display.roundtrip();
+      }
+    }
+
+    wp_image_description_v1_destroy(desc);
+    wp_color_management_output_v1_destroy(cm_output);
+
+    return query.color;
+  }
 
   /**
    * @brief Wayland screencopy capture backend shared by RAM and VRAM paths.
@@ -105,6 +301,22 @@ namespace wl {
       }
 
       output = monitor->output;
+
+      // Read once, here, rather than per frame. Sunshine asks is_hdr() when it
+      // builds an encode session, and a session is rebuilt whenever the client
+      // reconnects or the capture reinitialises, which is also every moment at
+      // which the seat's output could have changed colour.
+      hdr_color = query_output_color(display, interface.color_manager, output);
+
+      if (!interface[wl::interface_t::COLOR_MANAGER]) {
+        BOOST_LOG(info) << "[wlgrab] The compositor has no color-management-v1, so this capture is SDR"sv;
+      } else if (hdr_color.known) {
+        BOOST_LOG(info) << "[wlgrab] Output colour: primaries "sv << hdr_color.primaries
+                        << ", transfer function "sv << hdr_color.transfer_function
+                        << (is_hdr() ? " (HDR)"sv : " (SDR)"sv);
+      } else {
+        BOOST_LOG(info) << "[wlgrab] The compositor did not describe the output's colour, treating it as SDR"sv;
+      }
 
       offset_x = monitor->viewport.offset_x;
       offset_y = monitor->viewport.offset_y;
@@ -182,6 +394,61 @@ namespace wl {
       return platf::capture_e::ok;
     }
 
+    /**
+     * @brief Report whether the captured output is presenting in HDR.
+     *
+     * @return True when the output is BT.2020 with the PQ transfer function.
+     */
+    bool is_hdr() override {
+      return hdr_color.known &&
+             hdr_color.primaries == WP_COLOR_MANAGER_V1_PRIMARIES_BT2020 &&
+             hdr_color.transfer_function == WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ;
+    }
+
+    /**
+     * @brief Read HDR metadata for the captured output.
+     *
+     * @param metadata Output structure populated with HDR metadata.
+     * @return True when HDR metadata was written to the output structure.
+     */
+    bool get_hdr_metadata(SS_HDR_METADATA &metadata) override {
+      if (!is_hdr()) {
+        return false;
+      }
+
+      metadata = {};
+
+      // color-management-v1 carries CIE 1931 coordinates multiplied by a
+      // million; Moonlight's structure, which follows CTA-861, carries them
+      // multiplied by fifty thousand.
+      auto coord = [](std::int32_t value) {
+        return (std::uint16_t) std::clamp<std::int32_t>(value / 20, 0, 50000);
+      };
+
+      for (int i = 0; i < 3; i++) {
+        metadata.displayPrimaries[i].x = coord(hdr_color.target_primaries[i * 2]);
+        metadata.displayPrimaries[i].y = coord(hdr_color.target_primaries[i * 2 + 1]);
+      }
+
+      metadata.whitePoint.x = coord(hdr_color.target_primaries[6]);
+      metadata.whitePoint.y = coord(hdr_color.target_primaries[7]);
+
+      // The luminances already agree: the protocol gives the minimum in ten
+      // thousandths of a nit and everything else in whole nits, which is what
+      // Moonlight expects. Only the width has to be watched, because these
+      // arrive as 32 bit values and are handed on as 16 bit ones.
+      auto nits = [](std::uint32_t value) {
+        return (std::uint16_t) std::min<std::uint32_t>(value, 65535);
+      };
+
+      metadata.minDisplayLuminance = nits(hdr_color.target_min_luminance);
+      metadata.maxDisplayLuminance = nits(hdr_color.target_max_luminance);
+      metadata.maxContentLightLevel = nits(hdr_color.target_max_cll);
+      metadata.maxFrameAverageLightLevel = nits(hdr_color.target_max_fall);
+
+      return true;
+    }
+
     platf::mem_type_e mem_type;  ///< Mem type.
 
     std::chrono::nanoseconds delay;  ///< Delay before the timer task becomes eligible to run.
@@ -191,6 +458,7 @@ namespace wl {
     dmabuf_t dmabuf;  ///< DMA-BUF feedback and format state advertised by the compositor.
 
     wl_output *output;  ///< Wayland output selected for capture.
+    output_color_t hdr_color;  ///< What colour the compositor says the output is presenting in.
   };
 
   /**


### PR DESCRIPTION
## What this changes

`display_t::is_hdr()` defaults to `false` in `platform/common.h` and is overridden in two places: `kmsgrab.cpp`, from the connector's `HDR_OUTPUT_METADATA` property, and `pipewire.cpp`, from the SPA colorimetry. `wlgrab.cpp` overrides neither, so `colorspace_from_client_config()` always takes the SDR branch:

```cpp
if (config.dynamicRange > 0 && hdr_display) {
  colorspace.colorspace = colorspace_e::bt2020;
} else {
  ...
}
```

A client that asks for HDR over `capture = wlr` therefore gets a 10-bit encode of Rec. 709 and is correctly told HDR is off.

That is the right answer today, because the backend has no way to know better. It does not have to stay that way: colour-management-v1 publishes the output's whole image description to any client that asks, it carries more than the DRM property does, and it is available on a virtual output exactly as on a physical one.

So this binds `wp_color_manager_v1`, reads the captured output's image description once when the capture is set up — which is also every moment the answer could have changed, since the encode session is rebuilt on reconnect and on reinit — and answers `is_hdr()` and `get_hdr_metadata()` from it. It is the job `pipewire.cpp` already does with the SPA colorimetry, over the Wayland protocol instead.

Bound at version 1 deliberately: everything read here is in the first version, and a later one only adds events that would need handlers.

## Fallback

A compositor without the protocol, or one that will not describe the output, leaves the colour unknown, which reads as SDR everywhere it is used. That is the behaviour every wlroots compositor had before this existed, so nothing regresses.

## Testing

Compiles at `-Wall -Werror` against protocol headers generated from wayland-protocols 1.41 and 1.49, which is version 1 and version 3 of `wp_color_manager_v1`; the designated initialisers are there so it survives both, since 1.49 adds a `ready2` event and grows the listener struct.

The metadata conversion is checked against BT.2020's red primary, 0.708 and 0.292, which has to come out as 35400 and 14600 in `SS_HDR_METADATA`'s units.

On hardware: a headless sway 1.12 session on the Vulkan renderer, in an Incus container, on an RTX 4080 under the proprietary driver, streaming to a Moonlight client with HDR enabled.

```
Info: Output colour: primaries 6, transfer function 11 (HDR)
Info: Color coding: HDR (Rec. 2020 + SMPTE 2084 PQ)
Info: Color depth: 10-bit
```

The picture is correct, checked by eye and not only in the log. The output was at 2250x1206 at 120 Hz, adopted from the client mid-stream, so HDR survives a mode change.

## One dependency worth stating

This reports what the compositor says. For a **headless** output to be able to say anything, wlroots has to accept that a virtual output can present BT.2020 and PQ, which it does not today — the capability is read from a monitor's EDID and a headless output has no monitor. That is a ten-line change and is in flight separately at https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5453.

On a compositor whose output can already be in HDR, this change stands on its own.
