### PR TITLE
fix(linux): handle NVENC in builds without CUDA

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -75,7 +75,17 @@ sudo mv /tmp/sunshine build/sunshine
 ```
 
 ##### CUDA Toolkit
-Sunshine requires CUDA Toolkit for NVFBC capture. There are two caveats to CUDA:
+When building Sunshine for a system with an NVIDIA GPU, install the CUDA Toolkit before configuring or compiling
+Sunshine. CUDA support is selected at compile time and is used for NVFBC capture and direct GPU-memory NVENC encoding.
+This applies to every source build, including builds made through the AUR or for third-party repositories such as
+Omarchy. Installing the CUDA Toolkit after Sunshine was compiled does not enable CUDA support; Sunshine must be rebuilt.
+
+> [!NOTE]
+> Users installing a prebuilt package supplied by LizardByte do not need to install the CUDA Toolkit. This includes the
+> Arch Linux package from LizardByte's [pacman-repo](https://github.com/LizardByte/pacman-repo), which is already built
+> with CUDA support.
+
+There are two caveats to CUDA:
 
 1. The version installed depends on the version of GCC.
 2. The version of CUDA you use will determine compatibility with various GPU generations.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,12 +57,20 @@ available for manual download from each GitHub release.
 
 **CUDA Compatibility**
 
-CUDA is used for NVFBC capture.
+CUDA is used for NVFBC capture and direct GPU-memory NVENC encoding.
+
+> [!IMPORTANT]
+> CUDA support is selected when Sunshine is compiled. If you build Sunshine for an NVIDIA GPU yourself, including
+> through the AUR or for a third-party repository such as Omarchy, install the CUDA Toolkit before building Sunshine.
+> Installing CUDA after Sunshine has been compiled does not add CUDA support; Sunshine must be rebuilt.
+>
+> This requirement does not apply when installing a prebuilt package supplied by LizardByte. In particular, the
+> Arch Linux package from LizardByte's [pacman-repo](https://github.com/LizardByte/pacman-repo) is already built with
+> CUDA support, so its users do not need to install the CUDA Toolkit.
 
 > [!NOTE]
 > See [CUDA GPUS](https://developer.nvidia.com/cuda-gpus) to cross-reference Compute Capability to your GPU.
-> The table below applies to packages provided by LizardByte. If you use an official LizardByte package, then you do not
-> need to install CUDA.
+> The table below applies to packages provided by LizardByte.
 
 <table>
     <caption>CUDA Compatibility</caption>
@@ -148,6 +156,11 @@ apk del sunshine
 
 > [!CAUTION]
 > Use AUR packages at your own risk.
+
+> [!IMPORTANT]
+> NVIDIA users installing Sunshine from LizardByte's pacman-repo do not need the CUDA Toolkit. If Sunshine is compiled
+> locally from the AUR or by another package provider, such as Omarchy, the builder must install the CUDA Toolkit before
+> compilation. Installing CUDA after the package was built cannot enable CUDA support in that package.
 
 ##### Install Prebuilt Packages
 Follow the instructions at LizardByte's [pacman-repo](https://github.com/LizardByte/pacman-repo) to add

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -27,6 +27,14 @@
 
 namespace wl {
   /**
+   * @brief Determine whether wlroots capture should keep frames in VRAM for the requested memory type.
+   *
+   * @param hwdevice_type Hardware device type requested for capture or encode.
+   * @return `true` when the requested memory type should use the wlroots VRAM path.
+   */
+  bool use_vram_capture(platf::mem_type_e hwdevice_type);
+
+  /**
    * @brief Owning pointer for a Wayland display connection.
    */
   using display_internal_t = util::safe_ptr<wl_display, wl_display_disconnect>;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -19,6 +19,20 @@ namespace wl {
   static int env_width;
   static int env_height;
 
+  bool use_vram_capture(platf::mem_type_e hwdevice_type) {
+    if (hwdevice_type == platf::mem_type_e::vaapi) {
+      return true;
+    }
+
+#ifdef SUNSHINE_BUILD_CUDA
+    if (hwdevice_type == platf::mem_type_e::cuda) {
+      return true;
+    }
+#endif
+
+    return false;
+  }
+
   /**
    * @brief Captured frame buffer shared between capture and encode stages.
    */
@@ -488,7 +502,7 @@ namespace platf {
       return nullptr;
     }
 
-    if (hwdevice_type == platf::mem_type_e::vaapi || hwdevice_type == platf::mem_type_e::cuda) {
+    if (wl::use_vram_capture(hwdevice_type)) {
       auto wlr = std::make_shared<wl::wlr_vram_t>();
       if (wlr->init(hwdevice_type, display_name, config)) {
         return nullptr;
@@ -496,6 +510,12 @@ namespace platf {
 
       return wlr;
     }
+
+#ifndef SUNSHINE_BUILD_CUDA
+    if (hwdevice_type == platf::mem_type_e::cuda) {
+      BOOST_LOG(warning) << "This build does not include CUDA support. Falling back to GPU -> RAM -> GPU for NVENC."sv;
+    }
+#endif
 
     auto wlr = std::make_shared<wl::wlr_ram_t>();
     if (wlr->init(hwdevice_type, display_name, config)) {

--- a/tests/unit/platform/linux/test_wayland.cpp
+++ b/tests/unit/platform/linux/test_wayland.cpp
@@ -29,4 +29,20 @@ TEST(WaylandMonitorTest, UpdatesCurrentMode) {
   EXPECT_EQ(monitor.viewport.width, 2560);
   EXPECT_EQ(monitor.viewport.height, 1440);
 }
+
+TEST(WaylandCaptureTest, UsesVramForVaapi) {
+  EXPECT_TRUE(wl::use_vram_capture(platf::mem_type_e::vaapi));
+}
+
+TEST(WaylandCaptureTest, UsesSystemMemoryForSoftwareEncoding) {
+  EXPECT_FALSE(wl::use_vram_capture(platf::mem_type_e::system));
+}
+
+TEST(WaylandCaptureTest, UsesVramForCudaOnlyWhenCudaSupportIsBuilt) {
+  #ifdef SUNSHINE_BUILD_CUDA
+  EXPECT_TRUE(wl::use_vram_capture(platf::mem_type_e::cuda));
+  #else
+  EXPECT_FALSE(wl::use_vram_capture(platf::mem_type_e::cuda));
+  #endif
+}
 #endif


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Fixes wlroots failure by selecting RAM capture when CUDA support was not compiled


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Resolves https://github.com/LizardByte/Sunshine/issues/5309


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
