### PR TITLE
fix(linux): guard XRandR NULL returns to avoid a SEGV during display setup

### DIFF
--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -513,6 +513,10 @@ namespace platf {
       }
 
       screen_res_t screenr {x11::rr::GetScreenResources(xdisplay.get(), xwindow)};
+      if (!screenr) {
+        BOOST_LOG(error) << "Could not query X screen resources"sv;
+        return -1;
+      }
       int output = screenr->noutput;
 
       output_info_t result;
@@ -531,8 +535,12 @@ namespace platf {
         }
       }
 
+      crtc_info_t crt_info;
       if (result_found && result->crtc) {
-        crtc_info_t crt_info {x11::rr::GetCrtcInfo(xdisplay.get(), screenr.get(), result->crtc)};
+        crt_info = crtc_info_t {x11::rr::GetCrtcInfo(xdisplay.get(), screenr.get(), result->crtc)};
+      }
+
+      if (crt_info) {
         BOOST_LOG(info)
           << "Streaming display: "sv << result->name << " with res "sv << crt_info->width << 'x' << crt_info->height << " offset by "sv << crt_info->x << 'x' << crt_info->y;
 
@@ -942,6 +950,10 @@ namespace platf {
 
     auto xwindow = DefaultRootWindow(xdisplay.get());
     screen_res_t screenr {x11::rr::GetScreenResources(xdisplay.get(), xwindow)};
+    if (!screenr) {
+      BOOST_LOG(error) << "Could not query X screen resources"sv;
+      return {};
+    }
     int output = screenr->noutput;
 
     std::vector<std::string> names;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description

<!--- Please include a summary of the changes. --->

XRRGetScreenResources and XRRGetCrtcInfo return NULL on a transient X error. There are three call sites in src/platform/linux/x11grab.cpp that dereference without checking:

- screenr -> noutput at line 516 (x11_attr_t::init) and line 945 (x11_display_names)
- crt_info -> width at line 537

Trigger: RandR config still settling, ex: a second CRTC comes up as a multi-display session starts. Result is a process-wide SEGV.
What I saw: sunshine SEGVs on session start with two displays, succeeds on retry. Found and fixed in my own tree in July; running on my test bench (vdi-test, Debian 13 (trixie)) since.

Verified on Ubuntu 22.04 WSL2 that it builds clean against master (393/393). Unit tests show no new failures (MouseHIDTest and EncoderTest fail identically before and after the patch in that environment, because it has no /dev/uinput; 0 failed tests either way).

### Screenshot

<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed

<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

#### Roadmap Issues

<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->

## Type of Change

<!--- Select the type of change your PR introduces. You can select multiple types. --->

- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist

<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage

<!--- Select the option that best describes AI usage in this PR (choose only one). --->

See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
