### PR TITLE
fix(nvapi,nvenc): Load ARM64 DLLs on RTX Spark

### DIFF
--- a/src/nvenc/nvenc_dynamic_factory.cpp
+++ b/src/nvenc/nvenc_dynamic_factory.cpp
@@ -17,7 +17,9 @@
 
 namespace {
 
-  #ifdef _WIN64
+  #if defined(_M_ARM64) || defined(__aarch64__)
+  constexpr auto nvenc_dll_name = "nvEncodeAPIa64.dll";
+  #elif defined(_WIN64)
   constexpr auto nvenc_dll_name = "nvEncodeAPI64.dll";
   #else
   constexpr auto nvenc_dll_name = "nvEncodeAPI.dll";

--- a/src/platform/windows/nvprefs/nvapi_opensource_wrapper.cpp
+++ b/src/platform/windows/nvprefs/nvapi_opensource_wrapper.cpp
@@ -57,7 +57,9 @@ NvAPI_Initialize() {
     return NVAPI_OK;
   }
 
-#ifdef _WIN64
+#if defined(_M_ARM64) || defined(__aarch64__)
+  auto dll_name = "nvapia64.dll";
+#elif defined(_WIN64)
   auto dll_name = "nvapi64.dll";
 #else
   auto dll_name = "nvapi.dll";


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
This PR updates the name of the NVENC and NVAPI DLLs for the ARM64 build to match the name of the native ARM64 DLLs present in the [RTX Spark Developer Preview Driver](https://forums.developer.nvidia.com/t/rtx-spark-developer-preview/377106) and [RTX Spark Porting Guide](https://docs.nvidia.com/rtx-spark/rtx-spark-porting-guide/latest/porting/nvapi.html). On ARM64 systems, `nvEncodeAPI64.dll` and `nvapi64.dll` binaries are ARM64EC which can't load in native ARM64 processes (only x64 and ARM64EC processes).

One special note about `nvcuda.dll` (named `nvcuda_loader64.dll` in the driver bundle) referenced in `nvenc_d3d11_on_cuda.cpp`: It is _not_ necessary to adjust the name of this one for ARM64 because it's an ARM64X forwarder which is compatible with both x64 and native ARM64 processes.

I do not have access to pre-launch RTX Spark hardware, but I tested on a Snapdragon system with an extracted copy of the RTX Spark Developer Preview driver to confirm these DLLs load in a native ARM64 test binary.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
