### PR TITLE
build(Linux): harden Qt6 dependency detection

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -56,6 +56,17 @@ if(SUNSHINE_ENABLE_TRAY)
 
     add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/tray")
 
+    # TRAY_QT_VERSION is scoped to the tray subdirectory, so inspect the target's actual dependencies.
+    get_target_property(_sunshine_tray_link_libraries tray LINK_LIBRARIES)
+    if("Qt6::Widgets" IN_LIST _sunshine_tray_link_libraries)
+        set(SUNSHINE_TRAY_QT_VERSION 6)
+    elseif("Qt5::Widgets" IN_LIST _sunshine_tray_link_libraries)
+        set(SUNSHINE_TRAY_QT_VERSION 5)
+    else()
+        message(FATAL_ERROR "Could not determine the Qt version used by the tray target.")
+    endif()
+    unset(_sunshine_tray_link_libraries)
+
     if(BUILD_TESTS)
         target_compile_definitions(tray PRIVATE TRAY_ENABLE_TEST_HOOKS)
     endif()

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -163,7 +163,7 @@ if(${SUNSHINE_TRAY} STREQUAL 1)
     # Icons used by the Qt tray backend are no longer installed to the hicolor icon theme,
     # because Qt6 will not allow icons not part of the theme... so we will use icons from our web directory instead
 
-    if(TRAY_QT_VERSION EQUAL 6)
+    if(SUNSHINE_TRAY_QT_VERSION EQUAL 6)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                     ${CPACK_DEBIAN_PACKAGE_DEPENDS}, \
                     libqt6widgets6, \
@@ -178,7 +178,7 @@ if(${SUNSHINE_TRAY} STREQUAL 1)
                 devel/qt6-base
                 graphics/qt6-svg
         )
-    else()
+    elseif(SUNSHINE_TRAY_QT_VERSION EQUAL 5)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
                     ${CPACK_DEBIAN_PACKAGE_DEPENDS}, \
                     libqt5widgets5, \
@@ -193,6 +193,8 @@ if(${SUNSHINE_TRAY} STREQUAL 1)
                 x11-toolkits/qt5-widgets
                 graphics/qt5-svg
         )
+    else()
+        message(FATAL_ERROR "Unsupported tray Qt version: ${SUNSHINE_TRAY_QT_VERSION}")
     endif()
 endif()
 

--- a/docker/debian.dockerfile
+++ b/docker/debian.dockerfile
@@ -78,6 +78,17 @@ set -e
 ./scripts/linux_build.sh \
   --step=package \
   --sudo-off
+
+package_dependencies="$(dpkg-deb --field build/cpack_artifacts/*.deb Depends)"
+package_dependencies_valid=false
+case "${package_dependencies}" in
+  *libqt5*) ;;
+  *libqt6widgets6*libqt6svg6* | *libqt6svg6*libqt6widgets6*) package_dependencies_valid=true ;;
+esac
+if [ "${package_dependencies_valid}" = false ]; then
+  echo "Unexpected Qt package dependencies: ${package_dependencies}"
+  exit 1
+fi
 _BUILD
 
 # run tests

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -202,7 +202,7 @@ sudo apt install sunshine
 
 Download `sunshine_{version}-1+{distro}{distro-version}_{arch}.deb` and run the following command.
 ```bash
-sudo dpkg -i ./sunshine_{version}-1+{distro}{distro-version}_{arch}.deb
+sudo apt install ./sunshine_{version}-1+{distro}{distro-version}_{arch}.deb
 ```
 
 > [!NOTE]


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Harden Qt6 dep detection.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes https://github.com/LizardByte/Sunshine/issues/5593


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
