### PR TITLE
feat(windows): add externally managed audio capture

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -829,6 +829,26 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### external_audio
+
+Windows only. Enable capture-only operation when an external audio router manages
+application playback. An explicit [audio_sink](#audio_sink) is required; use an
+endpoint ID when names are ambiguous. Sunshine captures that endpoint directly
+without changing or restoring Windows default devices or endpoint formats.
+
+In this mode, [virtual_sink](#virtual_sink), automatic Steam audio driver installation,
+and Moonlight's host-playback toggle do not affect routing. Configure local playback
+and the audio sent to the selected endpoint in your external mixer. If the endpoint
+is unavailable, audio capture fails rather than falling back to another endpoint.
+Video streaming can continue without audio.
+
+Disabled by default. Other platforms retain their existing behavior.
+
+@code{}
+external_audio = enabled
+audio_sink = My Streaming Mix
+@endcode
+
 ### stream_audio
 
 <table>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -802,6 +802,7 @@ namespace config {
     {},  // virtual_sink
     true,  // stream audio
     true,  // install_steam_drivers
+    false,  // external_audio
   };
 
   /**
@@ -1705,6 +1706,7 @@ namespace config {
     string_f(vars, "virtual_sink", audio.virtual_sink);
     bool_f(vars, "stream_audio", audio.stream);
     bool_f(vars, "install_steam_audio_drivers", audio.install_steam_drivers);
+    bool_f(vars, "external_audio", audio.external_audio);
 
     string_restricted_f(vars, "origin_web_ui_allowed", nvhttp.origin_web_ui_allowed, {"pc"sv, "lan"sv, "wan"sv});
 

--- a/src/config.h
+++ b/src/config.h
@@ -214,6 +214,7 @@ namespace config {
     std::string virtual_sink;  ///< Virtual audio sink for audio routing
     bool stream;  ///< Enable audio streaming to clients
     bool install_steam_drivers;  ///< Install Steam audio drivers for enhanced compatibility
+    bool external_audio;  ///< Windows capture-only mode; an external router owns endpoint defaults and formats.
   };
 
   /**

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -6,6 +6,8 @@
 
 // standard includes
 #include <format>
+#include <functional>
+#include <type_traits>
 #include <utility>
 
 // platform includes
@@ -871,6 +873,15 @@ namespace platf::audio {
     std::optional<sink_t> sink_info() override {
       sink_t sink;
 
+      if (config::audio.external_audio) {
+        if (config::audio.sink.empty()) {
+          BOOST_LOG(error) << "external_audio requires an explicit audio_sink";
+          return std::nullopt;
+        }
+        sink.host = config::audio.sink;
+        return sink;
+      }
+
       // Fill host sink name with the device_id of the current default audio device.
       {
         auto device = default_device(device_enum);
@@ -987,9 +998,13 @@ namespace platf::audio {
     std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, bool continuous_audio, [[maybe_unused]] bool host_audio_enabled) override {
       auto mic = std::make_unique<mic_wasapi_t>();
 
-      // Prefer the sink that was assigned to this capture session since it accounts
-      // for the priority between virtual and configured sinks.
-      const auto &requested_sink = assigned_sink.empty() ? config::audio.sink : assigned_sink;
+      // External routing pins capture to the configured sink; otherwise prefer the session's assigned sink.
+      const auto &requested_sink = config::audio.external_audio || assigned_sink.empty() ? config::audio.sink : assigned_sink;
+
+      if (config::audio.external_audio && requested_sink.empty()) {
+        BOOST_LOG(error) << "external_audio requires an explicit audio_sink";
+        return nullptr;
+      }
 
       // Capture the requested sink directly instead of relying on it being the default
       // render device, so that capture keeps working when the default device differs
@@ -1011,7 +1026,7 @@ namespace platf::audio {
 
       // If this is a virtual sink, set a callback that will change the sink back if it's changed
       auto virtual_sink_info = extract_virtual_sink_info(assigned_sink);
-      if (virtual_sink_info) {
+      if (virtual_sink_info && !config::audio.external_audio) {
         mic->default_endpt_changed_cb = [this] {
           BOOST_LOG(info) << "Resetting sink to ["sv << assigned_sink << "] after default changed";
           set_sink(assigned_sink);
@@ -1098,6 +1113,10 @@ namespace platf::audio {
      * @return Status from updating sink.
      */
     int set_sink(const std::string &sink) override {
+      if (config::audio.external_audio) {
+        return 0;
+      }
+
       auto device_id = set_format(sink);
       if (!device_id) {
         return -1;
@@ -1252,6 +1271,10 @@ namespace platf::audio {
      * @brief Resets the default audio device from Steam Streaming Speakers.
      */
     void reset_default_device() {
+      if (config::audio.external_audio) {
+        return;
+      }
+
       auto matched_steam = find_device_id(match_steam_speakers());
       if (!matched_steam) {
         return;
@@ -1380,26 +1403,31 @@ namespace platf::audio {
     }
 
     /**
-     * @brief Initialize Windows audio policy interfaces.
+     * @brief Initialize endpoint enumeration and policy control when routing is managed by Sunshine.
      *
+     * @tparam CreateInstance Callable type used for COM activation.
+     * @param create_instance COM factory used to initialize the required interfaces.
      * @return 0 on success; nonzero or negative platform status on failure.
      */
-    int init() {
-      auto status = CoCreateInstance(
-        CLSID_CPolicyConfigClient,
-        nullptr,
-        CLSCTX_ALL,
-        IID_IPolicyConfig,
-        (void **) &policy
-      );
+    template<typename CreateInstance = decltype(&CoCreateInstance)>
+    int init(const CreateInstance &create_instance = &CoCreateInstance) {
+      if (!config::audio.external_audio) {
+        auto status = create_instance(
+          CLSID_CPolicyConfigClient,
+          nullptr,
+          CLSCTX_ALL,
+          IID_IPolicyConfig,
+          (void **) &policy
+        );
 
-      if (FAILED(status)) {
-        BOOST_LOG(error) << "Couldn't create audio policy config: [0x"sv << util::hex(status).to_string_view() << ']';
+        if (FAILED(status)) {
+          BOOST_LOG(error) << "Couldn't create audio policy config: [0x"sv << util::hex(status).to_string_view() << ']';
 
-        return -1;
+          return -1;
+        }
       }
 
-      status = CoCreateInstance(
+      auto status = create_instance(
         CLSID_MMDeviceEnumerator,
         nullptr,
         CLSCTX_ALL,
@@ -1428,6 +1456,36 @@ namespace platf::audio {
 
 #ifdef SUNSHINE_TESTS
   namespace tests {
+    /**
+     * @brief Exercise controller initialization with a supplied COM factory.
+     * @param create_instance Factory providing or rejecting the requested interfaces.
+     * @return Status from controller initialization.
+     */
+    int initialize_audio_control(const std::function<std::remove_pointer_t<decltype(&CoCreateInstance)>> &create_instance) {
+      audio_control_t control;
+      return control.init(create_instance);
+    }
+
+    /**
+     * @brief Exercise sink discovery without initializing Windows policy interfaces.
+     * @return Sinks reported by the production controller for the current configuration.
+     */
+    std::optional<sink_t> configured_sink_info() {
+      audio_control_t control;
+      return control.sink_info();
+    }
+
+    /**
+     * @brief Exercise the external-routing sink-change guard without policy interfaces.
+     * @param sink Sink a caller attempts to select.
+     * @return Status from the production sink setter.
+     */
+    int set_external_sink(const std::string &sink) {
+      audio_control_t control;
+      control.reset_default_device();
+      return control.set_sink(sink);
+    }
+
     /**
      * @brief Resolve a sink through the production Windows endpoint lookup.
      *
@@ -1542,7 +1600,7 @@ namespace platf {
 
     // Install Steam Streaming Speakers if needed. We do this during audio_control() to ensure
     // the sink information returned includes the new Steam Streaming Speakers device.
-    if (config::audio.install_steam_drivers && !control->find_device_id(control->match_steam_speakers())) {
+    if (!config::audio.external_audio && config::audio.install_steam_drivers && !control->find_device_id(control->match_steam_speakers())) {
       // This is best effort. Don't fail if it doesn't work.
       control->install_steam_audio_drivers();
     }

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -246,6 +246,7 @@
             options: {
               "audio_sink": "",
               "virtual_sink": "",
+              "external_audio": "disabled",
               "stream_audio": "enabled",
               "install_steam_audio_drivers": "enabled",
               "adapter_name": "",

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -49,6 +49,13 @@ const config = ref(props.config)
 
     <PlatformLayout :platform="platform">
       <template #windows>
+        <Checkbox class="mb-3"
+                  id="external_audio"
+                  locale-prefix="config"
+                  v-model="config.external_audio"
+                  default="false"
+        ></Checkbox>
+
         <!-- Virtual Sink -->
         <div class="mb-3">
           <label for="virtual_sink" class="form-label">{{ $t('config.virtual_sink') }}</label>

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -233,6 +233,8 @@
     "encoder_desc": "Force a specific encoder, otherwise Sunshine will select the best available option. Note: If you specify a hardware encoder on Windows, it must match the GPU where the display is connected.",
     "encoder_software": "Software",
     "encoders": "Encoders",
+    "external_audio": "Externally Managed Audio",
+    "external_audio_desc": "Capture only the configured Audio Sink without changing Windows defaults or device formats. Requires an explicit Audio Sink. Virtual Sink selection, automatic Steam audio driver installation, and Moonlight's host-playback toggle are ignored; manage playback and application routing in your audio mixer.",
     "external_ip": "External IP",
     "external_ip_desc": "If no external IP address is given, Sunshine will automatically detect external IP",
     "fec_percentage": "FEC Percentage",

--- a/tests/unit/platform/windows/test_audio.cpp
+++ b/tests/unit/platform/windows/test_audio.cpp
@@ -8,16 +8,23 @@
 
 #ifdef _WIN32
   // standard includes
+  #include <cstdlib>
   #include <cstring>
+  #include <functional>
+  #include <type_traits>
 
   // platform includes
   #include <mmdeviceapi.h>
   #include <propsys.h>
 
   // local includes
+  #include "src/config.h"
   #include "src/platform/common.h"
 
 namespace platf::audio::tests {
+  int initialize_audio_control(const std::function<std::remove_pointer_t<decltype(&CoCreateInstance)>> &create_instance);
+  std::optional<sink_t> configured_sink_info();
+  int set_external_sink(const std::string &sink);
   bool sink_device_available(const std::string &sink, IMMDeviceEnumerator *device_enum);
   bool microphone_available(const std::string &assigned_sink, const std::string &configured_sink, IMMDeviceEnumerator *device_enum);
   bool capture_follows_default_device(IMMDeviceEnumerator *device_enum, IMMDevice *capture_device);
@@ -264,6 +271,170 @@ TEST(WindowsAudioTest, DefaultDeviceIsUsedWhenNoSinkWasRequested) {
 
   platf::audio::tests::microphone_available({}, {}, &enumerator);
   EXPECT_EQ(enumerator.get_device_calls, 0);
+}
+
+/**
+ * @brief Preserve global audio configuration while exercising capture-only mode.
+ */
+class ExternalAudioTest: public testing::Test {
+protected:
+  void SetUp() override {
+    previous = config::audio;
+    config::audio.external_audio = true;
+    config::audio.sink = "configured-id";
+    config::audio.virtual_sink = "ignored-virtual-sink";
+    policy_requests = 0;
+    enumerator_requests = 0;
+    enumerator_status = S_OK;
+  }
+
+  void TearDown() override {
+    config::audio = previous;
+  }
+
+  /**
+   * @brief Get the number of policy activation requests.
+   * @return Requests observed by the test factory.
+   */
+  static int policy_request_count() {
+    return policy_requests;
+  }
+
+  /**
+   * @brief Get the number of endpoint enumeration activation requests.
+   * @return Requests observed by the test factory.
+   */
+  static int enumerator_request_count() {
+    return enumerator_requests;
+  }
+
+  /**
+   * @brief Simulate failure to initialize endpoint enumeration.
+   */
+  static void fail_enumerator_initialization() {
+    enumerator_status = E_FAIL;
+  }
+
+  /**
+   * @brief Supply endpoint enumeration while simulating an unavailable policy interface.
+   * @param class_id Requested COM class.
+   * @param outer Unused aggregation pointer.
+   * @param context Unused activation context.
+   * @param interface_id Unused interface identifier.
+   * @param object Receives the enumerator on success.
+   * @return Simulated COM activation status.
+   */
+  static HRESULT WINAPI create_capture_interface(REFCLSID class_id, [[maybe_unused]] LPUNKNOWN outer, [[maybe_unused]] DWORD context, [[maybe_unused]] REFIID interface_id, LPVOID *object) {
+    *object = nullptr;
+    if (class_id != CLSID_MMDeviceEnumerator) {
+      ++policy_requests;
+      return REGDB_E_CLASSNOTREG;
+    }
+    ++enumerator_requests;
+    if (FAILED(enumerator_status)) {
+      return enumerator_status;
+    }
+    static fake_device_enumerator_t enumerator {L"configured-id"};
+    enumerator.AddRef();
+    *object = static_cast<IMMDeviceEnumerator *>(&enumerator);
+    return S_OK;
+  }
+
+private:
+  config::audio_t previous;  ///< Configuration restored after each test.
+  inline static int policy_requests = 0;  ///< Requests for the unavailable policy interface.
+  inline static int enumerator_requests = 0;  ///< Requests for endpoint enumeration.
+  inline static HRESULT enumerator_status = S_OK;  ///< Simulated enumeration initialization result.
+};
+
+TEST_F(ExternalAudioTest, InitializesWithoutPolicyInterface) {
+  EXPECT_EQ(platf::audio::tests::initialize_audio_control(&create_capture_interface), 0);
+  EXPECT_EQ(policy_request_count(), 0);
+  EXPECT_EQ(enumerator_request_count(), 1);
+}
+
+TEST_F(ExternalAudioTest, InitializationRequiresEndpointEnumerator) {
+  fail_enumerator_initialization();
+  EXPECT_NE(platf::audio::tests::initialize_audio_control(&create_capture_interface), 0);
+  EXPECT_EQ(policy_request_count(), 0);
+  EXPECT_EQ(enumerator_request_count(), 1);
+}
+
+TEST_F(ExternalAudioTest, DisabledModeStillRequiresPolicyInterface) {
+  config::audio.external_audio = false;
+  EXPECT_NE(platf::audio::tests::initialize_audio_control(&create_capture_interface), 0);
+  EXPECT_EQ(policy_request_count(), 1);
+  EXPECT_EQ(enumerator_request_count(), 0);
+}
+
+TEST_F(ExternalAudioTest, RequiresExplicitSink) {
+  config::audio.sink.clear();
+  EXPECT_EXIT(std::exit(platf::audio::tests::configured_sink_info() ? 1 : 0), testing::ExitedWithCode(0), "");
+  fake_device_enumerator_t enumerator {L"endpoint-id"};
+  EXPECT_FALSE(platf::audio::tests::microphone_available({}, {}, &enumerator));
+  EXPECT_EQ(enumerator.get_default_device_calls, 0);
+  EXPECT_EQ(enumerator.get_device_calls, 0);
+}
+
+TEST_F(ExternalAudioTest, SkipsDefaultAndVirtualDeviceDiscovery) {
+  EXPECT_EXIT(
+    {
+      const auto sinks = platf::audio::tests::configured_sink_info();
+      std::exit(sinks && sinks->host == "configured-id" && !sinks->null ? 0 : 1);
+    },
+    testing::ExitedWithCode(0),
+    ""
+  );
+}
+
+TEST_F(ExternalAudioTest, SinkChangesDoNotAccessPolicyOrFormatInterfaces) {
+  EXPECT_EXIT(std::exit(platf::audio::tests::set_external_sink("virtual-Stereoendpoint-id")), testing::ExitedWithCode(0), "");
+  EXPECT_EXIT(std::exit(platf::audio::tests::set_external_sink("other-endpoint")), testing::ExitedWithCode(0), "");
+}
+
+TEST_F(ExternalAudioTest, ConfiguredSinkWinsOverAssignedSink) {
+  fake_device_enumerator_t enumerator {L"configured-id"};
+  EXPECT_FALSE(platf::audio::tests::microphone_available("virtual-Stereoother-id", "configured-id", &enumerator));
+  EXPECT_EQ(enumerator.last_requested_id, L"configured-id");
+  EXPECT_EQ(enumerator.get_default_device_calls, 0);
+}
+
+TEST_F(ExternalAudioTest, MissingSinkDoesNotFallBackToDefault) {
+  fake_device_enumerator_t enumerator {L"endpoint-id"};
+  EXPECT_FALSE(platf::audio::tests::microphone_available({}, "missing-id", &enumerator));
+  EXPECT_EQ(enumerator.get_default_device_calls, 0);
+}
+
+TEST_F(ExternalAudioTest, DisconnectedSinkDoesNotFallBackToDefault) {
+  fake_device_enumerator_t enumerator {L"configured-id"};
+  enumerator.device.state = DEVICE_STATE_UNPLUGGED;
+  EXPECT_FALSE(platf::audio::tests::microphone_available({}, "configured-id", &enumerator));
+  EXPECT_EQ(enumerator.get_default_device_calls, 0);
+}
+
+TEST_F(ExternalAudioTest, DisabledModePreservesAssignedSinkPriority) {
+  config::audio.external_audio = false;
+  fake_device_enumerator_t enumerator {L"assigned-id"};
+  EXPECT_FALSE(platf::audio::tests::microphone_available("assigned-id", "configured-id", &enumerator));
+  EXPECT_EQ(enumerator.last_requested_id, L"assigned-id");
+  EXPECT_EQ(enumerator.get_default_device_calls, 0);
+}
+
+TEST_F(ExternalAudioTest, DisabledModePreservesDefaultFallback) {
+  config::audio.external_audio = false;
+  fake_device_enumerator_t enumerator {L"endpoint-id"};
+  EXPECT_TRUE(platf::audio::tests::capture_follows_default_device(&enumerator, nullptr));
+  EXPECT_EQ(enumerator.get_default_device_calls, 1);
+  EXPECT_EQ(enumerator.get_device_calls, 0);
+}
+
+TEST_F(ExternalAudioTest, ReactivatedSinkCanBeResolvedAgain) {
+  fake_device_enumerator_t enumerator {L"configured-id"};
+  enumerator.device.state = DEVICE_STATE_UNPLUGGED;
+  EXPECT_FALSE(platf::audio::tests::sink_device_available("configured-id", &enumerator));
+  enumerator.device.state = DEVICE_STATE_ACTIVE;
+  EXPECT_TRUE(platf::audio::tests::sink_device_available("configured-id", &enumerator));
+  EXPECT_EQ(enumerator.get_default_device_calls, 0);
 }
 
 TEST(WindowsAudioTest, DefaultCaptureSelectsDefaultEndpoint) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

I use an audio mixer to route applications to different outputs, including a dedicated output for Moonlight. I want Sunshine to capture that output without changing the Windows default device. Otherwise, applications that follow the default can end up on the wrong output, or Sunshine and the mixer can keep undoing each other's changes.

This adds an **Externally Managed Audio** option on Windows. With it enabled, Sunshine captures the configured `audio_sink` and leaves default devices and device formats alone. It requires an explicit sink and won't fall back to another device if that sink is unavailable. Playback stays under the mixer's control, so the Virtual Sink and Moonlight host-playback settings don't affect routing in this mode.

The option is off by default. This builds on the direct capture support in [#5408](https://github.com/LizardByte/Sunshine/pull/5408), which intentionally kept default-device switching for existing setups. This PR lets external mixers opt out without changing that behavior for everyone else.

### Testing

Built and tested on Windows x64 and ARM64. The native test suites, frontend build, and browser checks pass.

Tested stereo playback and reconnecting from Moonlight while the mixer kept a separate local output. Added regression tests for sink selection, unavailable endpoints, endpoint reactivation, and compatibility with the option disabled.

Real-device unplug/replug and surround playback haven't been tested.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

![Externally Managed Audio option in the Windows Audio/Video settings](https://raw.githubusercontent.com/AlexAllocated/Sunshine/4bf0baaa7381305f43fcc0293f960d71d55aa23f/review/external-audio.png)

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes


