### PR TITLE
feat(linux/pipewire): add support for unpaced capture when appropriate

### DIFF
--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -1042,17 +1042,7 @@ namespace cuda {
         sleep_overshoot_logger.reset();
 
         while (true) {
-          auto now = std::chrono::steady_clock::now();
-          if (next_frame > now) {
-            std::this_thread::sleep_for(next_frame - now);
-            sleep_overshoot_logger.first_point(next_frame);
-            sleep_overshoot_logger.second_point_now_and_log();
-          }
-
-          next_frame += delay;
-          if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-            next_frame = now + delay;
-          }
+          platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
 
           std::shared_ptr<platf::img_t> img_out;
           auto status = snapshot(pull_free_image_cb, img_out, 150ms, *cursor);

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1522,18 +1522,7 @@ namespace platf {
         sleep_overshoot_logger.reset();
 
         while (true) {
-          auto now = std::chrono::steady_clock::now();
-
-          if (next_frame > now) {
-            std::this_thread::sleep_for(next_frame - now);
-            sleep_overshoot_logger.first_point(next_frame);
-            sleep_overshoot_logger.second_point_now_and_log();
-          }
-
-          next_frame += delay;
-          if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-            next_frame = now + delay;
-          }
+          platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
 
           std::shared_ptr<platf::img_t> img_out;
           auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);
@@ -1799,18 +1788,7 @@ namespace platf {
         sleep_overshoot_logger.reset();
 
         while (true) {
-          auto now = std::chrono::steady_clock::now();
-
-          if (next_frame > now) {
-            std::this_thread::sleep_for(next_frame - now);
-            sleep_overshoot_logger.first_point(next_frame);
-            sleep_overshoot_logger.second_point_now_and_log();
-          }
-
-          next_frame += delay;
-          if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-            next_frame = now + delay;
-          }
+          platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
 
           std::shared_ptr<platf::img_t> img_out;
           auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);

--- a/src/platform/linux/misc.h
+++ b/src/platform/linux/misc.h
@@ -67,4 +67,28 @@ namespace platf {
    * @return A file descriptor on success, or `-1` if `open()` itself fails.
    */
   int open_drm_card_fd(const std::filesystem::path &path, int flags = O_RDWR);
+
+  /**
+   * @brief Generic frame pacing logic for Linux capture methods.
+   *
+   * Advances the frame pacing timeline and re-anchors it if the capture thread falls behind.
+   *
+   * @param next_frame Time point that the next frame will be targeted against.
+   * @param delay Delay interval used to pace next frame.
+   * @param logger The sleep_overshoot_logger for tracking discontinuities.
+   */
+  inline void handle_pacing(std::chrono::steady_clock::time_point &next_frame, std::chrono::nanoseconds delay, auto &logger) {
+    auto now = std::chrono::steady_clock::now();
+
+    if (next_frame > now) {
+      std::this_thread::sleep_until(next_frame);
+      logger.first_point(next_frame);
+      logger.second_point_now_and_log();
+    }
+
+    next_frame += delay;
+    if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
+      next_frame = now + delay;
+    }
+  }
 }  // namespace platf

--- a/src/platform/linux/misc.h
+++ b/src/platform/linux/misc.h
@@ -5,8 +5,10 @@
 #pragma once
 
 // standard includes
+#include <chrono>
 #include <fcntl.h>
 #include <filesystem>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -225,6 +225,34 @@ namespace pipewire {
     }
 
     /**
+     * @brief Check and log whether the active session will require Sunshine to perform pacing.
+     *
+     * @param requested_framerate The framerate that we requested.
+     * @param requested_delay The delay corresponding to the requested framerate.
+     * @return True when Sunshine pacing is required.
+     */
+    bool is_pacing_required(AVRational requested_framerate, std::chrono::nanoseconds requested_delay) {
+      AVRational negotiated_rate =
+        {
+          static_cast<int32_t>(stream_data.format.info.raw.max_framerate.num),
+          static_cast<int32_t>(stream_data.format.info.raw.max_framerate.denom)
+        };
+      int rate_comparison = av_cmp_q(negotiated_rate, requested_framerate);
+      bool variable_rate = negotiated_rate.num == 0 && negotiated_rate.den == 1;
+      bool pacing_required = variable_rate || rate_comparison > 0;
+
+      if (!variable_rate && rate_comparison < 0) {
+        BOOST_LOG(warning)
+          << "[pipewire] Sunshine frame pacing: disabled (negotiated rate lower than requested rate)"sv;
+      } else {
+        BOOST_LOG(info) << "[pipewire] Sunshine frame pacing: "sv
+                        << (pacing_required ? std::format("enabled ({}ms)", std::chrono::duration<double, std::milli>(requested_delay).count()) : "disabled (event-driven capture)");
+      }
+
+      return pacing_required;
+    }
+
+    /**
      * @brief Set frame ready.
      *
      * @param ready Whether the PipeWire frame is ready for capture.
@@ -656,9 +684,10 @@ namespace pipewire {
       BOOST_LOG(info) << "[pipewire] Color primaries: "sv << d->format.info.raw.color_primaries;
       BOOST_LOG(info) << "[pipewire] Transfer function: "sv << d->format.info.raw.transfer_function;
       if (d->format.info.raw.max_framerate.num == 0 && d->format.info.raw.max_framerate.denom == 1) {
-        BOOST_LOG(info) << "[pipewire] Framerate (from compositor): 0/1 (variable rate capture)";
+        BOOST_LOG(info) << "[pipewire] Compositor negotiated frame rate: 0/1 (variable rate capture)"sv;
       } else {
-        BOOST_LOG(info) << "[pipewire] Framerate (from compositor): "sv << d->format.info.raw.framerate.num << "/"sv << d->format.info.raw.framerate.denom
+        BOOST_LOG(info) << "[pipewire] Compositor negotiated frame rate: "sv
+                        << d->format.info.raw.framerate.num << "/"sv << d->format.info.raw.framerate.denom
                         << ", max: "sv << d->format.info.raw.max_framerate.num << "/"sv << d->format.info.raw.max_framerate.denom;
       }
 
@@ -823,11 +852,11 @@ namespace pipewire {
 
       const AVRational fps = (negotiate_variable_rate ? AVRational {0, 1} : ::video::framerate_to_rational(config));
       if (fps.den != 1) {
-        BOOST_LOG(info) << "[pipewire] Requested frame rate [" << fps.num << "/" << fps.den << ", approx. " << av_q2d(fps) << " fps]";
+        BOOST_LOG(info) << "[pipewire] Requested frame rate: "sv << fps.num << "/"sv << fps.den << ", approx. "sv << av_q2d(fps) << " fps"sv;
       } else if (fps.num == 0 && fps.den == 1) {
-        BOOST_LOG(info) << "[pipewire] Requested variable rate capture [host pacing: " << std::chrono::duration<double, std::milli>(delay).count() << "ms]";
+        BOOST_LOG(info) << "[pipewire] Requested variable frame rate (Sunshine pacing required: "sv << std::chrono::duration<double, std::milli>(delay).count() << "ms)"sv;
       } else {
-        BOOST_LOG(info) << "[pipewire] Requested frame rate [" << fps.num << "fps]";
+        BOOST_LOG(info) << "[pipewire] Requested frame rate: "sv << fps.num << "fps"sv;
       }
       this->target_framerate = fps;
       mem_type = hwdevice_type;
@@ -983,6 +1012,9 @@ namespace pipewire {
       }
       sleep_overshoot_logger.reset();
 
+      // Check if pacing is required
+      bool pacing_required = pipewire.is_pacing_required(target_framerate, delay);
+
       while (true) {
         // Check if PipeWire signaled a dead stream
         if (shared_state->stream_dead.exchange(false)) {
@@ -995,16 +1027,19 @@ namespace pipewire {
           return platf::capture_e::reinit;
         }
 
-        // Advance to (or catch up with) next delay interval
-        auto now = std::chrono::steady_clock::now();
-        while (next_frame < now) {
-          next_frame += delay;
-        }
+        // Use unpaced event driven capture when possible
+        if (pacing_required) {
+          // Advance to (or catch up with) next delay interval
+          auto now = std::chrono::steady_clock::now();
+          while (next_frame < now) {
+            next_frame += delay;
+          }
 
-        if (next_frame > now) {
-          std::this_thread::sleep_until(next_frame);
-          sleep_overshoot_logger.first_point(next_frame);
-          sleep_overshoot_logger.second_point_now_and_log();
+          if (next_frame > now) {
+            std::this_thread::sleep_until(next_frame);
+            sleep_overshoot_logger.first_point(next_frame);
+            sleep_overshoot_logger.second_point_now_and_log();
+          }
         }
 
         std::shared_ptr<platf::img_t> img_out;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -236,7 +236,7 @@ namespace pipewire {
         {
           static_cast<int32_t>(stream_data.format.info.raw.max_framerate.num),
           static_cast<int32_t>(stream_data.format.info.raw.max_framerate.denom)
-        };
+      };
       int rate_comparison = av_cmp_q(negotiated_rate, requested_framerate);
       bool variable_rate = negotiated_rate.num == 0 && negotiated_rate.den == 1;
       bool pacing_required = variable_rate || rate_comparison > 0;

--- a/src/platform/linux/pipewire.cpp
+++ b/src/platform/linux/pipewire.cpp
@@ -1029,17 +1029,7 @@ namespace pipewire {
 
         // Use unpaced event driven capture when possible
         if (pacing_required) {
-          // Advance to (or catch up with) next delay interval
-          auto now = std::chrono::steady_clock::now();
-          while (next_frame < now) {
-            next_frame += delay;
-          }
-
-          if (next_frame > now) {
-            std::this_thread::sleep_until(next_frame);
-            sleep_overshoot_logger.first_point(next_frame);
-            sleep_overshoot_logger.second_point_now_and_log();
-          }
+          platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
         }
 
         std::shared_ptr<platf::img_t> img_out;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -204,18 +204,7 @@ namespace wl {
       sleep_overshoot_logger.reset();
 
       while (true) {
-        auto now = std::chrono::steady_clock::now();
-
-        if (next_frame > now) {
-          std::this_thread::sleep_for(next_frame - now);
-          sleep_overshoot_logger.first_point(next_frame);
-          sleep_overshoot_logger.second_point_now_and_log();
-        }
-
-        next_frame += delay;
-        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-          next_frame = now + delay;
-        }
+        platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);
@@ -368,18 +357,7 @@ namespace wl {
       sleep_overshoot_logger.reset();
 
       while (true) {
-        auto now = std::chrono::steady_clock::now();
-
-        if (next_frame > now) {
-          std::this_thread::sleep_for(next_frame - now);
-          sleep_overshoot_logger.first_point(next_frame);
-          sleep_overshoot_logger.second_point_now_and_log();
-        }
-
-        next_frame += delay;
-        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-          next_frame = now + delay;
-        }
+        platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -565,18 +565,7 @@ namespace platf {
       sleep_overshoot_logger.reset();
 
       while (true) {
-        auto now = std::chrono::steady_clock::now();
-
-        if (next_frame > now) {
-          std::this_thread::sleep_for(next_frame - now);
-          sleep_overshoot_logger.first_point(next_frame);
-          sleep_overshoot_logger.second_point_now_and_log();
-        }
-
-        next_frame += delay;
-        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-          next_frame = now + delay;
-        }
+        platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);
@@ -741,18 +730,7 @@ namespace platf {
       sleep_overshoot_logger.reset();
 
       while (true) {
-        auto now = std::chrono::steady_clock::now();
-
-        if (next_frame > now) {
-          std::this_thread::sleep_for(next_frame - now);
-          sleep_overshoot_logger.first_point(next_frame);
-          sleep_overshoot_logger.second_point_now_and_log();
-        }
-
-        next_frame += delay;
-        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-          next_frame = now + delay;
-        }
+        platf::handle_pacing(next_frame, delay, sleep_overshoot_logger);
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot(pull_free_image_cb, img_out, 1000ms, *cursor);


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
For pipewire capture, we only need to perform pacing on the Sunshine side for two cases: variable rate capture, or if the negotiated framerate is higher than the requested rate.

If the negotiated rate is equal to the target rate, we can make Sunshine's capture loop fully event driven, thus avoiding occasional dropped frames if the timing of Sunshine's capture thread and the compositor's producer thread are slightly out of sync.

If the negotiated rate is lower than requested (which can happen if the client requests a framerate that exceeds the host's active screen refresh rate), Sunshine would pace at the original interval, thus causing the compositor's producer thread to go out of sync with Sunshine's capture thread. For such cases, unpaced capture and logging a warning to the user is the best remediation.

Additional change (added to address Sonar CC warning):

    refactor(linux): implement linux pacing helper and refactor
    
    Revert pipewire pacing to use the previous version
    that utilizes an if() check with re-anchor to now() instead of
    while() loop that could potentially be the culprit for random freezing.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [x] **refactor**: Code change that neither fixes a bug nor adds a feature
- [x] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
