### PR TITLE
fix(nvhttp): non-blocking TLS shutdown in SunshineHTTPS destructor

### DIFF
--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -100,6 +100,17 @@ namespace nvhttp {
     virtual ~SunshineHTTPS() {
       // Gracefully shutdown the TLS connection
       SimpleWeb::error_code ec;
+
+      // Never block in the destructor waiting for the peer's close_notify.
+      // After sending our own close_notify, SSL_shutdown() waits for the peer's
+      // close_notify via a blocking read on the socket. Clients that keep the
+      // connection open (e.g. Moonlight's HTTP connection pool) never send one,
+      // which hangs the single io thread of the entire HTTPS server forever.
+      // With a non-blocking socket, the shutdown attempt returns immediately
+      // with would_block instead of waiting indefinitely.
+      // Use the error_code overload: the destructor is noexcept, so the
+      // throwing overload could terminate the process on failure.
+      lowest_layer().non_blocking(true, ec);
       shutdown(ec);
     }
   };


### PR DESCRIPTION
## Description
The HTTPS server (port 47984) can permanently stop accepting connections after certain Moonlight clients connect.

When a `SunshineHTTPS` connection object is destroyed (right after a response is written with `close_connection_after_response`), its destructor performs a synchronous TLS shutdown. After the server writes its own close_notify, `SSL_shutdown()` waits for the **peer's** close_notify via a blocking `read_some()` → `poll(fd, POLLIN, -1)` on the blocking socket. Clients that keep the connection open after receiving a response — part of the Moonlight HTTP connection pool, e.g. the Android app — never send a close_notify, so the single io thread of the HTTPS server blocks forever. Every later connection times out (Moonlight: *host reachable, app list authentication unavailable, HTTP timeout*), the 47984 listen backlog grows, while 47989/RTSP/streaming keep working and the process appears healthy.

I confirmed this by resolving the hung thread's stack from a core dump plus debug symbols:

```
io_context::run()
  → reactive_socket_send_op::do_complete          (response just sent)
    → Response::~Response → ~Session → Connection released
      → ~SunshineHTTPS() → stream::shutdown()
        → ssl::detail::io<shutdown_op>
          → basic_stream_socket::read_some        (socket is blocking)
            → socket_ops::sync_recv1 → poll_read(s, -1)   ← hangs forever
```

I also reproduced it locally with a minimal client that sends `GET /serverinfo` and then keeps the connection open: the server stops responding within seconds and stays wedged until restart.

The fix marks the underlying socket non-blocking **before** `shutdown()` so the attempt returns immediately with `would_block` instead of blocking indefinitely; the close_notify is still written best-effort and the socket closes right after. The `error_code` overload is used because the destructor is `noexcept` and the throwing overload could terminate the process (the SonarQube quality gate flagged this on the previous revision of this PR).

### Screenshot
N/A (no UI changes)

### Issues Fixed or Closed
- Fixes #5289

#### Roadmap Issues
N/A

## Type of Change
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

Testing done manually: with the stock binary the reproduction above wedges the server; with this fix the server stays responsive in the same scenario (repeated /serverinfo probes return 200 OK), and normal requests, pairing and streaming are unaffected.

### AI Usage
Please see the [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes

The debugging (core dump analysis, reproduction, fix) was performed with AI assistance; I reviewed and verified every step locally before submitting.
