### PR TITLE
fix(linux/nvenc): select HEVC RExt profile for YUV 4:4:4 encoding

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -817,8 +817,15 @@ namespace video {
         // HDR-specific options
         {"profile"s, std::to_underlying(nv::profile_hevc_e::main_10)},
       },
-      {},  // YUV444 SDR-specific options
-      {},  // YUV444 HDR-specific options
+      {
+        // YUV444 SDR-specific options
+        // HEVC uses the same RExt profile for both 8 and 10 bit YUV 4:4:4 encoding
+        {"profile"s, std::to_underlying(nv::profile_hevc_e::rext)},
+      },
+      {
+        // YUV444 HDR-specific options
+        {"profile"s, std::to_underlying(nv::profile_hevc_e::rext)},
+      },
       {},  // Fallback options
       "hevc_nvenc"s,
     },


### PR DESCRIPTION

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This change fills in the required profile for YUV 4:4:4 chroma subsampling for HEVC through NVENC, which is the Rext profile both for 8-bit and 10-bit encoding. It does the same thing for NVENC that the quicksync encoder setup does.

Before, when these fields were empty, no NVENC 4:4:4 options would be correctly probed: the encoder configuration for the probes would include fallback values inconsistent with the SDR444 and HDR444 requirements. As a result, they wouldn't appear in /serverinfo output and Moonlight would consider them unsupported. This would effectively lock Linux NVENC encoding to 4:2:0.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [X] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
