### PR TITLE
build: stop silently falling back to the latest build-deps release

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -18,37 +18,48 @@ if(NOT DEFINED FFMPEG_PREPARED_BINARIES)
     # Determine download location
     set(FFMPEG_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps")
 
-    # Fetch tags for the build-deps submodule so tag lookups work in CI shallow clones
-    execute_process(
-        COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" fetch --tags --depth=1
-        OUTPUT_QUIET
-        ERROR_QUIET
-    )
+    # An explicitly supplied tag wins over the git lookups below. This is the escape
+    # hatch when the submodule's tags are not available to git (source tarball,
+    # tagless or shallow clone, or a build-deps directory that is not a repo at all),
+    # since the fallback in that case is the LATEST release, which is not necessarily
+    # the release the pinned submodule corresponds to.
+    if(FFMPEG_RELEASE_TAG)
+        message(STATUS "Using caller-supplied build-deps tag: ${FFMPEG_RELEASE_TAG}")
+    else()
 
-    # Get the current commit/tag from the build-deps submodule
-    execute_process(
-        COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" describe --tags --exact-match
-        OUTPUT_VARIABLE FFMPEG_RELEASE_TAG
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-    )
-
-    # If no exact tag match, try to get the commit hash and look for a tag
-    if(NOT FFMPEG_RELEASE_TAG)
+        # Fetch tags for the build-deps submodule so tag lookups work in CI shallow clones
         execute_process(
-            COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" rev-parse HEAD
-            OUTPUT_VARIABLE BUILD_DEPS_COMMIT
-            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" fetch --tags --depth=1
+            OUTPUT_QUIET
             ERROR_QUIET
         )
 
-        # Try to find a tag that points to this commit
+        # Get the current commit/tag from the build-deps submodule
         execute_process(
-            COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" tag --points-at ${BUILD_DEPS_COMMIT}
+            COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" describe --tags --exact-match
             OUTPUT_VARIABLE FFMPEG_RELEASE_TAG
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET
         )
+
+        # If no exact tag match, try to get the commit hash and look for a tag
+        if(NOT FFMPEG_RELEASE_TAG)
+            execute_process(
+                COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" rev-parse HEAD
+                OUTPUT_VARIABLE BUILD_DEPS_COMMIT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+            )
+
+            # Try to find a tag that points to this commit
+            execute_process(
+                COMMAND git -C "${CMAKE_SOURCE_DIR}/third-party/build-deps" tag --points-at ${BUILD_DEPS_COMMIT}
+                OUTPUT_VARIABLE FFMPEG_RELEASE_TAG
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+            )
+        endif()
+
     endif()
 
     # Set GitHub release URL
@@ -60,7 +71,15 @@ if(NOT DEFINED FFMPEG_PREPARED_BINARIES)
     else()
         set(FFMPEG_RELEASE_URL "https://github.com/${FFMPEG_GITHUB_REPO}/releases/latest/download")
         set(FFMPEG_VERSION_DIR "${FFMPEG_DOWNLOAD_DIR}/ffmpeg-latest")
-        message(STATUS "Using FFmpeg from latest build-deps release")
+        message(WARNING
+                "Could not resolve a release tag for the third-party/build-deps submodule, so the "
+                "LATEST build-deps release will be used instead. That release can carry a different "
+                "Video Codec SDK than the pinned submodule, which shows up as an unexplained "
+                "'Check and update NVENC code for backwards compatibility!' error from "
+                "src/nvenc/nvenc_base.cpp when the bundled nvEncodeAPI.h version moves. "
+                "Build from a full clone with submodule tags fetched, or pass the intended tag "
+                "explicitly with -DFFMPEG_RELEASE_TAG=<tag>."
+        )
     endif()
 
     # Set extraction directory and prepared binaries path


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description

<!--- Please include a summary of the changes. --->

cmake/dependencies/ffmpeg.cmake resolves the prebuilt FFmpeg release from the third-party/build-deps submodule's git tag; when it cannot resolve one it downloads releases/latest silently instead. On non-Windows, nv-codec-headers come from the pinned submodule (cmake/compile_definitions/common.cmake:217) while the prebuilt binaries come from whatever release was downloaded, so a fallback pairs mismatched halves and the build stops being reproducible. A normal recursive clone is unaffected. Source tarballs, tagless or shallow clones, and any build-deps dir that is not a git repo take the fallback.

This was found in a downstream fork, where a Video Codec SDK guard tripped after the bundled nvEncodeAPI.h moved 13.0 → 13.1; upstream's exposure is the header/binary pairing rather than that guard.

The goal of the change is to honor an explicitly supplied -DFFMPEG_RELEASE_TAG and make the fallback a WARNING naming the failure mode rather than a STATUS line. Behavior when the tag resolves normally is unchanged.

All three paths verified, tag resolvable (unchanged), tag unresolvable (warns, still configures), tag unresolvable + -DFFMPEG_RELEASE_TAG is honored.

### Screenshot

<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed

<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

#### Roadmap Issues

<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->

## Type of Change

<!--- Select the type of change your PR introduces. You can select multiple types. --->

- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist

<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage

<!--- Select the option that best describes AI usage in this PR (choose only one). --->

See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
