### PR TITLE
fix(linux/vulkan): use vkGetDeviceQueue2 with FFmpeg 9.0 queue flags

### DIFF
--- a/src/platform/linux/vulkan_encode.cpp
+++ b/src/platform/linux/vulkan_encode.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_vulkan.h>
+#include <libavutil/version.h>
 }
 
 #include "graphics.h"
@@ -232,7 +233,19 @@ namespace vk {
         return -1;
       }
 
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(60, 32, 100)
+      // FFmpeg 9.0+ may create its queues with VK_DEVICE_QUEUE_CREATE_INTERNALLY_SYNCHRONIZED_BIT_KHR
+      // (when VK_KHR_internally_synchronized_queues is available). The Vulkan spec requires
+      // vkGetDeviceQueue2 to retrieve such queues; plain vkGetDeviceQueue would return an
+      // incompatible queue handle, breaking synchronization with the encoder.
+      VkDeviceQueueInfo2 queue_info = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2};
+      queue_info.flags = vk_dev.ctx->queue_flags;
+      queue_info.queueFamilyIndex = vk_dev.compute_qf;
+      queue_info.queueIndex = 0;
+      vkGetDeviceQueue2(vk_dev.dev, &queue_info, &vk_dev.compute_queue);
+#else
       vkGetDeviceQueue(vk_dev.dev, vk_dev.compute_qf, 0, &vk_dev.compute_queue);
+#endif
 
       // Load extension functions
       vk_dev.getMemoryFdProperties = (PFN_vkGetMemoryFdPropertiesKHR)


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
FFmpeg 9.0 creates its Vulkan device queues with
VK_DEVICE_QUEUE_CREATE_INTERNALLY_SYNCHRONIZED_BIT_KHR when VK_KHR_internally_synchronized_queues is available, and fetches them with vkGetDeviceQueue2. The Vulkan spec requires vkGetDeviceQueue2 for such queues; plain vkGetDeviceQueue returns an incompatible queue handle, which broke synchronization between the compute pipeline and the encoder and stopped Vulkan encoding from working.

Retrieve the queue with vkGetDeviceQueue2 using
AVVulkanDeviceContext::queue_flags on FFmpeg >= 9.0 (lavu >= 60.32.100), and fall back to vkGetDeviceQueue for older FFmpeg.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes https://github.com/LizardByte/Sunshine/issues/5660


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
